### PR TITLE
Adding TravelMode to step

### DIFF
--- a/GoogleMapsApi/Entities/Directions/Response/Step.cs
+++ b/GoogleMapsApi/Entities/Directions/Response/Step.cs
@@ -74,7 +74,7 @@ namespace GoogleMapsApi.Entities.Directions.Response
 		/// Gets the mode of transportation used in this step
 		/// </summary>
 		[DataMember(Name = "travel_mode")]
-		public string TravelModeString
+		internal string TravelModeString
 		{
 			get { return TravelMode.ToString(); }
 			set { Enum.TryParse(value, true, out _travelMode); }


### PR DESCRIPTION
Each step can have a different travel mode. Like the first part is walking, and the next part is driving. Adding TravelMode to each step so that users can tell the difference.

Note that I use TryParse instead of your normal method of Parse as I use the already existing enum TravelMode and TryParse have the ability to ignore case.
