### PR TITLE
Enable pagination for Places requests and responses

### DIFF
--- a/GoogleMapsApi/Entities/Places/Request/PlacesRequest.cs
+++ b/GoogleMapsApi/Entities/Places/Request/PlacesRequest.cs
@@ -67,6 +67,12 @@ namespace GoogleMapsApi.Entities.Places.Request
 		/// </summary>
 		public string Types { get; set; }
 
+        /// <summary>
+        /// If there is a next page of results, this token will be supplied by Google in a previous PlacesResponse. PageToken should be set to the previous response value to get the next page of results from Google.
+        /// When PageToken is set, all other Request parameters are ignored.
+        /// </summary>
+        public string PageToken { get; set; }
+
 		public override bool IsSSL
 		{
 			get
@@ -108,6 +114,8 @@ namespace GoogleMapsApi.Entities.Places.Request
 				parameters.Add("name", Name);
 			if (RankBy == RankBy.Distance)
 				parameters.Add("rankby", "distance");
+            if (!string.IsNullOrWhiteSpace(PageToken))
+                parameters.Add("pagetoken", PageToken);
 
 			return parameters;
 		}

--- a/GoogleMapsApi/Entities/Places/Response/PlacesResponse.cs
+++ b/GoogleMapsApi/Entities/Places/Response/PlacesResponse.cs
@@ -27,6 +27,17 @@ namespace GoogleMapsApi.Entities.Places.Response
 			}
 		}
 
+        /// <summary>
+        /// If there is a next page of results, the token will be supplied by Google. Token should be set on the next PlacesRequest object to get the next page of results from Google.
+        /// If null is returned, there is no next page of results.
+        /// </summary>
+        [DataMember(Name = "next_page_token")]
+        public string NextPage
+        {
+            get;
+            set;
+        }
+
 		/// <summary>
 		/// "results" contains an array of places, with information about the place. See Place Search Results for information about these results. The Places API returns up to 20 establishment results. Additionally, political results may be returned which serve to identify the area of the request.
 		/// </summary>


### PR DESCRIPTION
Wondering if you would find this a useful addition to your excellent library.  We were doing some work with Google Places and needed to use the pagination features for the returned search results.  Without this, you can only get the first 20 results.
