### PR TITLE
Fix UNIX timestamp DST issue

### DIFF
--- a/GoogleMapsApi.Test/GoogleMapsApi.Test.csproj
+++ b/GoogleMapsApi.Test/GoogleMapsApi.Test.csproj
@@ -63,6 +63,7 @@
     <Compile Include="IntegrationTests\PlaceAutocompleteTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="StaticMaps.cs" />
+    <Compile Include="UnixTimeConverterTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\GoogleMapsApi\GoogleMapsApi.csproj">

--- a/GoogleMapsApi.Test/UnixTimeConverterTest.cs
+++ b/GoogleMapsApi.Test/UnixTimeConverterTest.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Reflection;
+using NUnit.Framework;
+using GoogleMapsApi.Engine;
+
+namespace GoogleMapsApi.Test
+{
+    [TestFixture]
+    public class UnixTimeConverterTest
+    {
+        /// <summary>
+        /// This test verifies that the DateTimeToUnixTimestamp prdouces the expected Unix timestamps
+        /// </summary>
+        [Test]
+        public void DateTimeToUnixTimestamp_Test()
+        {
+            Assert.AreEqual(UnixTimeConverter.DateTimeToUnixTimestamp(new DateTime(2016, 4, 4, 12, 0, 0, DateTimeKind.Local)), 1459764000);
+            Assert.AreEqual(UnixTimeConverter.DateTimeToUnixTimestamp(new DateTime(2016, 4, 4, 10, 0, 0, DateTimeKind.Utc)), 1459764000);
+            Assert.AreEqual(UnixTimeConverter.DateTimeToUnixTimestamp(new DateTime(2016, 3, 1, 12, 0, 0, DateTimeKind.Local)), 1456830000);
+            Assert.AreEqual(UnixTimeConverter.DateTimeToUnixTimestamp(new DateTime(2016, 3, 1, 11, 0, 0, DateTimeKind.Utc)), 1456830000);
+        }
+    }
+}

--- a/GoogleMapsApi/Engine/UnixTimeConverter.cs
+++ b/GoogleMapsApi/Engine/UnixTimeConverter.cs
@@ -4,14 +4,14 @@ namespace GoogleMapsApi.Engine
 {
 	public static class UnixTimeConverter
 	{
-		private static DateTime epoch = new DateTime(1970, 1, 1);
+        private static DateTime epoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
 		/// <summary>
 		/// Converts a DateTime to a Unix timestamp
 		/// </summary>
 		public static int DateTimeToUnixTimestamp(DateTime dateTime)
 		{
-			return (int)(dateTime - epoch.ToLocalTime()).TotalSeconds;
+			return (int)(dateTime.ToUniversalTime() - epoch).TotalSeconds;
 		}
 	}
 }


### PR DESCRIPTION
Since the UnixTimeConverter used local time for epoch and provided datetime, there can be issues with daylight saving times.

Fixed by using UTC dates