### PR TITLE
Added the region property so that directions results can be localized

### DIFF
--- a/GoogleMapsApi.Test/IntegrationTests/DirectionsTests.cs
+++ b/GoogleMapsApi.Test/IntegrationTests/DirectionsTests.cs
@@ -149,6 +149,7 @@ namespace GoogleMapsApi.Test.IntegrationTests
                 TravelMode = TravelMode.Transit,
                 DepartureTime = dep_time,
                 Language = "sv"
+
             };
 
             DirectionsResponse result = GoogleMaps.Directions.Query(request);
@@ -162,6 +163,28 @@ namespace GoogleMapsApi.Test.IntegrationTests
                 .Lines?
                 .Vehicle?
                 .LocalIcon != null));
+        }
+
+        [Test]
+        public void Directions_WithRegionSearch()
+        {
+            var dep_time = DateTime.Today
+                            .AddDays(1)
+                            .AddHours(13);
+
+            var request = new DirectionsRequest
+            {
+                Origin = "Mt Albert",
+                Destination = "Parnell",
+                TravelMode = TravelMode.Transit,
+                DepartureTime = dep_time,
+                Region = "nz"
+            };
+
+            DirectionsResponse result = GoogleMaps.Directions.Query(request);
+
+            Assert.IsNotEmpty(result.Routes);
+            Assert.True(result.Status.Equals(DirectionsStatusCodes.OK));
         }
     }
 }

--- a/GoogleMapsApi/Entities/Directions/Request/DirectionsRequest.cs
+++ b/GoogleMapsApi/Entities/Directions/Request/DirectionsRequest.cs
@@ -81,6 +81,13 @@ namespace GoogleMapsApi.Entities.Directions.Request
 		/// </summary>
 		public TravelMode TravelMode { get; set; }
 
+        /// <summary>
+        /// This parameter takes a region code, specified as a IANA language region subtag (http://www.iana.org/assignments/language-subtag-registry/language-subtag-registry). 
+        /// In most cases, these tags map directly to familiar ccTLD ("top-level domain") two-character values such as "uk" in "co.uk" for example.
+        ///  In some cases, the region tag also supports ISO-3166-1 codes, which sometimes differ from ccTLD values ("GB" for "Great Britain" for example).
+        /// </summary>
+        public string Region { get; set; }
+
 		protected override QueryStringParametersList GetQueryStringParameters()
 		{
 			if (string.IsNullOrWhiteSpace(Origin))
@@ -109,7 +116,10 @@ namespace GoogleMapsApi.Entities.Directions.Request
 			if (!string.IsNullOrWhiteSpace(Language))
 				parameters.Add("language", Language);
 
-			if (Waypoints != null && Waypoints.Any())
+            if (!string.IsNullOrWhiteSpace(Region))
+                parameters.Add("region", Region);
+
+            if (Waypoints != null && Waypoints.Any())
 			{
 				IEnumerable<string> waypoints;
 


### PR DESCRIPTION
This simple change just adds the region parameter to the google directions request so that results can be localized to a given region such as US or NZ.