### PR TITLE
Variables should be changed before the v1.0.

### DIFF
--- a/GoogleMapsApi/Entities/Common/Type.cs
+++ b/GoogleMapsApi/Entities/Common/Type.cs
@@ -18,9 +18,9 @@ namespace GoogleMapsApi.Entities.Common
 		[EnumMember(Value = "administrative_area_level_1")]
 		AdministrativeAreaLevel1,// indicates a first-order civil entity below the country level. Within the United States, these administrative levels are states. Not all nations exhibit these administrative levels.
 		[EnumMember(Value = "administrative_area_level_2")]
-		AdministrativeAeaLvel2, // indicates a second-order civil entity below the country level. Within the United States, these administrative levels are counties. Not all nations exhibit these administrative levels.
+		AdministrativeAreaLevel2, // indicates a second-order civil entity below the country level. Within the United States, these administrative levels are counties. Not all nations exhibit these administrative levels.
 		[EnumMember(Value = "administrative_area_level_3")]
-		AdministrativeAeaLevel3, // indicates a third-order civil entity below the country level. This type indicates a minor civil division. Not all nations exhibit these administrative levels.
+		AdministrativeAreaLevel3, // indicates a third-order civil entity below the country level. This type indicates a minor civil division. Not all nations exhibit these administrative levels.
 		[EnumMember(Value = "colloquial_area")]
 		ColloquialArea, // indicates a commonly-used alternative name for the entity.
 		[EnumMember(Value = "locality")]

--- a/GoogleMapsApi/Entities/TimeZone/Response/TimeZoneResponse.cs
+++ b/GoogleMapsApi/Entities/TimeZone/Response/TimeZoneResponse.cs
@@ -30,7 +30,10 @@ namespace GoogleMapsApi.Entities.TimeZone.Response
         /// DstOffset: the offset for daylight-savings time in seconds. This will be zero if the time zone is not in Daylight Savings Time during the specified timestamp.
         /// </summary>
         [DataMember(Name = "dstOffset")]
-        public double OffSet { get; set; }
+        public double DstOffSet { get; set; }
+
+        [Obsolete("Use DstOffSet instead.")]
+        public double OffSet { get { return DstOffSet; }  }
 
         /// <summary>
         /// RawOffset: the offset from UTC (in seconds) for the given location. This does not take into effect daylight savings.


### PR DESCRIPTION
Very recommended change 'Offset' for 'DstOffset' in TimeZoneResponse. Cause 'Offset' can be mistaken for 'RawOffset'