### PR TITLE
Fix zero-longitude location string (should be "0.0", not "")

### DIFF
--- a/GoogleMapsApi.Test/GoogleMapsApi.Test.csproj
+++ b/GoogleMapsApi.Test/GoogleMapsApi.Test.csproj
@@ -61,6 +61,7 @@
     <Compile Include="IntegrationTests\PlacesTextTests.cs" />
     <Compile Include="IntegrationTests\TimeZoneTests.cs" />
     <Compile Include="IntegrationTests\PlaceAutocompleteTests.cs" />
+    <Compile Include="LocationToStringTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="StaticMaps.cs" />
     <Compile Include="UnixTimeConverterTest.cs" />

--- a/GoogleMapsApi.Test/LocationToStringTest.cs
+++ b/GoogleMapsApi.Test/LocationToStringTest.cs
@@ -1,0 +1,25 @@
+﻿using GoogleMapsApi.Entities.Common;
+using NUnit.Framework;
+
+namespace GoogleMapsApi.Test
+{
+    [TestFixture]
+    public class LocationToStringTest
+    {
+        [Test]
+        public void WhenNearZeroLongitude_ExpectCorrectToString()
+        {
+            // Longitude of 0.000009 is converted to 9E-06 using Invariant ToString, but we need 0.000009
+            var location = new Location(57.231d, 0.000009d);
+            Assert.AreEqual("57.231,0.000009", location.ToString());
+        }
+
+        [Test]
+        public void WhenZeroLongitude_ExpectCorrectToString()
+        {
+            // Longitude of 0.000009 is converted to 9E-06 using Invariant ToString, but we need 0.000009
+            var location = new Location(52.123123d, 0.0d);
+            Assert.AreEqual("52.123123,0.0", location.ToString());
+        }
+    }
+}

--- a/GoogleMapsApi/Entities/Common/Location.cs
+++ b/GoogleMapsApi/Entities/Common/Location.cs
@@ -23,7 +23,7 @@ namespace GoogleMapsApi.Entities.Common
 		{
 			get
 			{
-				return Latitude.ToString(CultureInfo.InvariantCulture) + "," + Longitude.ToString(CultureInfo.InvariantCulture);
+				return ToNonScientificString(Latitude) + "," + ToNonScientificString(Longitude);
 			}
 		}
 
@@ -31,5 +31,13 @@ namespace GoogleMapsApi.Entities.Common
 		{
 			return LocationString;
 		}
-	}
+
+        private static string ToNonScientificString(double d)
+        {
+            var s = d.ToString(DoubleFormat).TrimEnd('0');
+            return s.Length == 0 ? "0.0" : s;
+        }
+
+	    private static readonly string DoubleFormat = "0." + new string('#', 339);
+    }
 }


### PR DESCRIPTION
If longitude is 0 then location string should be "0", but was ""