### PR TITLE
Adding support for directions with traffic

### DIFF
--- a/GoogleMapsApi.Test/IntegrationTests/DirectionsTests.cs
+++ b/GoogleMapsApi.Test/IntegrationTests/DirectionsTests.cs
@@ -186,5 +186,26 @@ namespace GoogleMapsApi.Test.IntegrationTests
             Assert.IsNotEmpty(result.Routes);
             Assert.True(result.Status.Equals(DirectionsStatusCodes.OK));
         }
+
+        [Test]
+        {
+            var request = new DirectionsRequest
+            {
+                Origin = "285 Bedford Ave, Brooklyn, NY, USA",
+                Destination = "185 Broadway Ave, Manhattan, NY, USA",
+                DepartureTime = DateTime.Now.Date.AddDays(1).AddHours(8),
+                ApiKey = ApiKey //Duration in traffic requires an API key
+            };
+            var result = GoogleMaps.Directions.Query(request);
+
+            if (result.Status == DirectionsStatusCodes.OVER_QUERY_LIMIT)
+                Assert.Inconclusive("Cannot run test since you have exceeded your Google API query limit.");
+
+            //All legs have duration
+            Assert.IsTrue(result.Routes.First().Legs.All(l => l.DurationInTraffic != null));
+
+            //Duration with traffic is usually longer but is not guaranteed
+            Assert.AreNotEqual(result.Routes.First().Legs.Sum(s => s.Duration.Value.TotalSeconds), result.Routes.First().Legs.Sum(s => s.DurationInTraffic.Value.TotalSeconds));
+        }
     }
 }

--- a/GoogleMapsApi.Test/IntegrationTests/DirectionsTests.cs
+++ b/GoogleMapsApi.Test/IntegrationTests/DirectionsTests.cs
@@ -188,6 +188,7 @@ namespace GoogleMapsApi.Test.IntegrationTests
         }
 
         [Test]
+        public void Directions_CanGetDurationWithTraffic()
         {
             var request = new DirectionsRequest
             {

--- a/GoogleMapsApi/Entities/Directions/Response/Leg.cs
+++ b/GoogleMapsApi/Entities/Directions/Response/Leg.cs
@@ -28,10 +28,16 @@ namespace GoogleMapsApi.Entities.Directions.Response
 		[DataMember(Name = "duration")]
 		public Duration Duration { get; set; }
 
-		/// <summary>
-		/// start_location contains the latitude/longitude coordinates of the origin of this leg. Because the Directions API calculates directions between locations by using the nearest transportation option (usually a road) at the start and end points, start_location may be different than the provided origin of this leg if, for example, a road is not near the origin.
-		/// </summary>
-		[DataMember(Name = "start_location")]
+        /// <summary>
+        /// duration_in_traffic indicates the total duration of this leg. This value is an estimate of the time in traffic based on current and historical traffic conditions.
+        /// </summary>
+        [DataMember(Name = "duration_in_traffic")]
+        public Duration DurationInTraffic { get; set; }
+
+        /// <summary>
+        /// start_location contains the latitude/longitude coordinates of the origin of this leg. Because the Directions API calculates directions between locations by using the nearest transportation option (usually a road) at the start and end points, start_location may be different than the provided origin of this leg if, for example, a road is not near the origin.
+        /// </summary>
+        [DataMember(Name = "start_location")]
 		public Location StartLocation { get; set; }
 
 		/// <summary>


### PR DESCRIPTION
Noticed current version is missing the duration in traffic field for direction legs, added the field to Leg class and included a unit test that verifies values are coming back when calling Google's API.