### PR TITLE
Added support for Encoded polyline based Static map and API Key

### DIFF
--- a/GoogleMapsApi/Entities/Directions/Response/OverviewPolyline.cs
+++ b/GoogleMapsApi/Entities/Directions/Response/OverviewPolyline.cs
@@ -15,7 +15,7 @@ namespace GoogleMapsApi.Entities.Directions.Response
 		/// The encoded string containing the overview path points as they were received.
 		/// </summary>
 		[DataMember(Name = "points")]
-		internal string EncodedPoints { get; set; }
+		public string EncodedPoints { get; internal set; }
 
 		private Lazy<IEnumerable<Location>> pointsLazy;
 

--- a/GoogleMapsApi/StaticMaps/Entities/StaticMapRequest.cs
+++ b/GoogleMapsApi/StaticMaps/Entities/StaticMapRequest.cs
@@ -100,6 +100,11 @@ namespace GoogleMapsApi.StaticMaps.Entities
 
 		public bool IsSSL { get; set; }
 
+        /// <summary>
+        /// Add API key support for the static map
+        /// </summary>
+        public string ApiKey { get; set; }
+
 		public StaticMapRequest(ILocationString center, int zoom, ImageSize imageSize)
 		{
 			Center = center;
@@ -112,5 +117,13 @@ namespace GoogleMapsApi.StaticMaps.Entities
 			Markers = markers;
 			Size = imageSize;
 		}
-	}
+        /// <summary>
+        /// A constructor to support encoded polyline based static map
+        /// </summary>
+        /// <param name="imageSize">Image size to be passed to google api</param>
+        public StaticMapRequest(ImageSize imageSize)
+        {
+            Size = imageSize;
+        }
+    }
 }

--- a/GoogleMapsApi/StaticMaps/StaticMapsEngine.cs
+++ b/GoogleMapsApi/StaticMaps/StaticMapsEngine.cs
@@ -305,7 +305,13 @@ namespace GoogleMapsApi.StaticMaps
 
 			parametersList.Add("sensor", request.Sensor ? "true" : "false");
 
-			return scheme + BaseUrl + "?" + parametersList.GetQueryStringPostfix();
+            if (!string.IsNullOrEmpty(request.ApiKey))
+            {
+                string apiKey = request.ApiKey;
+                parametersList.Add("key", apiKey);
+            }
+
+            return scheme + BaseUrl + "?" + parametersList.GetQueryStringPostfix();
 		}
 	}
 }

--- a/MapsApiTest/Program.cs
+++ b/MapsApiTest/Program.cs
@@ -99,8 +99,28 @@ namespace MapsApiTest
 
 			Console.WriteLine("Map with path: " + url);
 
-			// Async! (Elevation)
-			var elevationRequest = new ElevationRequest
+            // Encoded polyline based static map
+            IList<ILocationString> encodedPolyline = new List<ILocationString>();
+            string encodedKey = "enc:";
+            AddressLocation polyline = new AddressLocation(string.Concat(encodedKey, drivingDirections.Routes.First().OverviewPath.EncodedPoints));
+            encodedPolyline.Add(polyline);
+
+            url = staticMapGenerator.GenerateStaticMapURL(new StaticMapRequest(new ImageSize(800, 400))
+            {
+                Pathes = new List<Path> { new Path
+                    {
+                        Style = new PathStyle
+                        {
+                            Color = "red"
+                        },
+                        Locations = encodedPolyline,
+                    }},
+            });
+
+            Console.WriteLine("Map with encoded polyline path: " + url);
+
+            // Async! (Elevation)
+            var elevationRequest = new ElevationRequest
 			{
 				Locations = new[] { new Location(54, 78) },
 			};


### PR DESCRIPTION
- Added support for encoded polyline to render static map url
- Added support for passing API Key to static map
- Updated the Test under MapsApiTest Project (Did not show how to pass API Key in the test but it should be same as DirectionsRequest)