### PR TITLE
Assert.IsNotEmpty instead of Is.Not.Null.And.Not.Empty 

### DIFF
--- a/GoogleMapsApi.Test/IntegrationTests/PlacesTextTests.cs
+++ b/GoogleMapsApi.Test/IntegrationTests/PlacesTextTests.cs
@@ -41,7 +41,7 @@ namespace GoogleMapsApi.Test.IntegrationTests
             if (result.Status == Status.OVER_QUERY_LIMIT)
                 Assert.Inconclusive("Cannot run test since you have exceeded your Google API query limit.");
             Assert.AreEqual(Status.OK, result.Status);
-            Assert.IsNotEmpty(result.Results.First().Photos);
+            Assert.That(result.Results.First().Photos, Is.Not.Null.And.Not.Empty);
         }
     }
 }


### PR DESCRIPTION
Unittest fix: this test failed with an unhandled exception instead of proper Assertion Message.
Reason: Assert.IsNotEmpty expects an initialized collection-object, not a null reference, but the code can return a null-object for the Photos-property