### PR TITLE
Fix for failing unit test

### DIFF
--- a/GoogleMapsApi.Test/IntegrationTests/DirectionsTests.cs
+++ b/GoogleMapsApi.Test/IntegrationTests/DirectionsTests.cs
@@ -136,7 +136,7 @@ namespace GoogleMapsApi.Test.IntegrationTests
         }
 
         [Test]
-        public void Directions_WithLocalIcons()
+        public void Directions_WithIcons()
         {
             var dep_time = DateTime.Today
                             .AddDays(1)
@@ -162,7 +162,7 @@ namespace GoogleMapsApi.Test.IntegrationTests
                 s.TransitDetails?
                 .Lines?
                 .Vehicle?
-                .LocalIcon != null));
+                .Icon != null));
         }
 
         [Test]


### PR DESCRIPTION
It seems based on google responses that localicons are untrustworthy, as I couldn't find any example where it works. I noticed there was no icons (ie non local) icons test so I refactored this test to fullfill the most similar test possible that makes sense.

This is a fix for:
https://github.com/maximn/google-maps/issues/95