### PR TITLE
Made sensor parameter obsolete

### DIFF
--- a/GoogleMapsApi.Test/IntegrationTests/PlacesNearByTests.cs
+++ b/GoogleMapsApi.Test/IntegrationTests/PlacesNearByTests.cs
@@ -20,7 +20,6 @@ namespace GoogleMapsApi.Test.IntegrationTests
                 Keyword = "pizza",
                 Radius = 10000,
                 Location = new Location(47.611162, -122.337644), //Seattle, Washington, USA
-                Sensor = false,
             };
 
             PlacesNearByResponse result = GoogleMaps.PlacesNearBy.Query(request);
@@ -39,7 +38,6 @@ namespace GoogleMapsApi.Test.IntegrationTests
                 ApiKey = ApiKey,
                 Radius = 10000,
                 Location = new Location(64.6247243, 21.0747553), // Skellefteå, Sweden
-                Sensor = false,
                 Type = "airport",
             };
 
@@ -62,7 +60,6 @@ namespace GoogleMapsApi.Test.IntegrationTests
                 Keyword = "pizza",
                 Radius = 10000,
                 Location = new Location(47.611162, -122.337644), //Seattle, Washington, USA
-                Sensor = false,
             };
 
             PlacesNearByResponse result = GoogleMaps.PlacesNearBy.Query(request);
@@ -86,7 +83,6 @@ namespace GoogleMapsApi.Test.IntegrationTests
                 Keyword = "pizza",
                 Radius = 10000,
                 Location = new Location(47.611162, -122.337644), //Seattle, Washington, USA
-                Sensor = false,
                 PageToken = result.NextPage
             };
             result = GoogleMaps.PlacesNearBy.Query(request);

--- a/GoogleMapsApi.Test/IntegrationTests/PlacesRadarTests.cs
+++ b/GoogleMapsApi.Test/IntegrationTests/PlacesRadarTests.cs
@@ -18,7 +18,6 @@ namespace GoogleMapsApi.Test.IntegrationTests
                 Keyword = "pizza",
                 Radius = 10000,
                 Location = new Location(47.611162, -122.337644), //Seattle, Washington, USA
-                Sensor = false,
             };
 
             PlacesRadarResponse result = GoogleMaps.PlacesRadar.Query(request);
@@ -37,7 +36,6 @@ namespace GoogleMapsApi.Test.IntegrationTests
                 ApiKey = ApiKey,
                 Radius = 10000,
                 Location = new Location(64.6247243, 21.0747553), // Skellefteå, Sweden
-                Sensor = false,
                 Type = "airport",
             };
 

--- a/GoogleMapsApi.Test/IntegrationTests/PlacesSearchTests.cs
+++ b/GoogleMapsApi.Test/IntegrationTests/PlacesSearchTests.cs
@@ -20,7 +20,6 @@ namespace GoogleMapsApi.Test.IntegrationTests
                 Keyword = "pizza",
                 Radius = 10000,
                 Location = new Location(47.611162, -122.337644), //Seattle, Washington, USA
-                Sensor = false,
             };
 
             PlacesResponse result = GoogleMaps.Places.Query(request);
@@ -39,7 +38,6 @@ namespace GoogleMapsApi.Test.IntegrationTests
                 ApiKey = ApiKey,
                 Radius = 10000,
                 Location = new Location(64.6247243, 21.0747553), // Skellefteå, Sweden
-                Sensor = false,
                 Type = "airport",
             };
 
@@ -62,7 +60,6 @@ namespace GoogleMapsApi.Test.IntegrationTests
                 Keyword = "pizza",
                 Radius = 10000,
                 Location = new Location(47.611162, -122.337644), //Seattle, Washington, USA
-                Sensor = false,
             };
 
             PlacesResponse result = GoogleMaps.Places.Query(request);
@@ -86,7 +83,6 @@ namespace GoogleMapsApi.Test.IntegrationTests
                 Keyword = "pizza",
                 Radius = 10000,
                 Location = new Location(47.611162, -122.337644), //Seattle, Washington, USA
-                Sensor = false,
                 PageToken = result.NextPage
             };
             result = GoogleMaps.Places.Query(request);

--- a/GoogleMapsApi.Test/StaticMaps.cs
+++ b/GoogleMapsApi.Test/StaticMaps.cs
@@ -39,13 +39,12 @@ namespace GoogleMapsApi.Test
 										Style = new MarkerStyle { Color = "red", Label = "C" },
 										Locations = new List<ILocationString> { new Location(40.718217, -73.998284) }
 									}
-							},
-					Sensor = false
+							}
 				};
 			string expectedResult = "http://maps.google.com/maps/api/staticmap" +
 									"?center=Brooklyn%20Bridge%2CNew%20York%2CNY&zoom=14&size=512x512&maptype=roadmap" +
 									"&markers=color%3Ablue%7Clabel%3AS%7C40.702147%2C-74.015794&markers=color%3Agreen%7Clabel%3AG%7C40.711614%2C-74.012318" +
-									"&markers=color%3Ared%7Clabel%3AC%7C40.718217%2C-73.998284&sensor=false";
+									"&markers=color%3Ared%7Clabel%3AC%7C40.718217%2C-73.998284";
 
 			string generateStaticMapURL = new StaticMapsEngine().GenerateStaticMapURL(request);
 
@@ -57,7 +56,7 @@ namespace GoogleMapsApi.Test
 		{
 			var request = new StaticMapRequest(new AddressLocation("Berkeley,CA"), 14, new ImageSize(400, 400));
 			string expectedResult = "http://maps.google.com/maps/api/staticmap" +
-									"?center=Berkeley%2CCA&zoom=14&size=400x400&sensor=false";
+									"?center=Berkeley%2CCA&zoom=14&size=400x400";
 
 			string generateStaticMapURL = new StaticMapsEngine().GenerateStaticMapURL(request);
 
@@ -69,7 +68,7 @@ namespace GoogleMapsApi.Test
 		{
 			var request = new StaticMapRequest(new Location(40.714728, -73.998672), 12, new ImageSize(400, 400));
 			string expectedResult = "http://maps.google.com/maps/api/staticmap" +
-									"?center=40.714728%2C-73.998672&zoom=12&size=400x400&sensor=false";
+									"?center=40.714728%2C-73.998672&zoom=12&size=400x400";
 
 			string generateStaticMapURL = new StaticMapsEngine().GenerateStaticMapURL(request);
 
@@ -81,7 +80,7 @@ namespace GoogleMapsApi.Test
 		{
 			var request = new StaticMapRequest(new Location(0, 0), 1, new ImageSize(400, 50));
 			string expectedResult = "http://maps.google.com/maps/api/staticmap" +
-									"?center=0.0%2C0.0&zoom=1&size=400x50&sensor=false";
+									"?center=0.0%2C0.0&zoom=1&size=400x50";
 
 			string generateStaticMapURL = new StaticMapsEngine().GenerateStaticMapURL(request);
 
@@ -95,7 +94,7 @@ namespace GoogleMapsApi.Test
 			var request = new StaticMapRequest(new Location(40.714728, -73.998672), 12, new ImageSize(400, 400));
 			request.MapType = MapType.Terrain;
 			string expectedResult = @"http://maps.google.com/maps/api/staticmap" +
-									@"?center=40.714728%2C-73.998672&zoom=12&size=400x400&maptype=terrain&sensor=false";
+									@"?center=40.714728%2C-73.998672&zoom=12&size=400x400&maptype=terrain";
 
 			string actualResult = new StaticMapsEngine().GenerateStaticMapURL(request);
 

--- a/GoogleMapsApi/Entities/Common/MapsBaseRequest.cs
+++ b/GoogleMapsApi/Entities/Common/MapsBaseRequest.cs
@@ -11,33 +11,19 @@ namespace GoogleMapsApi.Entities.Common
         public MapsBaseRequest()
         {
             this.isSsl = true;
-            Sensor = false;
             ApiKey = null;
         }
 
 
         /// <summary>
         /// True to indicate that request comes from a device with a location sensor, otherwise false. 
-        /// This information is required by Google and does not affect the results.
         /// </summary>
         /// <remarks>
-        /// It is unclear if Google refers to the device performing the request or the source of the location data.
-        /// In the geocoding API reference at https://developers.google.com/maps/documentation/geocoding/ the definition is:
-        /// 
-        ///     sensor (required) — Indicates whether or not the geocoding request comes from a device with a location sensor.
-        /// 
-        /// This implies that only mobile devices that are equipped with a location sensor (such as GPS) should set the Sensor value 
-        /// to True. So if a location is sent to a web server which then calls the Google API, it apparently should set the Sensor
-        /// value to false, since the web server isn't a location sensor equipped device.
-        /// 
-        /// In another page of their documentation, https://developers.google.com/maps/documentation/javascript/tutorial they say:
-        /// 
-        ///     The sensor parameter of the URL must be included, and indicates whether this application uses a sensor (such as a GPS 
-        ///     locator) to determine the user's location.
-        /// 
-        /// This implies something completely different, that the Sensor value must be set to true if the source of the location
-        /// information is a sensor or not, regardless if the request is being performed by a location sensor equipped device or not.
+        /// The Google Maps API previously required that you include the sensor parameter to indicate whether your application used a sensor to determine the user's location.
+        /// This parameter is no longer required.
+        /// See the geocoding API reference at https://developers.google.com/maps/documentation/geocoding/.
         /// </remarks>
+        [Obsolete]
         public bool Sensor { get; set; }
 
         /// <summary>
@@ -68,8 +54,6 @@ namespace GoogleMapsApi.Entities.Common
         protected virtual QueryStringParametersList GetQueryStringParameters()
         {
             QueryStringParametersList parametersList = new QueryStringParametersList();
-
-            parametersList.Add("sensor", Sensor.ToString().ToLower());
 
             if (!string.IsNullOrWhiteSpace(ApiKey))
             {

--- a/GoogleMapsApi/Entities/Directions/The Google Directions API - Google Maps API Web Services - Google Code.htm
+++ b/GoogleMapsApi/Entities/Directions/The Google Directions API - Google Maps API Web Services - Google Code.htm
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+﻿<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <!-- saved from url=(0058)http://code.google.com/apis/maps/documentation/directions/ -->
 <HTML><HEAD><META http-equiv="Content-Type" content="text/html; charset=UTF-8">
     
@@ -358,10 +358,6 @@ URL parameters:</P>
   results by using localized domains of
   <CODE>http://map.google.com</CODE>. See <A href="http://code.google.com/apis/maps/documentation/directions/#RegionBiasing">Region
   Biasing</A> for more information.</LI>
-  <LI><CODE>sensor</CODE> (<I>required</I>) — Indicates whether
-  or not the directions request comes from a device with a location
-  sensor. This value must be either <CODE>true</CODE> or
-  <CODE>false</CODE>.</LI>
 </UL>
 
 <P><SPAN style="color:red">* Note: </SPAN> You may pass either an
@@ -407,7 +403,7 @@ separated by the pipe (<CODE>|</CODE>) character.</P>
 for a route between Boston, MA and Concord, MA via Charlestown
 and Lexington, in that order:</P>
 
-<PRE>http://maps.google.com/maps/api/directions/json?origin=Boston,MA&amp;destination=Concord,MA&amp;waypoints=Charlestown,MA|Lexington,MA&amp;sensor=false
+<PRE>http://maps.google.com/maps/api/directions/json?origin=Boston,MA&amp;destination=Concord,MA&amp;waypoints=Charlestown,MA|Lexington,MA
 </PRE>
 
 <P>By default, the Directions service calculates a route through
@@ -430,7 +426,7 @@ Australia to each of South Australia's main wine regions using route
 optimization. </P>
 
 
-<PRE class="prettyprint"><SPAN class="pln">http</SPAN><SPAN class="pun">:</SPAN><SPAN class="com">//maps.google.com/maps/api/directions/json?origin=Adelaide,SA&amp;destination=Adelaide,SA&amp;waypoints=optimize:true|Barossa+Valley,SA|Clare,SA|Connawarra,SA|McLaren+Vale,SA&amp;sensor=false</SPAN></PRE>
+<PRE class="prettyprint"><SPAN class="pln">http</SPAN><SPAN class="pun">:</SPAN><SPAN class="com">//maps.google.com/maps/api/directions/json?origin=Adelaide,SA&amp;destination=Adelaide,SA&amp;waypoints=optimize:true|Barossa+Valley,SA|Clare,SA|Connawarra,SA|McLaren+Vale,SA</SPAN></PRE>
 
 
 <P>Inspection of the calculated route will indicate that the route is calculated using
@@ -467,7 +463,7 @@ returns a result when sent to <CODE>http://maps.google.es/</CODE>
 as "Toledo" is interpreted as the Spanish city:</P>
 
 
-<PRE><B>http://maps.google.es/maps/api/directions/json?origin=Toledo&amp;destination=Madrid&amp;sensor=false</B>
+<PRE><B>http://maps.google.es/maps/api/directions/json?origin=Toledo&amp;destination=Madrid</B>
 
 {
   "status": "OK",
@@ -488,7 +484,7 @@ as "Toledo" is interpreted as the Spanish city:</P>
 will not return any results, since "Toledo" is interpreted as the city in Ohio:</P>
 
 
-<PRE><B>http://maps.google.com/maps/api/directions/json?origin=Toledo&amp;destination=Madrid&amp;sensor=false</B>
+<PRE><B>http://maps.google.com/maps/api/directions/json?origin=Toledo&amp;destination=Madrid</B>
 
 {
   "status": "ZERO_RESULTS",
@@ -508,7 +504,7 @@ will not return any results, since "Toledo" is interpreted as the city in Ohio:<
 from Chicago, IL to Los Angeles, CA via two waypoints in Joplin, MO
 and Oklahoma City, OK:</P>
 
-<PRE class="prettyprint"><SPAN class="pln">http</SPAN><SPAN class="pun">:</SPAN><SPAN class="com">//maps.google.com/maps/api/directions/json?origin=Chicago,IL&amp;destination=Los+Angeles,CA&amp;waypoints=Joplin,MO|Oklahoma+City,OK&amp;sensor=false</SPAN></PRE>
+<PRE class="prettyprint"><SPAN class="pln">http</SPAN><SPAN class="pun">:</SPAN><SPAN class="com">//maps.google.com/maps/api/directions/json?origin=Chicago,IL&amp;destination=Los+Angeles,CA&amp;waypoints=Joplin,MO|Oklahoma+City,OK</SPAN></PRE>
 
 <P>The JSON result is shown below. Because directions results can be quite verbose,
 repeated elements within the response have been omitted for clarity.</P>
@@ -531,7 +527,7 @@ JSON</A> for some recommended design patterns.</P>
 <P>In this example, the Directions API requests an <CODE>xml</CODE> response for the
 identical query shown above for :</P>
 
-<PRE class="prettyprint"><SPAN class="pln">http</SPAN><SPAN class="pun">:</SPAN><SPAN class="com">//maps.google.com/maps/api/directions/xml?origin=Chicago,IL&amp;destination=Los+Angeles,CA&amp;waypoints=Joplin,MO|Oklahoma+City,OK&amp;sensor=false</SPAN></PRE>
+<PRE class="prettyprint"><SPAN class="pln">http</SPAN><SPAN class="pun">:</SPAN><SPAN class="com">//maps.google.com/maps/api/directions/xml?origin=Chicago,IL&amp;destination=Los+Angeles,CA&amp;waypoints=Joplin,MO|Oklahoma+City,OK</SPAN></PRE>
 
 <P>The XML returned by this request is shown below.</P>
 

--- a/GoogleMapsApi/Entities/Elevation/Response/Status.cs
+++ b/GoogleMapsApi/Entities/Elevation/Response/Status.cs
@@ -12,7 +12,7 @@ namespace GoogleMapsApi.Entities.Elevation.Response
 		[EnumMember]
 		OVER_QUERY_LIMIT, // indicating the requestor has exceeded quota
 		[EnumMember]
-		REQUEST_DENIED, // indicating the API did not complete the request, likely because the requestor failed to include a valid sensor parameter
+		REQUEST_DENIED, // indicating the API did not complete the request
 		[EnumMember]
 		UNKNOWN_ERROR //indicating an unknown error
 	}

--- a/GoogleMapsApi/Entities/Geocoding/Response/Status.cs
+++ b/GoogleMapsApi/Entities/Geocoding/Response/Status.cs
@@ -27,7 +27,7 @@ namespace GoogleMapsApi.Entities.Geocoding.Response
 		OVER_QUERY_LIMIT,
 
         /// <summary>
-        /// Indicates that your request was denied, generally because of lack of a sensor parameter.
+        /// Indicates that your request was denied.
         /// </summary>
 		[EnumMember]
 		REQUEST_DENIED,

--- a/GoogleMapsApi/Entities/PlaceAutocomplete/Response/Status.cs
+++ b/GoogleMapsApi/Entities/PlaceAutocomplete/Response/Status.cs
@@ -12,7 +12,7 @@ namespace GoogleMapsApi.Entities.PlaceAutocomplete.Response
 		[EnumMember(Value = "OVER_QUERY_LIMIT")]
 		OVER_QUERY_LIMIT, // indicates that you are over your quota.
 		[EnumMember(Value = "REQUEST_DENIED")]
-		REQUEST_DENIED, // indicates that your request was denied, generally because of lack of a sensor parameter.
+		REQUEST_DENIED, // indicates that your request was denied.
 		[EnumMember(Value = "INVALID_REQUEST")]
 		INVALID_REQUEST // generally indicates that the input parameter is missing.
 	}

--- a/GoogleMapsApi/Entities/Places/Response/Status.cs
+++ b/GoogleMapsApi/Entities/Places/Response/Status.cs
@@ -12,7 +12,7 @@ namespace GoogleMapsApi.Entities.Places.Response
 		[EnumMember(Value = "OVER_QUERY_LIMIT")]
 		OVER_QUERY_LIMIT, // indicates that you are over your quota.
 		[EnumMember(Value = "REQUEST_DENIED")]
-		REQUEST_DENIED, // indicates that your request was denied, generally because of lack of a sensor parameter.
+		REQUEST_DENIED, // indicates that your request was denied.
 		[EnumMember(Value = "INVALID_REQUEST")]
 		INVALID_REQUEST // generally indicates that the query parameter (location or radius) is missing.
 	}

--- a/GoogleMapsApi/Entities/PlacesDetails/Response/Status.cs
+++ b/GoogleMapsApi/Entities/PlacesDetails/Response/Status.cs
@@ -30,7 +30,7 @@ namespace GoogleMapsApi.Entities.PlacesDetails.Response
         OVER_QUERY_LIMIT,
 
         /// <summary>
-        /// Indicates that your request was denied, generally because of lack of a sensor parameter.
+        /// Indicates that your request was denied.
         /// </summary>
         [EnumMember(Value = "REQUEST_DENIED")]
         REQUEST_DENIED,

--- a/GoogleMapsApi/Entities/PlacesNearBy/Response/Status.cs
+++ b/GoogleMapsApi/Entities/PlacesNearBy/Response/Status.cs
@@ -12,7 +12,7 @@ namespace GoogleMapsApi.Entities.PlacesNearBy.Response
 		[EnumMember(Value = "OVER_QUERY_LIMIT")]
 		OVER_QUERY_LIMIT, // indicates that you are over your quota.
 		[EnumMember(Value = "REQUEST_DENIED")]
-		REQUEST_DENIED, // indicates that your request was denied, generally because of lack of a sensor parameter.
+		REQUEST_DENIED, // indicates that your request was denied.
 		[EnumMember(Value = "INVALID_REQUEST")]
 		INVALID_REQUEST // generally indicates that the query parameter (location or radius) is missing.
 	}

--- a/GoogleMapsApi/Entities/PlacesRadar/Response/Status.cs
+++ b/GoogleMapsApi/Entities/PlacesRadar/Response/Status.cs
@@ -12,7 +12,7 @@ namespace GoogleMapsApi.Entities.PlacesRadar.Response
 		[EnumMember(Value = "OVER_QUERY_LIMIT")]
 		OVER_QUERY_LIMIT, // indicates that you are over your quota.
 		[EnumMember(Value = "REQUEST_DENIED")]
-		REQUEST_DENIED, // indicates that your request was denied, generally because of lack of a sensor parameter.
+		REQUEST_DENIED, // indicates that your request was denied.
 		[EnumMember(Value = "INVALID_REQUEST")]
 		INVALID_REQUEST // generally indicates that the query parameter (location or radius) is missing.
 	}

--- a/GoogleMapsApi/Entities/PlacesText/Response/Status.cs
+++ b/GoogleMapsApi/Entities/PlacesText/Response/Status.cs
@@ -12,7 +12,7 @@ namespace GoogleMapsApi.Entities.PlacesText.Response
         [EnumMember(Value = "OVER_QUERY_LIMIT")]
         OVER_QUERY_LIMIT, // indicates that you are over your quota.
         [EnumMember(Value = "REQUEST_DENIED")]
-        REQUEST_DENIED, // indicates that your request was denied, generally because of lack of a sensor parameter.
+        REQUEST_DENIED, // indicates that your request was denied.
         [EnumMember(Value = "INVALID_REQUEST")]
         INVALID_REQUEST // generally indicates that the query parameter (location or radius) is missing.
     }

--- a/GoogleMapsApi/Entities/TimeZone/Response/Status.cs
+++ b/GoogleMapsApi/Entities/TimeZone/Response/Status.cs
@@ -12,7 +12,7 @@ namespace GoogleMapsApi.Entities.TimeZone.Response
         [EnumMember(Value = "OVER_QUERY_LIMIT")]
         OVER_QUERY_LIMIT, // indicates that you are over your quota.
         [EnumMember(Value = "REQUEST_DENIED")]
-        REQUEST_DENIED, // indicates that your request was denied, generally because of lack of a sensor parameter.
+        REQUEST_DENIED, // indicates that your request was denied.
         [EnumMember(Value = "INVALID_REQUEST")]
         INVALID_REQUEST, // generally indicates that the query parameter (location or radius) is missing.
         [EnumMember(Value = "UNKNOWN_ERROR")]

--- a/GoogleMapsApi/StaticMaps/Entities/StaticMapRequest.cs
+++ b/GoogleMapsApi/StaticMaps/Entities/StaticMapRequest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using GoogleMapsApi.Entities.Common;
 using GoogleMapsApi.StaticMaps.Enums;
@@ -93,9 +94,14 @@ namespace GoogleMapsApi.StaticMaps.Entities
 		public MapStyle Style { get; set; }
 
 		/// <summary>
-		/// sensor (required) specifies whether the application requesting the static map is using a sensor to determine the user's 
-		/// location. This parameter is required for all static map requests. 
+		/// (obsolete) sensor specifies whether the application requesting the static map is using a sensor to determine the user's 
+		/// location.
 		/// </summary>
+		/// <remarks>
+		/// The Google Static Maps API previously required that you include the sensor parameter to indicate whether your application used a sensor to determine the user's location.
+		/// This parameter is no longer required.
+		/// </remarks>
+		[Obsolete]
 		public bool Sensor { get; set; }
 
 		public bool IsSSL { get; set; }

--- a/GoogleMapsApi/StaticMaps/StaticMapsEngine.cs
+++ b/GoogleMapsApi/StaticMaps/StaticMapsEngine.cs
@@ -309,8 +309,6 @@ namespace GoogleMapsApi.StaticMaps
 				}
 			}
 
-			parametersList.Add("sensor", request.Sensor ? "true" : "false");
-
 			return scheme + BaseUrl + "?" + parametersList.GetQueryStringPostfix();
 		}
 	}


### PR DESCRIPTION
The property was retained for backward-compatibility but is no longer utilized as a parameter. The Google Maps API, which previously required that you include the sensor parameter, has indicated that this parameter is no longer required (or desired).