### PR TITLE
Fix deadlocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ obj/
 *.user
 _ReSharper*/
 packages
+project.lock.json
 
 # mstest test results
 [Tt]est[Rr]esult*

--- a/GoogleMapsApi/GoogleMapsApi.csproj
+++ b/GoogleMapsApi/GoogleMapsApi.csproj
@@ -35,10 +35,6 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net.Http">

--- a/GoogleMapsApi/HttpClientExtensions.cs
+++ b/GoogleMapsApi/HttpClientExtensions.cs
@@ -35,12 +35,12 @@ namespace GoogleMapsApi
         [Obsolete]
         public static async Task<byte[]> DownloadDataTaskAsync(this HttpClient client, Uri address, TimeSpan timeout, CancellationToken token = new CancellationToken())
         {
-            var dataDownloaded = await DownloadData(client, address, timeout, token);
+            var dataDownloaded = await DownloadData(client, address, timeout, token).ConfigureAwait(false);
 
             if (dataDownloaded != null)
-                return await dataDownloaded.Content.ReadAsByteArrayAsync();
+                return await dataDownloaded.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
 
-            return await GetCancelledTask<byte[]>();
+            return await GetCancelledTask<byte[]>().ConfigureAwait(false);
         }
 
         [Obsolete]
@@ -59,7 +59,7 @@ namespace GoogleMapsApi
         {
             var tcs = new TaskCompletionSource<T>();
             tcs.SetCanceled();
-            return await tcs.Task;
+            return await tcs.Task.ConfigureAwait(false);
         }
 
         [Obsolete]
@@ -74,14 +74,14 @@ namespace GoogleMapsApi
                 return null;
 
             client.Timeout = timeout;
-            var httpResponse = await client.GetAsync(address, token);
+            var httpResponse = await client.GetAsync(address, token).ConfigureAwait(false);
 
             if (!httpResponse.IsSuccessStatusCode)
             {
                 if (httpResponse.StatusCode == HttpStatusCode.Forbidden ||
                     httpResponse.StatusCode == HttpStatusCode.ProxyAuthenticationRequired ||
                     httpResponse.StatusCode == HttpStatusCode.Unauthorized)
-                    throw new AuthenticationException(await httpResponse.Content.ReadAsStringAsync());
+                    throw new AuthenticationException(await httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false));
 
                 if (httpResponse.StatusCode == HttpStatusCode.GatewayTimeout ||
                     httpResponse.StatusCode == HttpStatusCode.RequestTimeout)


### PR DESCRIPTION
This hopefully fixes issue #105 - it's been tested with a 4.6 Windows Forms app and prevents deadlocks compared with master as of feaba99
I've also removed a duplicate Newtonsoft.Json reference - it was causing issues with VS2017, and also told git to ignore project.lock.json.