### PR TITLE
Hotfix/ferry improvements

### DIFF
--- a/GoogleMapsApi/Entities/Directions/Request/AvoidWay.cs
+++ b/GoogleMapsApi/Entities/Directions/Request/AvoidWay.cs
@@ -7,6 +7,8 @@ namespace GoogleMapsApi.Entities.Directions.Request
 	{
 		Nothing = 0x0,
 		Tolls = 0x1,
-		Highways = 0x2
+		Highways = 0x2,
+		Ferries = 0x3,
+		Indoor = 0x4
 	}
 }

--- a/GoogleMapsApi/Entities/Directions/Response/Step.cs
+++ b/GoogleMapsApi/Entities/Directions/Response/Step.cs
@@ -82,5 +82,11 @@ namespace GoogleMapsApi.Entities.Directions.Response
 				}
 			}
 		}
+
+		/// <summary>
+		/// Gets the action to take for the current step (turn left, merge, straight, etc.) - Values in this list are subject to change. See documentation.
+		/// </summary>
+		[DataMember(Name = "maneuver")]
+		public string Maneuver { get; set; }
 	}
 }


### PR DESCRIPTION
This allows you to avoid Ferries and Indoor results, if desired. And also now provides the `maneuver` result back from Google. I did not use an enum for this, since they specified in their documentation that the values could change at any time.