### PR TITLE
Fix #124: Implement support for sessiontoken parameter

### DIFF
--- a/GoogleMapsApi/Entities/PlaceAutocomplete/Request/PlaceAutocompleteRequest.cs
+++ b/GoogleMapsApi/Entities/PlaceAutocomplete/Request/PlaceAutocompleteRequest.cs
@@ -81,6 +81,12 @@ namespace GoogleMapsApi.Entities.PlaceAutocomplete.Request
 				throw new NotSupportedException("This operation is not supported, PlaceAutocompleteRequest must use SSL");
 			}
 		}
+		
+		/// <summary>
+		/// A random string which identifies an autocomplete session for billing purposes.
+		/// If this parameter is omitted from an autocomplete request, the request is billed independently.
+		/// </summary>
+		public string SessionToken { get; set; }
 
 		protected override QueryStringParametersList GetQueryStringParameters()
 		{
@@ -106,7 +112,9 @@ namespace GoogleMapsApi.Entities.PlaceAutocomplete.Request
 			if (!string.IsNullOrWhiteSpace(Components))
 				parameters.Add("components", Components);
 			if (StrinctBounds)
-                		parameters.Add("strictbounds", StrinctBounds.ToString());
+				parameters.Add("strictbounds", StrinctBounds.ToString());
+			if (!string.IsNullOrWhiteSpace(SessionToken))
+				parameters.Add("sessiontoken", SessionToken);
 
 			return parameters;
 		}

--- a/GoogleMapsApi/Entities/PlacesDetails/Request/PlacesDetailsRequest.cs
+++ b/GoogleMapsApi/Entities/PlacesDetails/Request/PlacesDetailsRequest.cs
@@ -19,6 +19,12 @@ namespace GoogleMapsApi.Entities.PlacesDetails.Request
             get { return true; }
             set { throw new NotSupportedException("This operation is not supported, PlacesRequest must use SSL"); }
         }
+        
+        /// <summary>
+        /// A random string which identifies an autocomplete session for billing purposes.
+        /// If this parameter is omitted from an autocomplete request, the request is billed independently.
+        /// </summary>
+        public string SessionToken { get; set; }
 
         protected override QueryStringParametersList GetQueryStringParameters()
         {
@@ -33,6 +39,9 @@ namespace GoogleMapsApi.Entities.PlacesDetails.Request
             parameters.Add("placeid", PlaceId);
 
             if (!string.IsNullOrWhiteSpace(Language)) parameters.Add("language", Language);
+            
+            if (!string.IsNullOrWhiteSpace(SessionToken))
+                parameters.Add("sessiontoken", SessionToken);
             
             return parameters;
         }


### PR DESCRIPTION
This PR adds support for the `sessiontoken` parameter for `PlacesAutoCompleteRequest` and `PlacesDetailRequest`. Please have a look at the documentation of this parameter: https://developers.google.com/places/web-service/autocomplete.