### PR TITLE
Fixed missing enum-value.

### DIFF
--- a/GoogleMapsApi.Test/IntegrationTests/DirectionsTests.cs
+++ b/GoogleMapsApi.Test/IntegrationTests/DirectionsTests.cs
@@ -16,7 +16,7 @@ namespace GoogleMapsApi.Test.IntegrationTests
         public void Directions_SumOfStepDistancesCorrect()
         {
             var request = new DirectionsRequest { Origin = "285 Bedford Ave, Brooklyn, NY, USA", Destination = "185 Broadway Ave, Manhattan, NY, USA" };
-
+            request.ApiKey = ApiKey;
             var result = GoogleMaps.Directions.Query(request);
 
             AssertInconclusive.NotExceedQuota(result);
@@ -44,8 +44,7 @@ namespace GoogleMapsApi.Test.IntegrationTests
         [Test]
         public void Directions_WithWayPoints()
         {
-            var request = new DirectionsRequest { Origin = "NYC, USA", Destination = "Miami, USA", Waypoints = new string[] { "Philadelphia, USA" }, OptimizeWaypoints = true };
-
+            var request = new DirectionsRequest { Origin = "NYC, USA", Destination = "Miami, USA", Waypoints = new string[] { "Philadelphia, USA" }, OptimizeWaypoints = true, ApiKey = ApiKey };
             var result = GoogleMaps.Directions.Query(request);
 
             AssertInconclusive.NotExceedQuota(result);
@@ -53,6 +52,33 @@ namespace GoogleMapsApi.Test.IntegrationTests
             Assert.AreEqual(156097, result.Routes.First().Legs.First().Steps.Sum(s => s.Distance.Value), 10 * 1000);
 
             StringAssert.Contains("Philadelphia", result.Routes.First().Legs.First().EndAddress);
+        }
+        [Test]
+        public void Directions_ExceedingRouteLength()
+        {
+            var request = new DirectionsRequest
+            {
+                Origin = "NYC, USA", Destination = "Miami, USA", Waypoints = new string[]
+                {
+                    "Seattle, USA",
+                    "Dallas, USA",
+                    "Naginey, USA",
+                    "Edmonton, Canada",
+                    "Seattle, USA",
+                    "Dallas, USA",
+                    "Naginey, USA",
+                    "Edmonton, Canada",
+                    "Seattle, USA",
+                    "Dallas, USA",
+                    "Naginey, USA",
+                    "Edmonton, Canada"
+                },
+                ApiKey = ApiKey
+            };
+            var result = GoogleMaps.Directions.Query(request);
+
+            AssertInconclusive.NotExceedQuota(result);
+            Assert.AreEqual(DirectionsStatusCodes.MAX_ROUTE_LENGTH_EXCEEDED, result.Status, result.ErrorMessage);
         }
 
         [Test]

--- a/GoogleMapsApi/Entities/Directions/Response/StatusCodes.cs
+++ b/GoogleMapsApi/Entities/Directions/Response/StatusCodes.cs
@@ -13,6 +13,8 @@ namespace GoogleMapsApi.Entities.Directions.Response
 		ZERO_RESULTS, // indicates no route could be found between the origin and destination.
 		[EnumMember]
 		MAX_WAYPOINTS_EXCEEDED, // indicates that too many waypointss were provided in the request The maximum allowed waypoints is 8, plus the origin, and destination. ( Google Maps Premier customers may contain requests with up to 23 waypoints.)
+        [EnumMember]
+        MAX_ROUTE_LENGTH_EXCEEDED, // indicates the requested route is too long and cannot be processed.
 		[EnumMember]
 		INVALID_REQUEST, // indicates that the provided request was invalid.
 		[EnumMember]


### PR DESCRIPTION
Hi @maximn, 

Just to take a start contributing, I fixed #89. I changed some integrationtests by including the ApiKey to make them run. I think last run was before directions always need a ApiKey.  
Shall I change that for all tests?   