### PR TITLE
Improve GeocodingRequest.

### DIFF
--- a/GoogleMapsApi.Test/IntegrationTests/GeocodingTests.cs
+++ b/GoogleMapsApi.Test/IntegrationTests/GeocodingTests.cs
@@ -31,7 +31,6 @@ namespace GoogleMapsApi.Test.IntegrationTests
             StringAssert.IsMatch("40\\.\\d*,-73\\.\\d*", result.Results.First().Geometry.Location.LocationString);
         }
 
-
         [Test]
         public void GeocodingAsync_ReturnsCorrectLocation()
         {
@@ -93,12 +92,100 @@ namespace GoogleMapsApi.Test.IntegrationTests
         }
 
         [Test]
-        public async Task ReverseGeocoding_ReturnsCorrectAddress()
+        public async Task ReverseGeocoding_LatLng_ReturnsCorrectAddress()
         {
             var request = new GeocodingRequest
             {
                 ApiKey = ApiKey,
                 Location = new Location(40.7141289, -73.9614074)
+            };
+
+            var result = await GoogleMaps.Geocode.QueryAsync(request);
+
+            AssertInconclusive.NotExceedQuota(result);
+            Assert.AreEqual(Status.OK, result.Status);
+            StringAssert.Contains("Bedford Ave, Brooklyn, NY 11211, USA", result.Results.First().FormattedAddress);
+        }
+
+        [Test]
+        public async Task ReverseGeocoding_PlaceId_ReturnsCorrectAddress()
+        {
+            var request = new GeocodingRequest
+            {
+                ApiKey = ApiKey,
+                PlaceId = "ChIJo9YpQWBZwokR7OeY0hiWh8g"
+            };
+
+            var result = await GoogleMaps.Geocode.QueryAsync(request);
+
+            AssertInconclusive.NotExceedQuota(result);
+            Assert.AreEqual(Status.OK, result.Status);
+            StringAssert.Contains("Bedford Ave, Brooklyn, NY 11211, USA", result.Results.First().FormattedAddress);
+        }
+
+        [Test]
+        public async Task ReverseGeocoding_PlaceIdAndRegion_ReturnsCorrectAddress()
+        {
+            var request = new GeocodingRequest
+            {
+                ApiKey = ApiKey,
+                PlaceId = "ChIJo9YpQWBZwokR7OeY0hiWh8g",
+                Region = "US"
+            };
+
+            var result = await GoogleMaps.Geocode.QueryAsync(request);
+
+            AssertInconclusive.NotExceedQuota(result);
+            Assert.AreEqual(Status.OK, result.Status);
+            StringAssert.Contains("Bedford Ave, Brooklyn, NY 11211, USA", result.Results.First().FormattedAddress);
+        }
+
+        [Test]
+        public async Task ReverseGeocoding_PlaceIdAndBounds_ReturnsCorrectAddress()
+        {
+            var request = new GeocodingRequest
+            {
+                ApiKey = ApiKey,
+                PlaceId = "ChIJo9YpQWBZwokR7OeY0hiWh8g",
+                Bounds = new[]
+                {
+                    new Location(40.7154070802915, -73.9599636697085),
+                    new Location(40.7127091197085, -73.96266163029151)
+                }
+            };
+
+            var result = await GoogleMaps.Geocode.QueryAsync(request);
+
+            AssertInconclusive.NotExceedQuota(result);
+            Assert.AreEqual(Status.OK, result.Status);
+            StringAssert.Contains("Bedford Ave, Brooklyn, NY 11211, USA", result.Results.First().FormattedAddress);
+        }
+
+        [Test]
+        public async Task ReverseGeocoding_PlaceIdAndComponents_ReturnsCorrectAddress()
+        {
+            var request = new GeocodingRequest
+            {
+                ApiKey = ApiKey,
+                PlaceId = "ChIJo9YpQWBZwokR7OeY0hiWh8g",
+                Components = new() { Country = "US" }
+            };
+
+            var result = await GoogleMaps.Geocode.QueryAsync(request);
+
+            AssertInconclusive.NotExceedQuota(result);
+            Assert.AreEqual(Status.OK, result.Status);
+            StringAssert.Contains("Bedford Ave, Brooklyn, NY 11211, USA", result.Results.First().FormattedAddress);
+        }
+
+        [Test]
+        public async Task ReverseGeocoding_PlaceIdAndAddress_ReturnsCorrectAddress()
+        {
+            var request = new GeocodingRequest
+            {
+                ApiKey = ApiKey,
+                PlaceId = "ChIJo9YpQWBZwokR7OeY0hiWh8g",
+                Address = "Should be ignored"
             };
 
             var result = await GoogleMaps.Geocode.QueryAsync(request);

--- a/GoogleMapsApi/Entities/Geocoding/Request/GeocodingRequest.cs
+++ b/GoogleMapsApi/Entities/Geocoding/Request/GeocodingRequest.cs
@@ -56,33 +56,38 @@ namespace GoogleMapsApi.Entities.Geocoding.Request
 
         protected override QueryStringParametersList GetQueryStringParameters()
         {
-            bool hasAddress = !string.IsNullOrWhiteSpace(Address);
             bool hasPlaceId = !string.IsNullOrWhiteSpace(PlaceId);
+            bool hasLocation = Location is not null;
+            bool hasAddress = !string.IsNullOrWhiteSpace(Address);
 
-            if (!hasAddress && Location == null && !Components.Exists && !hasPlaceId)
-                throw new ArgumentException("Address, Location, Components OR PlaceId is required");
+            if (!(hasPlaceId || hasLocation || hasAddress || Components.Exists))
+                throw new ArgumentException("PlaceId, Location, Address or Components is required");
 
             var parameters = base.GetQueryStringParameters();
 
-            if (Location != null)
-                parameters.Add(_latlng, Location.ToString());
-
-            if (hasAddress)
-                parameters.Add(_address, Address);
-
             if (hasPlaceId)
+            {
                 parameters.Add(_placeId, PlaceId);
+            }
+            else if (hasLocation)
+            {
+                parameters.Add(_latlng, Location.ToString());
+            }
+            else if (hasAddress)
+            {
+                parameters.Add(_address, Address);
+            }
 
-            if (Components.Exists)
+            if (Components.Exists && !hasPlaceId)
             {
                 string components = Components.Build();
                 parameters.Add(_components, components);
             }
 
-            if (Bounds != null && Bounds.Any())
+            if (Bounds != null && Bounds.Any() && !hasPlaceId)
                 parameters.Add(_bounds, string.Join("|", Bounds.AsEnumerable()));
 
-            if (!string.IsNullOrWhiteSpace(Region))
+            if (!string.IsNullOrWhiteSpace(Region) && !hasPlaceId)
                 parameters.Add(_region, Region);
 
             if (!string.IsNullOrWhiteSpace(Language))
@@ -91,12 +96,12 @@ namespace GoogleMapsApi.Entities.Geocoding.Request
             return parameters;
         }
 
-        const string _latlng = "latlng";
-        const string _address = "address";
-        const string _placeId = "place_id";
-        const string _bounds = "bounds";
-        const string _region = "region";
-        const string _language = "language";
-        const string _components = "components";
+        private const string _latlng = "latlng";
+        private const string _address = "address";
+        private const string _placeId = "place_id";
+        private const string _bounds = "bounds";
+        private const string _region = "region";
+        private const string _language = "language";
+        private const string _components = "components";
     }
 }


### PR DESCRIPTION
In GeocodingRequest setting some combinations of properties result in a 400 response from the Google API. The first combination I ran into was PlaceId in combination with Region. But also PlaceId in combination with Bounds or Components are not allowed. I've added some unit tests to show this.
After some more testing I noticed only one of PlaceId, Location or Address is allowed to be used on the Google Geocoding API. GeocodingRequest allowed many combinations. I've updated the class to be more restrictive what property to use, also setting a preference for PlaceId, then Location and finally Address to use as parameters.
Maybe it's even better to split GeocodingRequest in three subclasses (PlaceIdGeocodingRequest, Location...) based on the type of input.