### PR TITLE
Updated dependencies and now compatible from netstandard2.0 to net8.0

### DIFF
--- a/GoogleMapsApi.Test/GoogleMapsApi.Test.csproj
+++ b/GoogleMapsApi.Test/GoogleMapsApi.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-	<TargetFrameworks>net8.0;net6.0</TargetFrameworks>
+	<TargetFrameworks>net8.0;net6.0;net4.8</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <OutputType>Library</OutputType>
     <IsPackable>false</IsPackable>
@@ -9,12 +9,18 @@
   </PropertyGroup>
 	
   <ItemGroup>
-	<FrameworkReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="NUnit" Version="4.0.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="3.10.0" />
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="NUnit" Version="4.2.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.3.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   
 	<ItemGroup>

--- a/GoogleMapsApi.Test/IntegrationTests/BaseTestIntegration.cs
+++ b/GoogleMapsApi.Test/IntegrationTests/BaseTestIntegration.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Configuration;
+﻿using GoogleMapsApi.Test.Utils;
 using System.IO;
 
 namespace GoogleMapsApi.Test.IntegrationTests
@@ -12,24 +12,12 @@ namespace GoogleMapsApi.Test.IntegrationTests
     public class BaseTestIntegration
     {
         const string ApiKeyEnvironmentVariable = "GOOGLE_API_KEY";
-        private readonly IConfigurationRoot Configuration;
 
         public BaseTestIntegration()
         {
-            var builder = new ConfigurationBuilder()
-                .SetBasePath(Directory.GetCurrentDirectory())
-                .AddEnvironmentVariables();
-
-            string appsettingsPath = Path.Combine(Directory.GetCurrentDirectory(), "appsettings.json");
-            if (File.Exists(appsettingsPath))
-            {
-                builder.AddJsonFile("appsettings.json", optional: true, reloadOnChange: true);
-            }
-
-            Configuration = builder.Build();
         }
 
-        protected string ApiKey => Configuration.GetValue<string>(ApiKeyEnvironmentVariable) 
+        protected string ApiKey => AppSettings.Load()?.GoogleApiKey
             ?? Environment.GetEnvironmentVariable(ApiKeyEnvironmentVariable) 
             ?? throw new InvalidOperationException($"API key is not configured. Please set the {ApiKeyEnvironmentVariable} environment variable.");
     }

--- a/GoogleMapsApi.Test/IntegrationTests/DistanceMatrixTests.cs
+++ b/GoogleMapsApi.Test/IntegrationTests/DistanceMatrixTests.cs
@@ -195,9 +195,7 @@
 
             static Uri onUriCreated(Uri uri)
             {
-                var builder = new UriBuilder(uri);
-                builder.Query = builder.Query.Replace("placeholder", "1,2");
-                return builder.Uri;
+                return new Uri(uri.ToString().Replace("placeholder", "1,2"));
             }
 
             GoogleMaps.DistanceMatrix.OnUriCreated += onUriCreated;

--- a/GoogleMapsApi.Test/Utils/AppSettings.cs
+++ b/GoogleMapsApi.Test/Utils/AppSettings.cs
@@ -1,0 +1,22 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GoogleMapsApi.Test.Utils
+{
+    internal class AppSettings
+    {
+        [JsonProperty(PropertyName ="GOOGLE_API_KEY")]
+        public string? GoogleApiKey { get; set; }
+
+        public static AppSettings? Load()
+        {
+            var path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "appsettings.json");
+            if (!File.Exists(path)) return null;
+            return JsonConvert.DeserializeObject<AppSettings>(File.ReadAllText(path));
+        }
+    }
+}

--- a/GoogleMapsApi/GoogleMapsApi.csproj
+++ b/GoogleMapsApi/GoogleMapsApi.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-	<TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.1</TargetFrameworks>
+	<TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.0</TargetFrameworks>
 	<LangVersion>latest</LangVersion>
 	<Version>0.0.0</Version>
 	<AppxAutoIncrementPackageRevision>True</AppxAutoIncrementPackageRevision>


### PR DESCRIPTION
- Updated all NuGet dependencies
- reverded the base target from **netstandard2.1** (introduced in ver 1.2.7) to **netstandard2.0** as this keeps it compatible with the still widely used **Net Framework 4.8**.
- Added **net4.8** to Tests targets and adapted appsettings.json code to work on every platform (used newtonsoft.json to read it instead of the AspNetCore configuration).
- In DistanceMatrixTests.ShouldReplaceUriViaOnUriCreated test implemented the placeholder replacement without using the UriBuilder as it was buggy in .net 4.8
**All tests passed on all targets.**
I'm already using in one of my .net 4.8 WinForms project and it's working flawlessy.