### PR TITLE
Enhance release script with direct workflow links

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -141,4 +141,19 @@ fi
 
 echo -e "${GREEN}🎉 Release process completed!${NC}"
 echo -e "${GREEN}📦 GitHub Actions will now build and publish the NuGet package${NC}"
-echo -e "${YELLOW}📋 You can monitor the progress at: https://github.com/maximn/google-maps/actions${NC}"
+
+# Try to get direct link to the workflow run (best effort)
+echo -e "${YELLOW}🔍 Looking for triggered workflow...${NC}"
+sleep 3  # Give GitHub a moment to register the workflow
+
+if command -v gh >/dev/null 2>&1; then
+    # Get the most recent workflow run (should be ours)
+    RUN_URL=$(gh run list --limit 1 --json url --jq '.[0].url' 2>/dev/null)
+    if [[ -n "$RUN_URL" && "$RUN_URL" != "null" ]]; then
+        echo -e "${YELLOW}📋 Direct link to workflow: ${RUN_URL}${NC}"
+    else
+        echo -e "${YELLOW}📋 You can monitor the progress at: https://github.com/maximn/google-maps/actions${NC}"
+    fi
+else
+    echo -e "${YELLOW}📋 You can monitor the progress at: https://github.com/maximn/google-maps/actions${NC}"
+fi


### PR DESCRIPTION
## Summary
- Enhanced release script to provide direct links to triggered GitHub Actions workflows
- Implemented GitHub CLI integration with best-effort approach and fallback
- Improved user experience by eliminating need to search for the correct workflow run

## Changes
- Added GitHub CLI (`gh run list`) integration to fetch the most recent workflow run URL
- Included 3-second wait period to allow GitHub to register the triggered workflow
- Implemented graceful fallback to generic actions page if direct link unavailable
- Enhanced output messaging with workflow lookup status

## Test plan
- [ ] Run `./release.sh --dry-run` to verify dry run functionality still works
- [ ] Test release script with actual tag creation to verify direct link generation
- [ ] Verify fallback behavior when GitHub CLI is unavailable or fails
- [ ] Confirm script behavior when no workflows are found