### PR TITLE
Add pagination support to Places Text Search API (#148)

### DIFF
--- a/GoogleMapsApi.Test/IntegrationTests/PlacesTextTests.cs
+++ b/GoogleMapsApi.Test/IntegrationTests/PlacesTextTests.cs
@@ -43,5 +43,48 @@ namespace GoogleMapsApi.Test.IntegrationTests
             Assert.That(result.Status, Is.EqualTo(Status.OK));
             Assert.That(result.Results, Is.Not.Null.And.Not.Empty);
         }
+
+        [Test]
+        public async Task Should_Support_Pagination_With_NextPageToken()
+        {
+            var request = new PlacesTextRequest
+            {
+                ApiKey = ApiKey,
+                Query = "restaurants in New York City"
+            };
+
+            PlacesTextResponse firstResponse = await GoogleMaps.PlacesText.QueryAsync(request);
+
+            AssertInconclusive.NotExceedQuota(firstResponse);
+            Assert.That(firstResponse.Status, Is.EqualTo(Status.OK));
+            Assert.That(firstResponse.Results, Is.Not.Null.And.Not.Empty);
+            
+            if (string.IsNullOrWhiteSpace(firstResponse.NextPage))
+            {
+                Assert.Inconclusive("This query did not return a next_page_token, cannot test pagination. Try a broader query that returns more results.");
+                return;
+            }
+
+            await Task.Delay(2000);
+
+            var secondRequest = new PlacesTextRequest
+            {
+                ApiKey = ApiKey,
+                Query = "restaurants in New York City",
+                PageToken = firstResponse.NextPage
+            };
+
+            PlacesTextResponse secondResponse = await GoogleMaps.PlacesText.QueryAsync(secondRequest);
+
+            AssertInconclusive.NotExceedQuota(secondResponse);
+            Assert.That(secondResponse.Status, Is.EqualTo(Status.OK));
+            Assert.That(secondResponse.Results, Is.Not.Null.And.Not.Empty);
+            
+            var firstResultsIds = firstResponse.Results.Select(r => r.PlaceId).ToArray();
+            var secondResultsIds = secondResponse.Results.Select(r => r.PlaceId).ToArray();
+            
+            Assert.That(firstResultsIds.Intersect(secondResultsIds).Count(), Is.EqualTo(0), 
+                "First and second page should contain different results");
+        }
     }
 }

--- a/GoogleMapsApi/Entities/PlacesText/Request/PlacesTextRequest.cs
+++ b/GoogleMapsApi/Entities/PlacesText/Request/PlacesTextRequest.cs
@@ -17,6 +17,7 @@ namespace GoogleMapsApi.Entities.PlacesText.Request
         public double? Radius { get; set; } // optional
         public string Language { get; set; } // optional
         public string Types { get; set; } // optional
+        public string PageToken { get; set; } // optional
 
         public override bool IsSSL
         {
@@ -41,6 +42,7 @@ namespace GoogleMapsApi.Entities.PlacesText.Request
             if (Radius != null) parameters.Add("radius", Radius.Value.ToString(CultureInfo.InvariantCulture));
             if (!string.IsNullOrWhiteSpace(Language)) parameters.Add("language", Language);
             if (!string.IsNullOrWhiteSpace(Types)) parameters.Add("types", Types);
+            if (!string.IsNullOrWhiteSpace(PageToken)) parameters.Add("pagetoken", PageToken);
 
             return parameters;
         }

--- a/GoogleMapsApi/Entities/PlacesText/Response/PlacesTextResponse.cs
+++ b/GoogleMapsApi/Entities/PlacesText/Response/PlacesTextResponse.cs
@@ -32,5 +32,11 @@ namespace GoogleMapsApi.Entities.PlacesText.Response
         /// </summary>
         [DataMember(Name = "results")]
         public IEnumerable<Result> Results { get; set; }
+
+        /// <summary>
+        /// Contains a token that can be used to return up to 20 additional results. When a next_page_token is returned, it contains the next set of results.
+        /// </summary>
+        [DataMember(Name = "next_page_token")]
+        public string NextPage { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
• Add NextPage property to PlacesTextResponse to capture next_page_token from Google API
• Add PageToken property to PlacesTextRequest for sending pagination requests  
• Add comprehensive integration test validating end-to-end pagination functionality
• Includes proper 2-second delay between requests as required by Google API

## Test plan
- [x] Existing PlacesTextTests continue to pass (2/2 tests)
- [x] New pagination test validates different results between pages  
- [x] Full test suite passes (73/76 tests, 3 skipped)
- [x] Integration test handles cases where pagination is not available

Fixes #148