### PR TITLE
Fix issue #147: Add helper methods to extract address components from…

### DIFF
--- a/GoogleMapsApi.Test/IntegrationTests/PlacesDetailsAddressComponentTests.cs
+++ b/GoogleMapsApi.Test/IntegrationTests/PlacesDetailsAddressComponentTests.cs
@@ -1,0 +1,152 @@
+using System.Linq;
+using System.Threading.Tasks;
+using GoogleMapsApi.Entities.PlacesDetails.Request;
+using GoogleMapsApi.Entities.PlacesDetails.Response;
+using NUnit.Framework;
+using GoogleMapsApi.Test.Utils;
+
+namespace GoogleMapsApi.Test.IntegrationTests
+{
+    [TestFixture]
+    public class PlacesDetailsAddressComponentTests : BaseTestIntegration
+    {
+        private const string GoogleSydneyOfficePlaceId = "ChIJN1t_tDeuEmsRUsoyG83frY4";
+
+        [Test]
+        public async Task CanExtractStreetAddressFromPlacesDetails()
+        {
+            // Test with a known place that has a street address
+            var request = new PlacesDetailsRequest
+            {
+                ApiKey = ApiKey,
+                PlaceId = GoogleSydneyOfficePlaceId
+            };
+
+            var result = await GoogleMaps.PlacesDetails.QueryAsync(request);
+
+            AssertInconclusive.NotExceedQuota(result);
+            Assert.That(result.Status, Is.EqualTo(Status.OK));
+            Assert.That(result.Result.AddressComponent, Is.Not.Null.And.Not.Empty);
+
+            // Extract street address using the helper method
+            var streetAddress = result.Result.GetStreetAddress();
+            Assert.That(streetAddress, Is.Not.Null.And.Not.Empty);
+            Assert.That(streetAddress, Does.Contain("Pirrama"));
+        }
+
+        [Test]
+        public async Task CanExtractStateFromPlacesDetails()
+        {
+            var request = new PlacesDetailsRequest
+            {
+                ApiKey = ApiKey,
+                PlaceId = GoogleSydneyOfficePlaceId
+            };
+
+            var result = await GoogleMaps.PlacesDetails.QueryAsync(request);
+
+            AssertInconclusive.NotExceedQuota(result);
+            Assert.That(result.Status, Is.EqualTo(Status.OK));
+
+            // Extract state using the helper method
+            var state = result.Result.GetState();
+            var stateShort = result.Result.GetState(useShortName: true);
+            
+            Assert.That(state, Is.Not.Null.And.Not.Empty);
+            Assert.That(stateShort, Is.Not.Null.And.Not.Empty);
+        }
+
+        [Test]
+        public async Task CanExtractPostalCodeFromPlacesDetails()
+        {
+            var request = new PlacesDetailsRequest
+            {
+                ApiKey = ApiKey,
+                PlaceId = GoogleSydneyOfficePlaceId
+            };
+
+            var result = await GoogleMaps.PlacesDetails.QueryAsync(request);
+
+            AssertInconclusive.NotExceedQuota(result);
+            Assert.That(result.Status, Is.EqualTo(Status.OK));
+
+            // Extract postal code using the helper method
+            var postalCode = result.Result.GetPostalCode();
+            Assert.That(postalCode, Is.Not.Null.And.Not.Empty);
+        }
+
+        [Test]
+        public async Task CanExtractCompleteAddressBreakdown()
+        {
+            var request = new PlacesDetailsRequest
+            {
+                ApiKey = ApiKey,
+                PlaceId = GoogleSydneyOfficePlaceId
+            };
+
+            var result = await GoogleMaps.PlacesDetails.QueryAsync(request);
+
+            AssertInconclusive.NotExceedQuota(result);
+            Assert.That(result.Status, Is.EqualTo(Status.OK));
+
+            // Extract complete address breakdown
+            var addressBreakdown = result.Result.GetAddressBreakdown();
+            
+            Assert.That(addressBreakdown, Is.Not.Null);
+            Assert.That(addressBreakdown.StreetAddress, Is.Not.Null.And.Not.Empty);
+            Assert.That(addressBreakdown.City, Is.Not.Null.And.Not.Empty);
+            Assert.That(addressBreakdown.State, Is.Not.Null.And.Not.Empty);
+            Assert.That(addressBreakdown.PostalCode, Is.Not.Null.And.Not.Empty);
+            Assert.That(addressBreakdown.Country, Is.Not.Null.And.Not.Empty);
+
+            // Test the ToString method
+            var formattedAddress = addressBreakdown.ToString();
+            Assert.That(formattedAddress, Is.Not.Null.And.Not.Empty);
+            Assert.That(formattedAddress, Does.Contain(","));
+        }
+
+        [Test]
+        public async Task CanExtractCityFromPlacesDetails()
+        {
+            var request = new PlacesDetailsRequest
+            {
+                ApiKey = ApiKey,
+                PlaceId = GoogleSydneyOfficePlaceId
+            };
+
+            var result = await GoogleMaps.PlacesDetails.QueryAsync(request);
+
+            AssertInconclusive.NotExceedQuota(result);
+            Assert.That(result.Status, Is.EqualTo(Status.OK));
+
+            // Extract city using the helper method
+            var city = result.Result.GetCity();
+            Assert.That(city, Is.Not.Null.And.Not.Empty);
+            // Google Sydney office is in Pyrmont, which is a suburb of Sydney
+            Assert.That(city, Is.EqualTo("Pyrmont"));
+        }
+
+        [Test]
+        public async Task CanExtractCountryFromPlacesDetails()
+        {
+            var request = new PlacesDetailsRequest
+            {
+                ApiKey = ApiKey,
+                PlaceId = GoogleSydneyOfficePlaceId
+            };
+
+            var result = await GoogleMaps.PlacesDetails.QueryAsync(request);
+
+            AssertInconclusive.NotExceedQuota(result);
+            Assert.That(result.Status, Is.EqualTo(Status.OK));
+
+            // Extract country using the helper method
+            var country = result.Result.GetCountry();
+            var countryShort = result.Result.GetCountry(useShortName: true);
+            
+            Assert.That(country, Is.Not.Null.And.Not.Empty);
+            Assert.That(countryShort, Is.Not.Null.And.Not.Empty);
+            Assert.That(countryShort, Is.EqualTo("AU"));
+        }
+    }
+}

--- a/GoogleMapsApi/Examples/PlacesDetailsAddressExtractionExample.cs
+++ b/GoogleMapsApi/Examples/PlacesDetailsAddressExtractionExample.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Threading.Tasks;
+using GoogleMapsApi.Entities.PlacesDetails.Request;
+using GoogleMapsApi.Entities.PlacesDetails.Response;
+
+namespace GoogleMapsApi.Examples
+{
+    /// <summary>
+    /// Example demonstrating how to extract street address, state, and postal code from Places Details API results
+    /// This addresses GitHub issue #147: "How do i get the street address, state, and postal code from the place results?"
+    /// </summary>
+    public class PlacesDetailsAddressExtractionExample
+    {
+        private const string GoogleSydneyOfficePlaceId = "ChIJN1t_tDeuEmsRUsoyG83frY4";
+
+        /// <summary>
+        /// Example showing how to extract individual address components
+        /// </summary>
+        public static async Task ExtractIndividualAddressComponents()
+        {
+            var request = new PlacesDetailsRequest
+            {
+                ApiKey = "YOUR_API_KEY_HERE",
+                PlaceId = GoogleSydneyOfficePlaceId
+            };
+
+            var result = await GoogleMaps.PlacesDetails.QueryAsync(request);
+
+            if (result.Status == Status.OK && result.Result?.AddressComponent != null)
+            {
+                // Extract individual address components using helper methods
+                var streetAddress = result.Result.GetStreetAddress();
+                var state = result.Result.GetState();
+                var stateShort = result.Result.GetState(useShortName: true);
+                var postalCode = result.Result.GetPostalCode();
+                var city = result.Result.GetCity();
+                var country = result.Result.GetCountry();
+
+                Console.WriteLine($"Street Address: {streetAddress}");
+                Console.WriteLine($"City: {city}");
+                Console.WriteLine($"State: {state} ({stateShort})");
+                Console.WriteLine($"Postal Code: {postalCode}");
+                Console.WriteLine($"Country: {country}");
+            }
+        }
+
+        /// <summary>
+        /// Example showing how to extract complete address breakdown
+        /// </summary>
+        public static async Task ExtractCompleteAddressBreakdown()
+        {
+            var request = new PlacesDetailsRequest
+            {
+                ApiKey = "YOUR_API_KEY_HERE",
+                PlaceId = GoogleSydneyOfficePlaceId
+            };
+
+            var result = await GoogleMaps.PlacesDetails.QueryAsync(request);
+
+            if (result.Status == Status.OK && result.Result?.AddressComponent != null)
+            {
+                // Extract complete address breakdown
+                var addressBreakdown = result.Result.GetAddressBreakdown();
+
+                Console.WriteLine($"Complete Address: {addressBreakdown}");
+                Console.WriteLine($"Street: {addressBreakdown.StreetAddress}");
+                Console.WriteLine($"City: {addressBreakdown.City}");
+                Console.WriteLine($"State: {addressBreakdown.State}");
+                Console.WriteLine($"Postal Code: {addressBreakdown.PostalCode}");
+                Console.WriteLine($"Country: {addressBreakdown.Country}");
+            }
+        }
+
+        /// <summary>
+        /// Example showing how to extract address components for multiple places
+        /// </summary>
+        public static async Task ExtractAddressComponentsForMultiplePlaces()
+        {
+            var placeIds = new[]
+            {
+                "ChIJN1t_tDeuEmsRUsoyG83frY4", // Google Sydney
+                "ChIJj61dQgK6j4AR4GeTYWZsKWw", // Google Mountain View
+                "ChIJV4FfHcUZwokR5lP9_0s2OGI"  // Times Square, NYC
+            };
+
+            foreach (var placeId in placeIds)
+            {
+                var request = new PlacesDetailsRequest
+                {
+                    ApiKey = "YOUR_API_KEY_HERE",
+                    PlaceId = placeId
+                };
+
+                var result = await GoogleMaps.PlacesDetails.QueryAsync(request);
+
+                if (result.Status == Status.OK && result.Result?.AddressComponent != null)
+                {
+                    var addressBreakdown = result.Result.GetAddressBreakdown();
+                    Console.WriteLine($"{result.Result.Name}: {addressBreakdown}");
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
… Places Details API

- Add GetStreetAddress(), GetState(), GetPostalCode(), GetCity(), GetCountry() methods to Result class
- Add GetAddressBreakdown() method that returns a structured AddressBreakdown object
- Add comprehensive integration tests demonstrating usage
- Add example code showing how to extract address components
- Extract hardcoded place IDs to constants for better maintainability
- Remove unnecessary AddressComponentExtensions class in favor of direct class methods

This addresses GitHub issue #147: 'How do i get the street address, state, and postal code from the place results?'