### PR TITLE
update target versions

### DIFF
--- a/GoogleMapsApi.Test/GoogleMapsApi.Test.csproj
+++ b/GoogleMapsApi.Test/GoogleMapsApi.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-	<TargetFrameworks>net8.0;net6.0;net4.8</TargetFrameworks>
+	<TargetFrameworks>net8.0;net6.0;net481</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <OutputType>Library</OutputType>
     <IsPackable>false</IsPackable>

--- a/GoogleMapsApi/GoogleMapsApi.csproj
+++ b/GoogleMapsApi/GoogleMapsApi.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-	<TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.0</TargetFrameworks>
+	<TargetFrameworks>netstandard2.0;net6.0;net8.0;net481;net462</TargetFrameworks>
 	<LangVersion>latest</LangVersion>
 	<Version>0.0.0</Version>
 	<AppxAutoIncrementPackageRevision>True</AppxAutoIncrementPackageRevision>
@@ -34,5 +34,9 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net481' OR '$(TargetFramework)' == 'net462'">
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Framework Targeting Update Complete:
  - ✅ Build successful for all targets: netstandard2.0;net6.0;net8.0;net481;net462
  - ✅ Tests pass on available framework (.NET 8.0)
  - ✅ Added net462 for broader .NET Framework compatibility
  - ✅ Added net481 for latest .NET Framework features
  - ✅ Removed EOL net7.0