### PR TITLE
Updated System.Text.Json dependency to reference minimum supported versions per target framework

### DIFF
--- a/GoogleMapsApi/GoogleMapsApi.csproj
+++ b/GoogleMapsApi/GoogleMapsApi.csproj
@@ -49,6 +49,6 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net481' OR '$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Text.Json" Version="4.6.0" />  
+    <PackageReference Include="System.Text.Json" Version="5.0.0" />  
   </ItemGroup>
 </Project>

--- a/GoogleMapsApi/GoogleMapsApi.csproj
+++ b/GoogleMapsApi/GoogleMapsApi.csproj
@@ -33,11 +33,22 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net481' OR '$(TargetFramework)' == 'net462'">
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+  	<PackageReference Include="System.Text.Json" Version="8.0.5" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+  	<PackageReference Include="System.Text.Json" Version="6.0.10" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net481' OR '$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Text.Json" Version="4.6.0" />  
   </ItemGroup>
 </Project>


### PR DESCRIPTION
I would like to propose updating the referenced version of System.Text.Json to be dependent on the target framework. Currently this library references System.Text.Json v8.0.5 for all target frameworks, which would force any consuming application to use v8.0.5 or higher as well. It is not always feasible for consumer applications to upgrade package versions for these kinds of core libraries that are used by many other things. Referencing the minimum viable version for each target framework will allow consuming applications more flexibility in which versions of System.Text.Json are currently in use.