### PR TITLE
test: stabilize integration tests against Google API drift

### DIFF
--- a/GoogleMapsApi.Test/IntegrationTests/DistanceMatrixTests.cs
+++ b/GoogleMapsApi.Test/IntegrationTests/DistanceMatrixTests.cs
@@ -193,9 +193,11 @@
                 Destinations = new[] { "3,4" },
             };
 
-            static Uri onUriCreated(Uri uri)
+            Uri? rewrittenUri = null;
+            Uri onUriCreated(Uri uri)
             {
-                return new Uri(uri.ToString().Replace("placeholder", "1,2"));
+                rewrittenUri = new Uri(uri.ToString().Replace("placeholder", "1,2"));
+                return rewrittenUri;
             }
 
             GoogleMaps.DistanceMatrix.OnUriCreated += onUriCreated;
@@ -205,8 +207,9 @@
                 var result = await GoogleMaps.DistanceMatrix.QueryAsync(request);
 
                 AssertInconclusive.NotExceedQuota(result);
+                Assert.That(rewrittenUri, Is.Not.Null, "OnUriCreated was not invoked");
+                Assert.That(rewrittenUri.ToString(), Does.Not.Contain("placeholder"));
                 Assert.That(result.Status, Is.EqualTo(DistanceMatrixStatusCodes.OK), result.ErrorMessage);
-                Assert.That(result.OriginAddresses.First(), Is.EqualTo("1,2"));
             }
             finally
             {

--- a/GoogleMapsApi.Test/IntegrationTests/PlaceAutocompleteTests.cs
+++ b/GoogleMapsApi.Test/IntegrationTests/PlaceAutocompleteTests.cs
@@ -84,7 +84,6 @@ namespace GoogleMapsApi.Test.IntegrationTests
 
 
         [TestCase("oakfield road, chea", "CHEADLE")]
-        [TestCase("128 abbey r", "MACCLESFIELD")]
         public async Task CheckForExpectedRoad( string aSearch, string anExpected)
         {
             var request = new PlaceAutocompleteRequest


### PR DESCRIPTION
## Summary
Two integration tests have been failing on master since at least 2025-09 due to changes in Google's API responses, not in this library. They were blocking merges (and would block Renovate auto-merge once #194 is merged).

### `DistanceMatrixTests.ShouldReplaceUriViaOnUriCreated`
The test verifies that the `OnUriCreated` event hook can rewrite the outgoing URL. It was asserting `result.OriginAddresses.First() == "1,2"`, but Google now normalizes that to `"1.0000000,2.0000000"`. Reworked to capture the rewritten URI in the callback and assert it no longer contains the `"placeholder"` token — directly tests the hook, independent of Google's response formatting.

### `PlaceAutocompleteTests.CheckForExpectedRoad`
Removed the `("128 abbey r", "MACCLESFIELD")` case. Google's autocomplete no longer returns Macclesfield for that query. The other case (`oakfield road, chea` → CHEADLE) is retained and still passes.

## Test plan
- [ ] CI `build` job passes on this PR
- [ ] Confirm `DistanceMatrixTests.ShouldReplaceUriViaOnUriCreated` now passes
- [ ] Confirm `PlaceAutocompleteTests.CheckForExpectedRoad("oakfield road, chea","CHEADLE")` still passes