### PR TITLE
ci: check out PR head and gate pull_request_target to same-repo PRs

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -7,11 +7,15 @@ on:
 
 jobs:
   build:
-
+    if: >
+      github.event_name == 'push' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha || github.sha }}
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:


### PR DESCRIPTION
## Summary
The `.NET` workflow is currently testing the **wrong code** on every PR. `pull_request_target` (introduced in #189) runs in the base-branch context, and `actions/checkout@v4` without an explicit `ref` defaults to checking out the base branch (master). So every PR's `build` job has been running master's tests, not the PR's tests.

This is why fixes pushed to PRs (e.g. #199) appear to have no effect on CI — the workflow never sees them.

## Changes
- **`ref: \${{ github.event.pull_request.head.sha || github.sha }}`** — checkout the PR's actual code (falls back to `github.sha` for `push` events on master).
- **`if:` gate** — only run when the event is a push to master or a PR from this same repository. PRs from forks are skipped.

The `if:` gate is important because `pull_request_target` + checkout-of-PR-head + secrets is the classic [GitHub credential-exfiltration anti-pattern](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/). Without the gate, any fork could open a PR whose code runs with access to \`GOOGLE_API_KEY\`. With the gate, only branches in this repo (maintainer branches, Renovate, Dependabot) get CI with secrets.

## Tradeoff
External-fork PRs will no longer run CI under this workflow. This partially reverts #189's intent (giving forks integration-test coverage). The principled long-term fix is to **split unit vs integration tests** — unit tests run on `pull_request` for everyone (no secrets needed), integration tests run on `pull_request_target` gated to same-repo or a \`safe-to-test\` label. That refactor is intentionally left as a follow-up.

## Test plan
- [ ] After merge, re-run CI on PR #199 — the `build` job should now actually exercise the test fixes and pass (modulo the still-disabled Time Zone API).
- [ ] Confirm a fork PR's `build` job is skipped (no leaked secrets).