### PR TITLE
feat: generate release notes with claude -p and post as GitHub Release

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -8,11 +8,12 @@ NC='\033[0m' # No Color
 
 # Function to display usage
 usage() {
-    echo "Usage: $0 [patch|minor|major] [--dry-run]"
+    echo "Usage: $0 [patch|minor|major] [--dry-run] [--no-notes]"
     echo "  patch: Increment patch version (x.y.z -> x.y.z+1)"
     echo "  minor: Increment minor version (x.y.z -> x.y+1.0)"
     echo "  major: Increment major version (x.y.z -> x+1.0.0)"
     echo "  --dry-run: Show what would be done without making changes"
+    echo "  --no-notes: Skip release notes generation and GitHub Release creation"
     echo "  If no argument provided, defaults to patch"
     exit 1
 }
@@ -46,12 +47,16 @@ increment_version() {
 
 # Parse command line arguments
 DRY_RUN=false
+NO_NOTES=false
 INCREMENT_TYPE="patch"
 
 for arg in "$@"; do
     case $arg in
         --dry-run)
             DRY_RUN=true
+            ;;
+        --no-notes)
+            NO_NOTES=true
             ;;
         patch|minor|major)
             INCREMENT_TYPE="$arg"
@@ -62,6 +67,18 @@ for arg in "$@"; do
             ;;
     esac
 done
+
+# Verify required tools when generating notes
+if [ "$NO_NOTES" = false ]; then
+    MISSING_TOOLS=()
+    command -v claude >/dev/null 2>&1 || MISSING_TOOLS+=("claude")
+    command -v gh >/dev/null 2>&1 || MISSING_TOOLS+=("gh")
+    if [ ${#MISSING_TOOLS[@]} -gt 0 ]; then
+        echo -e "${RED}Error: missing required tools: ${MISSING_TOOLS[*]}${NC}"
+        echo -e "${YELLOW}Re-run with --no-notes to skip release notes generation.${NC}"
+        exit 1
+    fi
+fi
 
 if [ "$DRY_RUN" = true ]; then
     echo -e "${YELLOW}🚀 Starting release process (DRY RUN)...${NC}"
@@ -101,14 +118,69 @@ NEW_TAG="v${NEW_VERSION}"
 echo -e "${YELLOW}New version: ${NEW_VERSION}${NC}"
 echo -e "${YELLOW}New tag: ${NEW_TAG}${NC}"
 
+# Generate release notes
+NOTES_FILE=""
+if [ "$NO_NOTES" = false ]; then
+    NOTES_FILE=$(mktemp -t release-notes-XXXXXX.md)
+    trap 'rm -f "$NOTES_FILE"' EXIT
+
+    echo -e "${YELLOW}✍️  Generating release notes for ${LATEST_TAG}..HEAD with claude -p...${NC}"
+
+    COMMIT_LOG=$(git log --pretty=format:"- %s" "${LATEST_TAG}..HEAD")
+    if [[ -z "$COMMIT_LOG" ]]; then
+        echo -e "${RED}Error: no commits between ${LATEST_TAG} and HEAD${NC}"
+        exit 1
+    fi
+
+    PROMPT="Generate concise release notes in GitHub-flavored markdown for version ${NEW_VERSION} of a .NET library (Google Maps API wrapper).
+
+Group commits under these H2 sections, omitting any section with no entries:
+## Features
+## Bug fixes
+## Dependencies
+## Other
+
+Rules:
+- Use short, user-facing bullets. Strip conventional-commit prefixes (feat:, fix:, chore:, etc.).
+- Do not include commit hashes, PR numbers, or a title heading.
+- If a commit is purely internal (CI, formatting), put it under Other or omit.
+
+Commits:
+${COMMIT_LOG}"
+
+    if ! claude -p "$PROMPT" > "$NOTES_FILE"; then
+        echo -e "${RED}❌ claude -p failed to generate release notes${NC}"
+        exit 1
+    fi
+
+    if [ "$DRY_RUN" = false ]; then
+        echo -e "${YELLOW}📝 Opening notes in ${EDITOR:-vi} for review (save & exit to continue, exit with empty file to abort)...${NC}"
+        "${EDITOR:-vi}" "$NOTES_FILE"
+        if [ ! -s "$NOTES_FILE" ]; then
+            echo -e "${RED}Release cancelled (empty notes)${NC}"
+            exit 0
+        fi
+    fi
+fi
+
 if [ "$DRY_RUN" = true ]; then
     echo -e "${GREEN}🔍 DRY RUN SUMMARY:${NC}"
     echo -e "${GREEN}  - Current version: ${CURRENT_VERSION}${NC}"
     echo -e "${GREEN}  - New version: ${NEW_VERSION}${NC}"
     echo -e "${GREEN}  - Tag to create: ${NEW_TAG}${NC}"
     echo -e "${GREEN}  - Commands that would run:${NC}"
-    echo -e "${GREEN}    git tag ${NEW_TAG}${NC}"
+    if [ "$NO_NOTES" = false ]; then
+        echo -e "${GREEN}    git tag -a ${NEW_TAG} -F <notes>${NC}"
+    else
+        echo -e "${GREEN}    git tag ${NEW_TAG}${NC}"
+    fi
     echo -e "${GREEN}    git push origin ${NEW_TAG}${NC}"
+    if [ "$NO_NOTES" = false ]; then
+        echo -e "${GREEN}    gh release create ${NEW_TAG} -F <notes> --title ${NEW_TAG}${NC}"
+        echo -e "${YELLOW}--- Generated release notes preview ---${NC}"
+        cat "$NOTES_FILE"
+        echo -e "${YELLOW}--- end preview ---${NC}"
+    fi
     echo -e "${YELLOW}📦 This would trigger GitHub Actions to build and publish to NuGet${NC}"
     echo -e "${YELLOW}📋 Monitor progress at: https://github.com/maximn/google-maps/actions${NC}"
     exit 0
@@ -124,8 +196,14 @@ fi
 
 echo -e "${YELLOW}📝 Creating and pushing tag...${NC}"
 
-# Create and push the tag
-if git tag "$NEW_TAG"; then
+# Create and push the tag (annotated when we have notes, so workflow/git can inspect them later)
+if [ "$NO_NOTES" = false ]; then
+    TAG_OK=$(git tag -a "$NEW_TAG" -F "$NOTES_FILE" && echo ok || echo fail)
+else
+    TAG_OK=$(git tag "$NEW_TAG" && echo ok || echo fail)
+fi
+
+if [ "$TAG_OK" = "ok" ]; then
     echo -e "${GREEN}✅ Tag $NEW_TAG created successfully${NC}"
 else
     echo -e "${RED}❌ Failed to create tag $NEW_TAG${NC}"
@@ -137,6 +215,18 @@ if git push origin "$NEW_TAG"; then
 else
     echo -e "${RED}❌ Failed to push tag $NEW_TAG${NC}"
     exit 1
+fi
+
+# Create GitHub Release
+if [ "$NO_NOTES" = false ]; then
+    echo -e "${YELLOW}🚀 Creating GitHub Release...${NC}"
+    if gh release create "$NEW_TAG" --title "$NEW_TAG" --notes-file "$NOTES_FILE"; then
+        echo -e "${GREEN}✅ GitHub Release $NEW_TAG created${NC}"
+    else
+        echo -e "${RED}⚠️  Failed to create GitHub Release (tag is already pushed). Create manually with:${NC}"
+        echo -e "${YELLOW}    gh release create $NEW_TAG --title $NEW_TAG --notes-file $NOTES_FILE${NC}"
+        exit 1
+    fi
 fi
 
 echo -e "${GREEN}🎉 Release process completed!${NC}"


### PR DESCRIPTION
## Summary

Extends `release.sh` to generate release notes via `claude -p` from commits since the last tag, let the author review/edit them, create an annotated git tag with those notes as the body, and publish a GitHub Release — all in one local flow.

## Changes

- Generate notes from `git log` using `claude -p` with a structured prompt (groups into Features / Bug fixes / Dependencies / Other)
- Open notes in `$EDITOR` for human review before committing to anything
- Create an annotated tag (`git tag -a -F`) so the notes travel with the tag in git history
- Publish a GitHub Release via `gh release create --notes-file`
- Add `--no-notes` flag to bypass the whole flow for emergency releases
- Fail fast with a clear message if `claude` or `gh` are not on PATH
- Fix missing trailing newline at EOF

## Test plan

- [ ] `./release.sh patch --dry-run` — verify it calls `claude -p`, prints generated notes preview, and exits without touching git
- [ ] `./release.sh patch --no-notes --dry-run` — verify it skips note generation entirely
- [ ] Uninstall `gh` temporarily; verify the missing-tool error message fires
- [ ] Full run on a branch with commits ahead of the latest tag
