### PR TITLE
chore: drop net6.0 from test project

### DIFF
--- a/GoogleMapsApi.Test/GoogleMapsApi.Test.csproj
+++ b/GoogleMapsApi.Test/GoogleMapsApi.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-	<TargetFrameworks>net8.0;net6.0;net481</TargetFrameworks>
+	<TargetFrameworks>net8.0;net481</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <OutputType>Library</OutputType>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
## Summary

- Removes `net6.0` from `GoogleMapsApi.Test.csproj` target frameworks.
- .NET 6 reached end-of-support on 2024-11-12; `Microsoft.NET.Test.Sdk` 17.14.x now errors out on net6.0 targets ([release notes](https://github.com/microsoft/vstest/releases/tag/v17.14.0)), which is why renovate PR #203 fails.
- Library (`GoogleMapsApi.csproj`) still targets `net6.0` for downstream consumers — only the test project changes here.
- Unblocks #203 (Microsoft.NET.Test.Sdk 17.11.1 → 17.14.1).

A follow-up PR will add `net10.0` (current LTS) to library, tests, and CI.

## Test plan

- [ ] CI build job passes on this PR
- [ ] After merge, retry/rebase #203 and confirm it goes green