### PR TITLE
chore: add net10.0 target framework

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -25,11 +25,16 @@ jobs:
         dotnet-version: |
           6.0.x
           8.0.x
+          10.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build
       run: dotnet build --no-restore
-    - name: Test
+    - name: Test (net8.0)
       run: dotnet test --no-build --verbosity normal --framework net8.0
+      env:
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+    - name: Test (net10.0)
+      run: dotnet test --no-build --verbosity normal --framework net10.0
       env:
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}

--- a/GoogleMapsApi.Test/GoogleMapsApi.Test.csproj
+++ b/GoogleMapsApi.Test/GoogleMapsApi.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-	<TargetFrameworks>net8.0;net481</TargetFrameworks>
+	<TargetFrameworks>net8.0;net10.0;net481</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <OutputType>Library</OutputType>
     <IsPackable>false</IsPackable>

--- a/GoogleMapsApi/GoogleMapsApi.csproj
+++ b/GoogleMapsApi/GoogleMapsApi.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-	<TargetFrameworks>netstandard2.0;net6.0;net8.0;net481;net462</TargetFrameworks>
+	<TargetFrameworks>netstandard2.0;net6.0;net8.0;net10.0;net481;net462</TargetFrameworks>
 	<LangVersion>latest</LangVersion>
 	<Version>0.0.0</Version>
 	<AppxAutoIncrementPackageRevision>True</AppxAutoIncrementPackageRevision>


### PR DESCRIPTION
## Summary

- Adds `net10.0` (current LTS, supported until Nov 2028) as a target on the library and the test project.
- CI now installs the .NET 10 SDK and runs the test suite on **both** `net8.0` and `net10.0`.

## Why now

.NET 10 went LTS in Nov 2025 and the repo already uses the .NET 10 SDK for builds (see the recent renovate "update dotnet monorepo to v10" bump). The library wasn't actually exposing a `net10.0` assembly — consumers on .NET 10 were falling back to `net8.0` / `netstandard2.0`. Adding the explicit TFM gives them a properly-targeted build.

## Scope (what is and isn't changed)

- Library `<TargetFrameworks>`: **adds** `net10.0`. Keeps `netstandard2.0`, `net6.0`, `net8.0`, `net481`, `net462` to avoid a breaking change for existing consumers.
- Test project `<TargetFrameworks>`: **adds** `net10.0` next to `net8.0` and `net481`.
- CI: adds `10.0.x` to `setup-dotnet` and splits the test step into `net8.0` and `net10.0` runs.

> Note: This PR is currently stacked on top of #215 (drop net6.0 from tests). Once #215 merges, the diff will narrow to just the net10 additions.

## Follow-ups worth considering (out of scope for this PR)

- Drop `net6.0` from the **library** target frameworks. .NET 6 has been EOL since 2024-11-12. This is a breaking change for consumers explicitly targeting net6 and warrants a major version bump.

## Test plan

- [ ] CI builds all five library TFMs (`netstandard2.0`, `net6.0`, `net8.0`, `net10.0`, `net481`, `net462`)
- [ ] CI runs the test suite on both `net8.0` and `net10.0`
- [ ] Resulting NuGet package contains a `lib/net10.0/` folder