### PR TITLE
test: reproduce AOT/trim failure for #195 (do not merge)

### DIFF
--- a/GoogleMapsApi/GoogleMapsApi.csproj
+++ b/GoogleMapsApi/GoogleMapsApi.csproj
@@ -27,6 +27,18 @@
 	<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
 
+  <!--
+    Repro for issue #195: AOT/trim incompatibility.
+    Enabling the AOT/trim analyzers and promoting IL2026/IL3050 to errors will fail
+    the build on every reflection-based JsonSerializer call site and on the enum
+    JsonConverterFactory. Once a source-generated JsonSerializerContext replaces
+    them, this build should go green with no further changes here.
+  -->
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <IsAotCompatible>true</IsAotCompatible>
+    <WarningsAsErrors>IL2026;IL2104;IL3050;IL3053</WarningsAsErrors>
+  </PropertyGroup>
+
   <ItemGroup>
     <None Include="..\README.md" Pack="true" PackagePath="\" />
     <None Include="..\LICENSE.md" Pack="true" PackagePath="\" />


### PR DESCRIPTION
**Repro for #195 — intentionally failing. Do not merge.**

Enables `IsAotCompatible` on `net8.0` and promotes `IL2026`, `IL2104`, `IL3050`, `IL3053` to errors in `GoogleMapsApi/GoogleMapsApi.csproj`. No source changes.

## Today's failures (5 errors)

- `Engine/MapsAPIGenericEngine.cs:39` — `JsonSerializer.Deserialize<T>(string, JsonSerializerOptions)` (IL2026 + IL3050)
- `Engine/JsonConverters/EnumMemberJsonConverter.cs:75` — `Enum.GetValues(Type)` (IL3050)
- `Engine/JsonConverters/EnumMemberJsonConverter.cs:95` — `Enum.GetValues(Type)` (IL3050)
- `Engine/JsonConverters/EnumMemberJsonConverter.cs:123` — `Type.MakeGenericType(...)` in `EnumMemberJsonConverterFactory` (IL3050)

These are the exact call sites a source-generated `JsonSerializerContext` + per-enum converters need to replace.

## Acceptance criterion for the AOT fix PR

`dotnet build GoogleMapsApi/GoogleMapsApi.csproj -f net8.0 -c Release` is green with this csproj change in place.

## Why not for merge

Merging would break `master` for everyone on `net8.0` until the fix lands. Two paths forward:
1. Cherry-pick the csproj diff into the fix PR so both arrive together.
2. Keep this branch around as a living repro; close once the fix is merged.

## Out of scope
- The actual `JsonSerializerContext` source-gen change.
- `net10.0` (not on `master` yet); add the same condition for it in the fix PR if relevant.
- A runtime AOT smoke test (`PublishAot` console app) — possible follow-up.