### PR TITLE
ci: add TestGlance for PR test summaries

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   build:
@@ -31,10 +32,15 @@ jobs:
     - name: Build
       run: dotnet build --no-restore
     - name: Test (net8.0)
-      run: dotnet test --no-build --verbosity normal --framework net8.0
+      run: dotnet test --no-build --verbosity normal --framework net8.0 --logger "junit;LogFilePath=test-results/{assembly}.net8.0.xml"
       env:
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
     - name: Test (net10.0)
-      run: dotnet test --no-build --verbosity normal --framework net10.0
+      run: dotnet test --no-build --verbosity normal --framework net10.0 --logger "junit;LogFilePath=test-results/{assembly}.net10.0.xml"
       env:
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+    - name: TestGlance
+      if: always()
+      uses: testglance/action@v1
+      with:
+        github-token: ${{ github.token }}

--- a/GoogleMapsApi.Test/GoogleMapsApi.Test.csproj
+++ b/GoogleMapsApi.Test/GoogleMapsApi.Test.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 	
   <ItemGroup>
+    <PackageReference Include="JunitXml.TestLogger" Version="*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="NUnit" Version="4.6.1" />


### PR DESCRIPTION
## Summary
- Adds `JunitXml.TestLogger` to `GoogleMapsApi.Test` so tests emit JUnit XML to `test-results/`.
- Updates the .NET workflow to invoke `testglance/action@v1` after both `net8.0` and `net10.0` test runs, producing a PR test summary with flake detection and slowest-tests breakdown.
- Grants `pull-requests: write` so the action can post its summary comment.

## Notes
- The framework name is encoded in each log path (`{assembly}.net8.0.xml` / `{assembly}.net10.0.xml`) to keep the two test runs from overwriting each other in `test-results/`.
- `JunitXml.TestLogger` is referenced with `Version="*"` per the TestGlance install guide; happy to pin if you'd prefer to match the rest of the csproj.
- TestGlance runs locally in the runner — no signup, API key, or outbound calls.

## Test plan
- [ ] CI workflow completes on this PR
- [ ] TestGlance comment is posted on the PR with results from both target frameworks
- [ ] Workflow still runs and reports correctly when a test fails (action uses `if: always()`)