### PR TITLE
📝 docs: modernize README header, badges, and elevator pitch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,28 @@
+[![NuGet Downloads](https://img.shields.io/nuget/dt/GoogleMapsApi.svg)](https://www.nuget.org/packages/GoogleMapsApi/)
+[![NuGet Version](https://img.shields.io/nuget/v/GoogleMapsApi.svg)](https://www.nuget.org/packages/GoogleMapsApi/)
 [![Build Status](https://github.com/maximn/google-maps/actions/workflows/dotnet.yml/badge.svg)](https://github.com/maximn/google-maps/actions/workflows/dotnet.yml)
-[![NuGet Status](https://img.shields.io/nuget/v/GoogleMapsApi.svg)](https://www.nuget.org/packages/GoogleMapsApi/)
+[![License: BSD-2-Clause](https://img.shields.io/badge/License-BSD_2--Clause-blue.svg)](LICENSE.md)
+[![.NET](https://img.shields.io/badge/.NET-net10.0%20%7C%20net8.0%20%7C%20netstandard2.0%20%7C%20net481%20%7C%20net462-512BD4)](https://dotnet.microsoft.com/)
 
-google-maps
-===========
+# GoogleMapsApi
 
-Google Maps Web Services API wrapper for .NET
+A friendly, strongly-typed .NET wrapper for the Google Maps Web Services APIs — Geocoding, Directions, Distance Matrix, Elevation, Time Zone, Places, and Static Maps. Multi-framework (net10.0, net8.0, netstandard2.0, net481, net462), async-first, and battle-tested with **2M+ downloads** on NuGet.
 
-For Quickstart and more info read the wiki pages (https://github.com/maximn/google-maps/wiki)
+## Supported APIs
 
-The web page - http://maximn.github.com/google-maps
+| API | Description |
+| --- | --- |
+| Geocoding | Convert between addresses and geographic coordinates |
+| Directions | Route planning between two points with multiple travel modes |
+| Distance Matrix | Travel time and distance between multiple origins/destinations |
+| Elevation | Elevation data for individual locations or paths |
+| Time Zone | Time zone information for any coordinate |
+| Places | Find / Nearby / Text search, Place Details, Autocomplete |
+| Static Maps | Generate URLs for static map images with markers, paths, and styles |
 
-NuGet page - https://www.nuget.org/packages/GoogleMapsApi/
+## Why this vs Google's official SDKs
 
-
-**Check out my blog at http://maxondev.com**
+Google's official .NET packages (e.g. `Google.Maps.Routing.V2`, `Google.Maps.Places.V1`) are auto-generated from gRPC service definitions — they're verbose, split across many packages, and feel like protobuf instead of .NET. **GoogleMapsApi** is a single, idiomatic NuGet package: one install, async-first, multi-target (modern .NET through legacy .NET Framework), with hand-crafted request/response types that read like normal C#.
 
 # Installation
 
@@ -28,14 +37,6 @@ dotnet add package GoogleMapsApi
 ```
 
 # Quickstart
-
-This library wraps Google maps API.
-
-You can easily query Google maps for Geocoding, Directions, Elevation, Distance Matrix, and Places.
-
-NEW! Now you can easily show the results on a Static Google Map!
-
-This Library is well documented and easy to use.
 
 ## API Key Configuration
 
@@ -53,9 +54,12 @@ DirectionsRequest directionsRequest = new DirectionsRequest()
 // Option 2: Set globally via app.config/appsettings.json (see wiki for details)
 ```
 
+For more configuration options and detailed guides, see the [wiki](https://github.com/maximn/google-maps/wiki).
+
 ## Code Examples
 
-### Basic Usage
+### Basic Usage (async-first)
+
 ``` C#
 using GoogleMapsApi;
 using GoogleMapsApi.Entities.Common;
@@ -72,10 +76,6 @@ DirectionsRequest directionsRequest = new DirectionsRequest()
     Origin = "NYC, 5th and 39",
     Destination = "Philadelphia, Chestnut and Walnut",
 };
-
-// Synchronous call
-DirectionsResponse directions = GoogleMaps.Directions.Query(directionsRequest);
-Console.WriteLine(directions);
 
 // Async call (recommended)
 DirectionsResponse directions = await GoogleMaps.Directions.QueryAsync(directionsRequest);
@@ -113,3 +113,16 @@ string url = staticMapGenerator.GenerateStaticMapURL(new StaticMapRequest(new Lo
 });
 Console.WriteLine("Map with path: " + url);
 ```
+
+### Synchronous Usage
+
+Synchronous calls are also supported via `Query` (use `QueryAsync` whenever possible):
+
+``` C#
+DirectionsResponse directions = GoogleMaps.Directions.Query(directionsRequest);
+Console.WriteLine(directions);
+```
+
+---
+
+*If this library saved you time, please ⭐ the repo — it helps others find it.*


### PR DESCRIPTION
## Summary

P0 from the improvement plan: close the visibility gap by making the README reflect that this is a 2M-download library.

## Changes

- **Badges reordered + new downloads badge.** Order is now: downloads → version → build → license → .NET targets. Downloads (the strongest social proof) is now first.
- **README opening rewritten.** Replaced the 1-line `google-maps ===` intro with:
  - A `# GoogleMapsApi` title
  - A one-paragraph elevator pitch (multi-framework, async-first, 2M+ downloads)
  - A **Supported APIs** table
  - A **Why this vs Google's official SDKs** blurb
- **Quickstart reordered async-first.** Async is the recommended path; the sync example is now in a small `Synchronous Usage` subsection below.
- **Dead content removed.** Dropped the `maxondev.com` blog link, the redundant web-page / NuGet links, and the dated "NEW!" / "well documented and easy to use" puff lines.
- **Star CTA appended** at the bottom under a horizontal rule.

## Test plan

- [x] README renders correctly on GitHub (preview)
- [x] All badge URLs return 200
- [x] No source code touched