### PR TITLE
✨ chore: add CONTRIBUTING, CoC, and GitHub issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,49 @@
+name: Bug report
+description: Report a bug in GoogleMapsApi
+labels: ["bug"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: A short description of the bug.
+    validations: {required: true}
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction
+      description: Minimal code or steps to reproduce.
+      render: csharp
+    validations: {required: true}
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+    validations: {required: true}
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behaviour
+    validations: {required: true}
+  - type: input
+    id: version
+    attributes:
+      label: GoogleMapsApi version
+      placeholder: "1.4.7"
+    validations: {required: true}
+  - type: input
+    id: tfm
+    attributes:
+      label: .NET target framework
+      placeholder: "net8.0"
+    validations: {required: true}
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+    validations: {required: false}
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional context
+    validations: {required: false}

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Q&A / Discussions
+    url: https://github.com/maximn/google-maps/discussions
+    about: Ask a question or share an idea.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,26 @@
+name: Feature request
+description: Propose a new API surface or enhancement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: What would you like?
+    validations: {required: true}
+  - type: textarea
+    id: why
+    attributes:
+      label: Why / use case
+    validations: {required: true}
+  - type: textarea
+    id: api
+    attributes:
+      label: Proposed API shape
+      description: Optional. Example signatures or pseudo-code.
+      render: csharp
+    validations: {required: false}
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations: {required: false}

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+<!-- Thanks for contributing! Please fill in the sections below. -->
+
+## Summary
+
+<!-- One or two sentences describing what this PR does and why. -->
+
+## Related issue
+
+<!-- e.g. Fixes #123, Closes #456, or "n/a" if this is a small standalone change. -->
+
+## Changes
+
+<!-- Bullet list of the notable changes in this PR. -->
+-
+-
+
+## Test plan
+
+<!-- How did you verify this works? Which tests did you add or run? -->
+-
+
+## Checklist
+
+- [ ] `dotnet format` has been run.
+- [ ] `dotnet test` passes locally (with a valid `GOOGLE_API_KEY` for integration tests).
+- [ ] Multi-framework build passes (net8.0, net6.0, netstandard2.0, net481, net462).
+- [ ] XML documentation updated if public API surface changed.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,8 @@
+# Code of Conduct
+
+This project follows the Contributor Covenant v2.1.
+Full text: https://www.contributor-covenant.org/version/2/1/code_of_conduct/
+
+By participating, you agree to uphold these standards. To report unacceptable
+behaviour, open an issue at https://github.com/maximn/google-maps/issues
+(or contact a maintainer privately if the issue is sensitive).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,63 @@
+# Contributing to GoogleMapsApi
+
+Thanks for your interest in improving the library. This project is a community-maintained
+.NET wrapper for Google Maps Web Services APIs, run by a single maintainer with help from
+contributors like you. Issues and pull requests are reviewed as time allows, so please be
+patient and constructive.
+
+## Filing a bug
+
+If something does not work the way you expect, please open a bug report using the
+[bug issue template](.github/ISSUE_TEMPLATE/bug.yml). A minimal repro (a few lines of C#
+that reproduce the failure) is the single most useful thing you can include.
+
+## Proposing a feature
+
+For new APIs, parameters, or behaviour changes, open a feature request using the
+[feature issue template](.github/ISSUE_TEMPLATE/feature.yml). Describe the use case first
+and the proposed API shape second. For open-ended questions or design discussions, use
+[GitHub Discussions](https://github.com/maximn/google-maps/discussions) instead of an issue.
+
+## Local development quick start
+
+The library targets net8.0, net6.0, netstandard2.0, net481, and net462. You need a recent
+.NET SDK installed.
+
+```bash
+dotnet restore
+dotnet build
+dotnet test
+```
+
+The integration tests hit the live Google Maps APIs and require an API key. Provide it
+via the `GOOGLE_API_KEY` environment variable, or copy
+`GoogleMapsApi.Test/appsettings.template.json` to `appsettings.json` and fill in the value.
+Note that running the test suite consumes your Google API quota.
+
+## Style
+
+Run `dotnet format` before pushing. It applies the repo's .editorconfig rules and keeps
+diffs focused on real changes.
+
+Prefer self-documenting code over comments. Comments should explain *why* something
+non-obvious is being done, not *what* the code is doing.
+
+## Pull request checklist
+
+Before opening a PR, please confirm:
+
+- [ ] `dotnet format` has been run.
+- [ ] `dotnet build` succeeds across all target frameworks.
+- [ ] `dotnet test` passes locally (with a valid `GOOGLE_API_KEY`).
+- [ ] New public API surface has XML documentation comments.
+- [ ] If you fixed a bug, a regression test covers it.
+- [ ] The PR description links the related issue and explains the change.
+
+Smaller, focused PRs land faster than large ones. If you are planning a substantial
+change, open an issue or discussion first so we can agree on the approach.
+
+## Translations welcome
+
+If you would like to translate the README into another language, please open a PR adding
+`README.<lang>.md` at the repo root and link it from the main README. Translations are a
+great first contribution.


### PR DESCRIPTION
## Summary

P0 from the improvement plan: ship the standard OSS community files. Reduces low-quality issues, raises perceived maturity, gives contributors a clear on-ramp.

## Changes

- **`CONTRIBUTING.md`** — welcome, bug/feature filing pointers, local dev quick start (`dotnet restore` / `build` / `test`, `GOOGLE_API_KEY` env var note), `dotnet format` style guide, PR checklist, translations note
- **`CODE_OF_CONDUCT.md`** — references Contributor Covenant v2.1 by URL; report channel = GitHub issues / maintainer
- **`.github/ISSUE_TEMPLATE/bug.yml`** — structured form (summary, repro, expected/actual, version, TFM, OS, extra)
- **`.github/ISSUE_TEMPLATE/feature.yml`** — what / why / proposed API / alternatives
- **`.github/ISSUE_TEMPLATE/config.yml`** — disables blank issues, links to Discussions
- **`.github/PULL_REQUEST_TEMPLATE.md`** — summary, related issue, changes, test plan, checklist

No existing files modified.

## Test plan

- [x] Open a new issue on the PR's branch — both forms render correctly
- [x] Open a new PR — template body pre-filled
- [x] All linked URLs resolve