### PR TITLE
📝 docs: fix CLAUDE.md drift — System.Text.Json + net10.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ This is a comprehensive .NET wrapper library for Google Maps Web Services APIs, 
 ### Core Components
 - **GoogleMaps.cs**: Static entry point providing access to all API services via facade pattern
 - **EngineFacade<TRequest, TResponse>**: Generic facade implementing async/sync query operations with timeout and cancellation support
-- **MapsAPIGenericEngine<TRequest, TResponse>**: Core HTTP client engine using Newtonsoft.Json for serialization
+- **MapsAPIGenericEngine<TRequest, TResponse>**: Core HTTP client engine using System.Text.Json for serialization
 - **Static Maps**: Separate engine for generating Google Static Maps URLs with marker, path, and styling support
 
 ### Request/Response Pattern
@@ -36,7 +36,7 @@ All API operations follow a consistent pattern:
 # Restore dependencies
 dotnet restore
 
-# Build (targets: net8.0, net6.0, netstandard2.0, net481, net462)
+# Build (targets: net10.0, net8.0, net6.0, netstandard2.0, net481, net462)
 dotnet build
 
 # Run tests with API key
@@ -74,8 +74,8 @@ dotnet test --filter "TestMethodName=Should_Get_Directions"
 5. Add integration tests in `GoogleMapsApi.Test/IntegrationTests/`
 
 ### Multi-Framework Compatibility
-- Main library targets: net8.0, net6.0, netstandard2.0, net481, net462
-- Tests target: net8.0, net6.0, net481
+- Main library targets: net10.0, net8.0, net6.0, netstandard2.0, net481, net462
+- Tests target: net10.0, net8.0, net481
 - Use conditional compilation when framework-specific features needed
 
 ### HTTP Client Usage


### PR DESCRIPTION
## Summary

P0 from the improvement plan. `CLAUDE.md` had two pieces of stale info that would mislead future contributors (and AI agents):

1. Said the engine uses **Newtonsoft.Json** — it actually uses **System.Text.Json** (verified in `GoogleMapsApi/Engine/MapsAPIGenericEngine.cs` and `GoogleMapsApi.csproj`)
2. Target framework lists were missing **net10.0** (added in #216), and the tests target list listed `net6.0` which isn't in the test csproj

## Changes

- `MapsAPIGenericEngine` line: "Newtonsoft.Json" → "System.Text.Json"
- `dotnet build` comment: target list updated to `net10.0, net8.0, net6.0, netstandard2.0, net481, net462`
- Main library targets: same update
- Tests target: `net8.0, net6.0, net481` → `net10.0, net8.0, net481` (matches `GoogleMapsApi.Test.csproj` which has `net8.0;net10.0;net481`)

## Test plan

- [x] Diffs verified against actual `.csproj` `<TargetFrameworks>` values
- [x] Grep for `Newtonsoft` in the library shows zero references (only the test project still uses it)