### PR TITLE
🔧 ci: add OpenSSF Scorecard and CodeQL workflows + badges

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,53 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  schedule:
+    - cron: '27 4 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (csharp)
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'csharp' ]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Restore dependencies
+        run: dotnet restore GoogleMapsApi/GoogleMapsApi.csproj
+
+      - name: Build
+        run: dotnet build GoogleMapsApi/GoogleMapsApi.csproj --framework net8.0 --no-restore --configuration Release
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   analyze:
-    name: Analyze (csharp)
+    name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
     timeout-minutes: 360
 
@@ -25,29 +25,35 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'csharp' ]
+        include:
+          - language: csharp
+            build-mode: manual
+          - language: actions
+            build-mode: none
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
 
       - name: Setup .NET
+        if: matrix.build-mode == 'manual'
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 8.0.x
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
-
-      - name: Restore dependencies
-        run: dotnet restore GoogleMapsApi/GoogleMapsApi.csproj
+          build-mode: ${{ matrix.build-mode }}
 
       - name: Build
-        run: dotnet build GoogleMapsApi/GoogleMapsApi.csproj --framework net8.0 --no-restore --configuration Release
+        if: matrix.build-mode == 'manual'
+        run: |
+          dotnet restore GoogleMapsApi/GoogleMapsApi.csproj
+          dotnet build GoogleMapsApi/GoogleMapsApi.csproj --framework net8.0 --no-restore --configuration Release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -41,6 +41,6 @@ jobs:
           retention-days: 5
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,46 @@
+name: Scorecard supply-chain security
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '32 4 * * 1'
+  push:
+    branches: [ master ]
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      actions: read
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@v2
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 [![NuGet Downloads](https://img.shields.io/nuget/dt/GoogleMapsApi.svg)](https://www.nuget.org/packages/GoogleMapsApi/)
 [![NuGet Version](https://img.shields.io/nuget/v/GoogleMapsApi.svg)](https://www.nuget.org/packages/GoogleMapsApi/)
 [![Build Status](https://github.com/maximn/google-maps/actions/workflows/dotnet.yml/badge.svg)](https://github.com/maximn/google-maps/actions/workflows/dotnet.yml)
+[![CodeQL](https://github.com/maximn/google-maps/actions/workflows/codeql.yml/badge.svg)](https://github.com/maximn/google-maps/actions/workflows/codeql.yml)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/maximn/google-maps/badge)](https://scorecard.dev/viewer/?uri=github.com/maximn/google-maps)
 [![License: BSD-2-Clause](https://img.shields.io/badge/License-BSD_2--Clause-blue.svg)](LICENSE.md)
 [![.NET](https://img.shields.io/badge/.NET-net10.0%20%7C%20net8.0%20%7C%20netstandard2.0%20%7C%20net481%20%7C%20net462-512BD4)](https://dotnet.microsoft.com/)
 


### PR DESCRIPTION
## Summary

Adds two industry-standard supply-chain security workflows and surfaces their status in the README badge row.

### `.github/workflows/codeql.yml` — GitHub CodeQL (C#)
- **When:** push to `master`, PRs targeting `master`, weekly schedule (Mondays 04:27 UTC).
- **What:** initializes CodeQL for `csharp`, runs an explicit `dotnet build` against `GoogleMapsApi/GoogleMapsApi.csproj` on `net8.0` (more reliable than `autobuild` for multi-TFM projects), then runs the analysis.
- **Queries:** template default (`security-and-quality`) — not overridden.
- **Permissions:** least-privilege at job level (`security-events: write`, `actions: read`, `contents: read`).
- **Results:** appear under the repo's **Security → Code scanning** tab.

### `.github/workflows/scorecard.yml` — OpenSSF Scorecard
- **When:** weekly schedule (Mondays 04:32 UTC), push to `master`, `branch_protection_rule`, and `workflow_dispatch`.
- **What:** runs Scorecard checks and uploads SARIF to GitHub code scanning + publishes to scorecard.dev.
- **Permissions:** top-level `read-all`; job adds `security-events: write`, `id-token: write`, `actions: read`, `contents: read` (needed for `publish_results: true` OIDC attestation).
- **Results:** Security → Code scanning tab + public score at [scorecard.dev](https://scorecard.dev/viewer/?uri=github.com/maximn/google-maps).

### README
Two new badges slotted into the security-adjacent position (after Build, before License) — CodeQL and OpenSSF Scorecard.

## Action versions pinned
- `actions/checkout@v6`, `actions/setup-dotnet@v5`, `actions/upload-artifact@v7` (matches existing workflows)
- `github/codeql-action/init@v3`, `github/codeql-action/analyze@v3`, `github/codeql-action/upload-sarif@v3`
- `ossf/scorecard-action@v2`

All major-pinned; no floating `@main` references.

## Maintainer action required before workflows are fully useful

1. **Enable GitHub Code Scanning** in repo Settings → Code security and analysis (one-time). Without this, SARIF uploads will fail.
2. **First Scorecard badge may show "no data" for up to ~24h** until the first scheduled run (or manual `workflow_dispatch`) completes and publishes results.
3. Scorecard requires the default branch (`master`) to have at least one workflow run to score `Maintained`/`CII-Best-Practices`/etc.; first run on merge handles this.

## Test plan
- [ ] After merge, confirm CodeQL workflow runs successfully against `master`
- [ ] Trigger Scorecard via `workflow_dispatch` to seed the first score (optional, otherwise waits for weekly cron)
- [ ] Verify badges render correctly in README on GitHub
- [ ] Confirm results appear under Security → Code scanning