### PR TITLE
✨ docs: add sample apps (console, minimal API, Blazor)

### DIFF
--- a/GoogleMapsApi.sln
+++ b/GoogleMapsApi.sln
@@ -17,6 +17,14 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "artifacts", "artifacts", "{
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GoogleMapsApi", "GoogleMapsApi\GoogleMapsApi.csproj", "{61E9FC82-47B0-43C3-8749-95D3A9967060}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{19C7D2B1-FE79-42F7-9F9E-4F403BDA6033}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Console.Geocoding", "samples\Console.Geocoding\Console.Geocoding.csproj", "{17CFAF86-9C0D-4958-823E-2A1C0F90C0CD}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MinimalApi.Directions", "samples\MinimalApi.Directions\MinimalApi.Directions.csproj", "{ACCC7155-3FAC-4B76-B822-26AA5634270F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Blazor.Geocoding", "samples\Blazor.Geocoding\Blazor.Geocoding.csproj", "{9742F184-5CDF-49A8-B43A-1F691F077460}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -50,6 +58,42 @@ Global
 		{61E9FC82-47B0-43C3-8749-95D3A9967060}.Release|Mixed Platforms.Build.0 = Release|Any CPU
 		{61E9FC82-47B0-43C3-8749-95D3A9967060}.Release|x86.ActiveCfg = Release|Any CPU
 		{61E9FC82-47B0-43C3-8749-95D3A9967060}.Release|x86.Build.0 = Release|Any CPU
+		{17CFAF86-9C0D-4958-823E-2A1C0F90C0CD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{17CFAF86-9C0D-4958-823E-2A1C0F90C0CD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{17CFAF86-9C0D-4958-823E-2A1C0F90C0CD}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{17CFAF86-9C0D-4958-823E-2A1C0F90C0CD}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{17CFAF86-9C0D-4958-823E-2A1C0F90C0CD}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{17CFAF86-9C0D-4958-823E-2A1C0F90C0CD}.Debug|x86.Build.0 = Debug|Any CPU
+		{17CFAF86-9C0D-4958-823E-2A1C0F90C0CD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{17CFAF86-9C0D-4958-823E-2A1C0F90C0CD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{17CFAF86-9C0D-4958-823E-2A1C0F90C0CD}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{17CFAF86-9C0D-4958-823E-2A1C0F90C0CD}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{17CFAF86-9C0D-4958-823E-2A1C0F90C0CD}.Release|x86.ActiveCfg = Release|Any CPU
+		{17CFAF86-9C0D-4958-823E-2A1C0F90C0CD}.Release|x86.Build.0 = Release|Any CPU
+		{ACCC7155-3FAC-4B76-B822-26AA5634270F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ACCC7155-3FAC-4B76-B822-26AA5634270F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ACCC7155-3FAC-4B76-B822-26AA5634270F}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{ACCC7155-3FAC-4B76-B822-26AA5634270F}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{ACCC7155-3FAC-4B76-B822-26AA5634270F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{ACCC7155-3FAC-4B76-B822-26AA5634270F}.Debug|x86.Build.0 = Debug|Any CPU
+		{ACCC7155-3FAC-4B76-B822-26AA5634270F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ACCC7155-3FAC-4B76-B822-26AA5634270F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ACCC7155-3FAC-4B76-B822-26AA5634270F}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{ACCC7155-3FAC-4B76-B822-26AA5634270F}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{ACCC7155-3FAC-4B76-B822-26AA5634270F}.Release|x86.ActiveCfg = Release|Any CPU
+		{ACCC7155-3FAC-4B76-B822-26AA5634270F}.Release|x86.Build.0 = Release|Any CPU
+		{9742F184-5CDF-49A8-B43A-1F691F077460}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9742F184-5CDF-49A8-B43A-1F691F077460}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9742F184-5CDF-49A8-B43A-1F691F077460}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{9742F184-5CDF-49A8-B43A-1F691F077460}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{9742F184-5CDF-49A8-B43A-1F691F077460}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9742F184-5CDF-49A8-B43A-1F691F077460}.Debug|x86.Build.0 = Debug|Any CPU
+		{9742F184-5CDF-49A8-B43A-1F691F077460}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9742F184-5CDF-49A8-B43A-1F691F077460}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9742F184-5CDF-49A8-B43A-1F691F077460}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{9742F184-5CDF-49A8-B43A-1F691F077460}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{9742F184-5CDF-49A8-B43A-1F691F077460}.Release|x86.ActiveCfg = Release|Any CPU
+		{9742F184-5CDF-49A8-B43A-1F691F077460}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -57,6 +101,9 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{AD9AD8E9-0E2C-470E-9004-373679F9D954} = {9D09CCCC-6AFA-41EA-BFB3-4698FC5830E6}
 		{61E9FC82-47B0-43C3-8749-95D3A9967060} = {950E065F-B61E-4C05-8C74-5F03946AD7E2}
+		{17CFAF86-9C0D-4958-823E-2A1C0F90C0CD} = {19C7D2B1-FE79-42F7-9F9E-4F403BDA6033}
+		{ACCC7155-3FAC-4B76-B822-26AA5634270F} = {19C7D2B1-FE79-42F7-9F9E-4F403BDA6033}
+		{9742F184-5CDF-49A8-B43A-1F691F077460} = {19C7D2B1-FE79-42F7-9F9E-4F403BDA6033}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {061AA237-7231-49DE-835A-296ED94715C4}

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Or via .NET CLI:
 dotnet add package GoogleMapsApi
 ```
 
+Looking for runnable examples? See [`samples/`](samples/) — console, ASP.NET Core minimal API, and Blazor Server.
+
 # Quickstart
 
 ## API Key Configuration

--- a/samples/Blazor.Geocoding/Blazor.Geocoding.csproj
+++ b/samples/Blazor.Geocoding/Blazor.Geocoding.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>Samples.Blazor.Geocoding</RootNamespace>
+    <AssemblyName>Samples.Blazor.Geocoding</AssemblyName>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\GoogleMapsApi\GoogleMapsApi.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/Blazor.Geocoding/Components/App.razor
+++ b/samples/Blazor.Geocoding/Components/App.razor
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <base href="/" />
+    <title>Blazor.Geocoding sample</title>
+    <HeadOutlet />
+</head>
+<body>
+    <Routes />
+    <script src="_framework/blazor.web.js"></script>
+</body>
+</html>

--- a/samples/Blazor.Geocoding/Components/Pages/Home.razor
+++ b/samples/Blazor.Geocoding/Components/Pages/Home.razor
@@ -1,0 +1,69 @@
+@page "/"
+@using GoogleMapsApi.Entities.Geocoding.Response
+@using Samples.Blazor.Geocoding.Services
+@inject GeocodingService Geocoder
+
+<PageTitle>Geocoding sample</PageTitle>
+
+<h1>Geocoding sample</h1>
+
+@if (!Geocoder.HasApiKey)
+{
+    <p style="color:red">
+        Set the <code>GOOGLE_API_KEY</code> environment variable (or <code>GoogleApiKey</code> in configuration) and restart.
+    </p>
+}
+
+<form @onsubmit="OnSubmitAsync" @onsubmit:preventDefault>
+    <input @bind="address" placeholder="Address" style="width: 24rem" />
+    <button type="submit" disabled="@(_busy || !Geocoder.HasApiKey)">Geocode</button>
+</form>
+
+@if (_busy)
+{
+    <p>Loading...</p>
+}
+else if (_error is not null)
+{
+    <p style="color:red">@_error</p>
+}
+else if (_result is not null)
+{
+    <h2>@_result.FormattedAddress</h2>
+    <p>Lat: @_result.Geometry.Location.Latitude.ToString("F6")</p>
+    <p>Lng: @_result.Geometry.Location.Longitude.ToString("F6")</p>
+}
+
+@code {
+    private string address = "1600 Amphitheatre Parkway, Mountain View, CA";
+    private bool _busy;
+    private string? _error;
+    private Result? _result;
+
+    private async Task OnSubmitAsync()
+    {
+        _busy = true;
+        _error = null;
+        _result = null;
+        try
+        {
+            var response = await Geocoder.GeocodeAsync(address);
+            if (response.Status != Status.OK || response.Results is null)
+            {
+                _error = $"Geocoding failed: {response.Status}";
+            }
+            else
+            {
+                _result = response.Results.FirstOrDefault();
+            }
+        }
+        catch (Exception ex)
+        {
+            _error = ex.Message;
+        }
+        finally
+        {
+            _busy = false;
+        }
+    }
+}

--- a/samples/Blazor.Geocoding/Components/Routes.razor
+++ b/samples/Blazor.Geocoding/Components/Routes.razor
@@ -1,0 +1,5 @@
+<Router AppAssembly="@typeof(Program).Assembly">
+    <Found Context="routeData">
+        <RouteView RouteData="@routeData" />
+    </Found>
+</Router>

--- a/samples/Blazor.Geocoding/Program.cs
+++ b/samples/Blazor.Geocoding/Program.cs
@@ -1,0 +1,31 @@
+using Samples.Blazor.Geocoding.Components;
+using Samples.Blazor.Geocoding.Services;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddRazorComponents()
+    .AddInteractiveServerComponents();
+
+builder.Services.AddSingleton<GeocodingService>(_ =>
+{
+    string? apiKey = Environment.GetEnvironmentVariable("GOOGLE_API_KEY")
+                     ?? builder.Configuration["GoogleApiKey"];
+    return new GeocodingService(apiKey);
+});
+
+var app = builder.Build();
+
+if (!app.Environment.IsDevelopment())
+{
+    app.UseExceptionHandler("/Error", createScopeForErrors: true);
+    app.UseHsts();
+}
+
+app.UseHttpsRedirection();
+app.UseStaticFiles();
+app.UseAntiforgery();
+
+app.MapRazorComponents<App>()
+    .AddInteractiveServerRenderMode();
+
+app.Run();

--- a/samples/Blazor.Geocoding/README.md
+++ b/samples/Blazor.Geocoding/README.md
@@ -1,0 +1,20 @@
+# Blazor.Geocoding
+
+Blazor Server app with a single page: type an address and see the geocoded coordinates. Server-side rendering keeps the Google API key off the client.
+
+## Run
+
+```bash
+GOOGLE_API_KEY=your_api_key dotnet run --project samples/Blazor.Geocoding
+```
+
+Open the URL the host prints (typically `https://localhost:5001`).
+
+The API key is sourced from the `GOOGLE_API_KEY` env var, falling back to the `GoogleApiKey` config value (e.g. via `appsettings.json` or user secrets).
+
+## What this demonstrates
+
+- [`GoogleMaps.Geocode`](../../GoogleMapsApi/GoogleMaps.cs) facade entry point
+- [`GeocodingRequest`](../../GoogleMapsApi/Entities/Geocoding/Request/GeocodingRequest.cs)
+- [`GeocodingResponse`](../../GoogleMapsApi/Entities/Geocoding/Response/GeocodingResponse.cs)
+- Wrapping the library in a DI-injected service consumed by a Blazor Server component

--- a/samples/Blazor.Geocoding/Services/GeocodingService.cs
+++ b/samples/Blazor.Geocoding/Services/GeocodingService.cs
@@ -1,0 +1,25 @@
+using GoogleMapsApi;
+using GoogleMapsApi.Entities.Geocoding.Request;
+using GoogleMapsApi.Entities.Geocoding.Response;
+
+namespace Samples.Blazor.Geocoding.Services;
+
+public sealed class GeocodingService
+{
+    private readonly string? _apiKey;
+
+    public GeocodingService(string? apiKey) => _apiKey = apiKey;
+
+    public bool HasApiKey => !string.IsNullOrWhiteSpace(_apiKey);
+
+    public async Task<GeocodingResponse> GeocodeAsync(string address, CancellationToken ct = default)
+    {
+        var request = new GeocodingRequest
+        {
+            Address = address,
+            ApiKey = _apiKey,
+        };
+
+        return await GoogleMaps.Geocode.QueryAsync(request, ct);
+    }
+}

--- a/samples/Blazor.Geocoding/_Imports.razor
+++ b/samples/Blazor.Geocoding/_Imports.razor
@@ -1,0 +1,9 @@
+@using System.Net.Http
+@using Microsoft.AspNetCore.Components
+@using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.Components.Routing
+@using Microsoft.AspNetCore.Components.Web
+@using Microsoft.JSInterop
+@using Samples.Blazor.Geocoding
+@using Samples.Blazor.Geocoding.Components
+@using Samples.Blazor.Geocoding.Components.Pages

--- a/samples/Blazor.Geocoding/appsettings.json
+++ b/samples/Blazor.Geocoding/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/samples/Console.Geocoding/Console.Geocoding.csproj
+++ b/samples/Console.Geocoding/Console.Geocoding.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>Samples.ConsoleGeocoding</RootNamespace>
+    <AssemblyName>Samples.ConsoleGeocoding</AssemblyName>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\GoogleMapsApi\GoogleMapsApi.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/Console.Geocoding/Program.cs
+++ b/samples/Console.Geocoding/Program.cs
@@ -1,0 +1,50 @@
+using GoogleMapsApi;
+using GoogleMapsApi.Entities.Geocoding.Request;
+using GoogleMapsApi.Entities.Geocoding.Response;
+
+string? address = args.Length > 0
+    ? string.Join(' ', args)
+    : PromptForAddress();
+
+if (string.IsNullOrWhiteSpace(address))
+{
+    Console.Error.WriteLine("No address provided. Pass it as args or type one when prompted.");
+    return 1;
+}
+
+string? apiKey = Environment.GetEnvironmentVariable("GOOGLE_API_KEY");
+if (string.IsNullOrWhiteSpace(apiKey))
+{
+    Console.Error.WriteLine("GOOGLE_API_KEY environment variable is not set.");
+    return 2;
+}
+
+var request = new GeocodingRequest
+{
+    Address = address,
+    ApiKey = apiKey,
+};
+
+GeocodingResponse response = await GoogleMaps.Geocode.QueryAsync(request);
+
+if (response.Status != Status.OK || response.Results is null)
+{
+    Console.Error.WriteLine($"Geocoding failed: {response.Status}");
+    return 3;
+}
+
+foreach (var result in response.Results)
+{
+    var location = result.Geometry.Location;
+    Console.WriteLine($"Address : {result.FormattedAddress}");
+    Console.WriteLine($"Lat/Lng : {location.Latitude:F6}, {location.Longitude:F6}");
+    Console.WriteLine();
+}
+
+return 0;
+
+static string? PromptForAddress()
+{
+    Console.Write("Address: ");
+    return Console.ReadLine();
+}

--- a/samples/Console.Geocoding/README.md
+++ b/samples/Console.Geocoding/README.md
@@ -1,0 +1,22 @@
+# Console.Geocoding
+
+Console app that takes an address (from command-line args or stdin) and prints the geocoded latitude/longitude plus Google's formatted address.
+
+## Run
+
+```bash
+GOOGLE_API_KEY=your_api_key dotnet run --project samples/Console.Geocoding -- "1600 Amphitheatre Parkway, Mountain View, CA"
+```
+
+Or omit the address and you'll be prompted:
+
+```bash
+GOOGLE_API_KEY=your_api_key dotnet run --project samples/Console.Geocoding
+```
+
+## What this demonstrates
+
+- [`GoogleMaps.Geocode`](../../GoogleMapsApi/GoogleMaps.cs) facade entry point
+- [`GeocodingRequest`](../../GoogleMapsApi/Entities/Geocoding/Request/GeocodingRequest.cs)
+- [`GeocodingResponse`](../../GoogleMapsApi/Entities/Geocoding/Response/GeocodingResponse.cs)
+- Async-first usage via `QueryAsync`

--- a/samples/MinimalApi.Directions/MinimalApi.Directions.csproj
+++ b/samples/MinimalApi.Directions/MinimalApi.Directions.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>Samples.MinimalApi.Directions</RootNamespace>
+    <AssemblyName>Samples.MinimalApi.Directions</AssemblyName>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\GoogleMapsApi\GoogleMapsApi.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/MinimalApi.Directions/Program.cs
+++ b/samples/MinimalApi.Directions/Program.cs
@@ -1,0 +1,55 @@
+using GoogleMapsApi;
+using GoogleMapsApi.Entities.Directions.Request;
+using GoogleMapsApi.Entities.Directions.Response;
+
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+
+app.MapGet("/directions", async (string origin, string destination, IConfiguration config) =>
+{
+    string? apiKey = Environment.GetEnvironmentVariable("GOOGLE_API_KEY")
+                     ?? config["GoogleApiKey"];
+
+    if (string.IsNullOrWhiteSpace(apiKey))
+    {
+        return Results.Problem(
+            "GOOGLE_API_KEY env var or GoogleApiKey config value is required.",
+            statusCode: StatusCodes.Status500InternalServerError);
+    }
+
+    if (string.IsNullOrWhiteSpace(origin) || string.IsNullOrWhiteSpace(destination))
+    {
+        return Results.BadRequest(new { error = "origin and destination are required" });
+    }
+
+    var request = new DirectionsRequest
+    {
+        Origin = origin,
+        Destination = destination,
+        ApiKey = apiKey,
+    };
+
+    DirectionsResponse response = await GoogleMaps.Directions.QueryAsync(request);
+
+    if (response.Status != DirectionsStatusCodes.OK || response.Routes is null)
+    {
+        return Results.Problem(
+            $"Directions failed: {response.Status} {response.ErrorMessage}",
+            statusCode: StatusCodes.Status502BadGateway);
+    }
+
+    var route = response.Routes.First();
+    var leg = route.Legs?.FirstOrDefault();
+
+    return Results.Ok(new
+    {
+        summary = route.Summary,
+        startAddress = leg?.StartAddress,
+        endAddress = leg?.EndAddress,
+        distance = leg?.Distance?.Text,
+        duration = leg?.Duration?.Text,
+        copyrights = route.Copyrights,
+    });
+});
+
+app.Run();

--- a/samples/MinimalApi.Directions/README.md
+++ b/samples/MinimalApi.Directions/README.md
@@ -1,0 +1,24 @@
+# MinimalApi.Directions
+
+ASP.NET Core minimal API that exposes `GET /directions?origin=X&destination=Y` and returns a route summary as JSON.
+
+## Run
+
+```bash
+GOOGLE_API_KEY=your_api_key dotnet run --project samples/MinimalApi.Directions
+```
+
+Then in another terminal:
+
+```bash
+curl 'http://localhost:5000/directions?origin=New+York,NY&destination=Boston,MA'
+```
+
+The API key is sourced from the `GOOGLE_API_KEY` env var, falling back to the `GoogleApiKey` config value (e.g. via `appsettings.json` or user secrets).
+
+## What this demonstrates
+
+- [`GoogleMaps.Directions`](../../GoogleMapsApi/GoogleMaps.cs) facade entry point
+- [`DirectionsRequest`](../../GoogleMapsApi/Entities/Directions/Request/DirectionsRequest.cs)
+- [`DirectionsResponse`](../../GoogleMapsApi/Entities/Directions/Response/DirectionsResponse.cs) (route summary, legs, distance, duration)
+- Async-first usage inside an ASP.NET Core minimal API handler

--- a/samples/MinimalApi.Directions/appsettings.json
+++ b/samples/MinimalApi.Directions/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,0 +1,13 @@
+# Samples
+
+Minimal, copy-pasteable demos of [GoogleMapsApi](../GoogleMapsApi/GoogleMapsApi.csproj) across common .NET project types. Each sample references the library by `<ProjectReference>` so you can see them working against tip-of-master.
+
+All samples read the Google Maps API key from the `GOOGLE_API_KEY` environment variable. The Minimal API and Blazor samples also accept `GoogleApiKey` from configuration (e.g. `appsettings.json` or user secrets) as a fallback. Samples target `net10.0` with a `net8.0` fallback for older SDKs.
+
+| Sample | What it demonstrates | Run |
+| --- | --- | --- |
+| [Console.Geocoding](Console.Geocoding/) | Geocoding an address from a console app | `GOOGLE_API_KEY=... dotnet run --project samples/Console.Geocoding -- "1600 Amphitheatre Parkway"` |
+| [MinimalApi.Directions](MinimalApi.Directions/) | ASP.NET Core minimal API returning a directions route summary as JSON | `GOOGLE_API_KEY=... dotnet run --project samples/MinimalApi.Directions` |
+| [Blazor.Geocoding](Blazor.Geocoding/) | Blazor Server page that geocodes an address typed in the browser | `GOOGLE_API_KEY=... dotnet run --project samples/Blazor.Geocoding` |
+
+> Get an API key in the [Google Cloud Console](https://console.cloud.google.com/) and enable the Geocoding and/or Directions API for your project.


### PR DESCRIPTION
## Summary

Adds three minimal, runnable demo apps under `/samples` so new users can see GoogleMapsApi working across common .NET project types in well under 100 LOC each:

| Sample | Demonstrates | Run |
| --- | --- | --- |
| [`samples/Console.Geocoding`](samples/Console.Geocoding) | `GoogleMaps.Geocode` from a plain console app, reading an address from args or stdin | `GOOGLE_API_KEY=... dotnet run --project samples/Console.Geocoding -- "1600 Amphitheatre Parkway"` |
| [`samples/MinimalApi.Directions`](samples/MinimalApi.Directions) | `GoogleMaps.Directions` from an ASP.NET Core minimal API — `GET /directions?origin=X&destination=Y` returns a route summary as JSON | `GOOGLE_API_KEY=... dotnet run --project samples/MinimalApi.Directions` |
| [`samples/Blazor.Geocoding`](samples/Blazor.Geocoding) | `GoogleMaps.Geocode` from a Blazor Server page (server-side rendering keeps the API key off the client) | `GOOGLE_API_KEY=... dotnet run --project samples/Blazor.Geocoding` |

Each sample:

- References the in-repo library via `<ProjectReference Include="..\..\GoogleMapsApi\GoogleMapsApi.csproj" />` so it tracks tip-of-master.
- Reads the API key from `GOOGLE_API_KEY`; web samples also accept `GoogleApiKey` from `IConfiguration` as a fallback. No hardcoded keys.
- Uses file-scoped namespaces / top-level statements, nullable enabled, async-first.
- Has only the package deps strictly required (no Serilog, Swashbuckle, etc.).
- Ships its own `README.md` with a 1-2 sentence description and one-line run instructions.

Also:

- Added a `samples` solution folder to `GoogleMapsApi.sln` containing all three projects.
- Added a single line to the root `README.md` pointing to `/samples` (kept tiny because other PRs are touching the README in parallel).

## Target framework

Samples target `net10.0` (matching the library's top TFM) with a `net8.0` fallback so they still build on machines whose SDK predates .NET 10. The main library already targets both, so the project reference resolves cleanly.

## Build verification

All three samples build with `0 Warning(s), 0 Error(s)`:

```
dotnet build samples/Console.Geocoding/Console.Geocoding.csproj
dotnet build samples/MinimalApi.Directions/MinimalApi.Directions.csproj
dotnet build samples/Blazor.Geocoding/Blazor.Geocoding.csproj
```

Verified locally against the `net8.0` TFM (only SDK installed on this machine). CI with the .NET 10 SDK will exercise the `net10.0` TFM as well.

## Notes

- The repo's root `.gitignore` ignores `**/appsettings.json` (presumably to keep API keys out of `GoogleMapsApi.Test/appsettings.json`). The two sample `appsettings.json` files contain only default logging config and were force-added; they hold no secrets.
- No CI workflow added for sample builds — left as a separate concern per the PR scope.

## Test plan

- [ ] `dotnet build samples/Console.Geocoding/Console.Geocoding.csproj` → succeeds
- [ ] `dotnet build samples/MinimalApi.Directions/MinimalApi.Directions.csproj` → succeeds
- [ ] `dotnet build samples/Blazor.Geocoding/Blazor.Geocoding.csproj` → succeeds
- [ ] With a real `GOOGLE_API_KEY`: `dotnet run --project samples/Console.Geocoding -- "1600 Amphitheatre Parkway"` prints a lat/lng + formatted address
- [ ] With a real `GOOGLE_API_KEY`: `dotnet run --project samples/MinimalApi.Directions` then `curl 'http://localhost:5000/directions?origin=NYC&destination=Boston'` returns a JSON route summary
- [ ] With a real `GOOGLE_API_KEY`: `dotnet run --project samples/Blazor.Geocoding` shows the geocoding page and returns coords on submit