### PR TITLE
📝 docs: enable XML doc generation + comment core public API surface

### DIFF
--- a/GoogleMapsApi/EngineFacade.cs
+++ b/GoogleMapsApi/EngineFacade.cs
@@ -7,10 +7,11 @@ using System.Threading.Tasks;
 namespace GoogleMapsApi
 {
     /// <summary>
-    /// A public-surface API that exposes the Google Maps API functionality.
+    /// Default engine that executes a Google Maps API request and returns its strongly-typed response.
+    /// Use the singleton accessors on <see cref="GoogleMaps"/> to obtain an instance per API.
     /// </summary>
-    /// <typeparam name="TRequest"></typeparam>
-    /// <typeparam name="TResponse"></typeparam>
+    /// <typeparam name="TRequest">The request type, deriving from <see cref="MapsBaseRequest"/>.</typeparam>
+    /// <typeparam name="TResponse">The response type returned for <typeparamref name="TRequest"/>.</typeparam>
     public class EngineFacade<TRequest, TResponse> : IEngineFacade<TRequest, TResponse>
         where TRequest : MapsBaseRequest, new()
         where TResponse : IResponseFor<TRequest>

--- a/GoogleMapsApi/Entities/Common/IResponseFor.cs
+++ b/GoogleMapsApi/Entities/Common/IResponseFor.cs
@@ -1,4 +1,9 @@
 namespace GoogleMapsApi.Entities.Common
 {
+	/// <summary>
+	/// Marker interface that pairs a response type with its corresponding request type,
+	/// enabling compile-time matching in the engine facade.
+	/// </summary>
+	/// <typeparam name="T">The request type this response is produced for.</typeparam>
 	public interface IResponseFor<T> where T : MapsBaseRequest { }
 }

--- a/GoogleMapsApi/Entities/Common/MapsBaseRequest.cs
+++ b/GoogleMapsApi/Entities/Common/MapsBaseRequest.cs
@@ -6,8 +6,14 @@ using System.Linq;
 
 namespace GoogleMapsApi.Entities.Common
 {
+    /// <summary>
+    /// Base class for all Google Maps Web Service requests. Provides API key, SSL, and URL composition.
+    /// </summary>
     public abstract class MapsBaseRequest
     {
+        /// <summary>
+        /// Initializes a new request with SSL enabled and no API key.
+        /// </summary>
         public MapsBaseRequest()
         {
             this.isSsl = true;
@@ -37,6 +43,10 @@ namespace GoogleMapsApi.Entities.Common
         private bool isSsl;
 
 
+        /// <summary>
+        /// Base URL (without scheme) for the Google Maps Web Service endpoint this request targets.
+        /// Derived requests append their service-specific path.
+        /// </summary>
         protected internal virtual string BaseUrl
         {
             get
@@ -51,6 +61,11 @@ namespace GoogleMapsApi.Entities.Common
         /// </summary>
         public string? ApiKey { get; set; }
 
+        /// <summary>
+        /// Builds the list of query-string parameters that will be sent with the request.
+        /// Derived classes override to contribute their service-specific parameters.
+        /// </summary>
+        /// <returns>The parameters to include in the request URL.</returns>
         protected virtual QueryStringParametersList GetQueryStringParameters()
         {
             QueryStringParametersList parametersList = new QueryStringParametersList();
@@ -67,6 +82,10 @@ namespace GoogleMapsApi.Entities.Common
             return parametersList;
         }
 
+        /// <summary>
+        /// Builds the absolute request URI, including scheme, base URL, and serialized query-string parameters.
+        /// </summary>
+        /// <returns>The fully composed URI to send to the Google Maps API.</returns>
         public virtual Uri GetUri()
         {
             string scheme = IsSSL ? "https://" : "http://";

--- a/GoogleMapsApi/Entities/Directions/Request/DirectionsRequest.cs
+++ b/GoogleMapsApi/Entities/Directions/Request/DirectionsRequest.cs
@@ -7,6 +7,10 @@ using GoogleMapsApi.Entities.Common;
 
 namespace GoogleMapsApi.Entities.Directions.Request
 {
+	/// <summary>
+	/// Request for the Google Directions API, which computes a route between an origin and a destination
+	/// for a chosen travel mode, with optional waypoints and routing preferences.
+	/// </summary>
 	public class DirectionsRequest : SignableRequest
 	{
 		protected internal override string BaseUrl

--- a/GoogleMapsApi/Entities/Directions/Response/DirectionsResponse.cs
+++ b/GoogleMapsApi/Entities/Directions/Response/DirectionsResponse.cs
@@ -8,6 +8,9 @@ using GoogleMapsApi.Engine.JsonConverters;
 
 namespace GoogleMapsApi.Entities.Directions.Response
 {
+	/// <summary>
+	/// Response from the Google Directions API containing one or more computed routes from origin to destination.
+	/// </summary>
 	public class DirectionsResponse : IResponseFor<DirectionsRequest>
 	{
 		/// <summary>

--- a/GoogleMapsApi/Entities/Directions/Response/VehicleType.cs
+++ b/GoogleMapsApi/Entities/Directions/Response/VehicleType.cs
@@ -89,7 +89,7 @@ namespace GoogleMapsApi.Entities.Directions.Response
 
         /// <summary>
         /// Not by google documented vehicle type. But returned by e.g. following directions API call:
-        /// https://maps.googleapis.com/maps/api/directions/json?&mode=transit&origin=zurich+airport&destination=brig&departure_time=1534606200
+        /// https://maps.googleapis.com/maps/api/directions/json?&amp;mode=transit&amp;origin=zurich+airport&amp;destination=brig&amp;departure_time=1534606200
         /// </summary>
         LONG_DISTANCE_TRAIN
     }

--- a/GoogleMapsApi/Entities/DistanceMatrix/Request/DistanceMatrixRequest.cs
+++ b/GoogleMapsApi/Entities/DistanceMatrix/Request/DistanceMatrixRequest.cs
@@ -10,6 +10,10 @@
 
     using GoogleMapsApi.Engine;
 
+    /// <summary>
+    /// Request for the Google Distance Matrix API, which returns travel distance and duration
+    /// for a matrix of origins and destinations across a chosen travel mode.
+    /// </summary>
     public class DistanceMatrixRequest : SignableRequest
     {
         protected internal override string BaseUrl
@@ -42,8 +46,8 @@
         /// <summary>
         /// For the calculation of distances, you may specify the transportation mode to use. By default, distances are calculated for driving mode. The following travel modes are supported:
         /// - driving(default) indicates distance calculation using the road network.
-        /// - walking requests distance calculation for walking via pedestrian paths & sidewalks (where available).
-        /// - bicycling requests distance calculation for bicycling via bicycle paths & preferred streets(where available).
+        /// - walking requests distance calculation for walking via pedestrian paths &amp; sidewalks (where available).
+        /// - bicycling requests distance calculation for bicycling via bicycle paths &amp; preferred streets(where available).
         /// - transit requests distance calculation via public transit routes(where available). This value may only be specified if the request includes an API key or a Google Maps APIs Premium Plan client ID.If you set the mode to transit you can optionally specify either a departure_time or an arrival_time.If neither time is specified, the departure_time defaults to now(that is, the departure time defaults to the current time). You can also optionally include a transit_mode and/or a transit_routing_preference.
         /// * Note: Both walking and bicycling routes may sometimes not include clear pedestrian or bicycling paths, so these responses will return warnings in the returned result which you must display to the user.
         /// </summary>

--- a/GoogleMapsApi/Entities/DistanceMatrix/Response/DistanceMatrixResponse.cs
+++ b/GoogleMapsApi/Entities/DistanceMatrix/Response/DistanceMatrixResponse.cs
@@ -9,6 +9,9 @@
     using GoogleMapsApi.Entities.DistanceMatrix.Request;
     using GoogleMapsApi.Engine.JsonConverters;
 
+    /// <summary>
+    /// Response from the Google Distance Matrix API containing travel distance and duration between each origin and destination.
+    /// </summary>
     public class DistanceMatrixResponse: IResponseFor<DistanceMatrixRequest>
     {
         /// <summary>

--- a/GoogleMapsApi/Entities/Elevation/Response/ElevationResponse.cs
+++ b/GoogleMapsApi/Entities/Elevation/Response/ElevationResponse.cs
@@ -8,6 +8,9 @@ using GoogleMapsApi.Engine.JsonConverters;
 
 namespace GoogleMapsApi.Entities.Elevation.Response
 {
+	/// <summary>
+	/// Response from the Google Elevation API containing elevation values for the requested locations or path.
+	/// </summary>
 	public class ElevationResponse : IResponseFor<ElevationRequest>
 	{
 		[JsonPropertyName("status")]

--- a/GoogleMapsApi/Entities/Geocoding/Request/GeocodingRequest.cs
+++ b/GoogleMapsApi/Entities/Geocoding/Request/GeocodingRequest.cs
@@ -5,6 +5,10 @@ using GoogleMapsApi.Entities.Common;
 
 namespace GoogleMapsApi.Entities.Geocoding.Request
 {
+    /// <summary>
+    /// Request for the Google Geocoding API, which converts between addresses and geographic coordinates.
+    /// Supports forward geocoding (address to coordinates) and reverse geocoding (coordinates to address).
+    /// </summary>
     public class GeocodingRequest : SignableRequest
     {
         protected internal override string BaseUrl

--- a/GoogleMapsApi/Entities/Geocoding/Response/GeocodingResponse.cs
+++ b/GoogleMapsApi/Entities/Geocoding/Response/GeocodingResponse.cs
@@ -8,6 +8,9 @@ using GoogleMapsApi.Engine.JsonConverters;
 
 namespace GoogleMapsApi.Entities.Geocoding.Response
 {
+	/// <summary>
+	/// Response from the Google Geocoding API containing geocoded results matching the input address or coordinates.
+	/// </summary>
 	public class GeocodingResponse : IResponseFor<GeocodingRequest>
 	{
 		[JsonPropertyName("status")]

--- a/GoogleMapsApi/Entities/PlaceAutocomplete/Response/PlaceAutocompleteResponse.cs
+++ b/GoogleMapsApi/Entities/PlaceAutocomplete/Response/PlaceAutocompleteResponse.cs
@@ -7,6 +7,9 @@ using GoogleMapsApi.Engine.JsonConverters;
 
 namespace GoogleMapsApi.Entities.PlaceAutocomplete.Response
 {
+    /// <summary>
+    /// Response from the Google Place Autocomplete API containing predicted place matches for the input text.
+    /// </summary>
     public class PlaceAutocompleteResponse : IResponseFor<PlaceAutocompleteRequest>
 	{
 		/// <summary>

--- a/GoogleMapsApi/Entities/Places/Response/PlacesResponse.cs
+++ b/GoogleMapsApi/Entities/Places/Response/PlacesResponse.cs
@@ -7,6 +7,9 @@ using GoogleMapsApi.Engine.JsonConverters;
 
 namespace GoogleMapsApi.Entities.Places.Response
 {
+	/// <summary>
+	/// Response from the Google Places Search API containing places matching the search criteria.
+	/// </summary>
 	public class PlacesResponse : IResponseFor<PlacesRequest>
 	{
 		/// <summary>

--- a/GoogleMapsApi/Entities/PlacesDetails/Request/PlacesDetailsRequest.cs
+++ b/GoogleMapsApi/Entities/PlacesDetails/Request/PlacesDetailsRequest.cs
@@ -3,6 +3,10 @@ using GoogleMapsApi.Entities.Common;
 
 namespace GoogleMapsApi.Entities.PlacesDetails.Request
 {
+    /// <summary>
+    /// Request for the Google Place Details API, which returns rich information about a single place
+    /// identified by its Place ID.
+    /// </summary>
     public class PlacesDetailsRequest : MapsBaseRequest
     {
         protected internal override string BaseUrl

--- a/GoogleMapsApi/Entities/PlacesDetails/Response/PlacesDetailsResponse.cs
+++ b/GoogleMapsApi/Entities/PlacesDetails/Response/PlacesDetailsResponse.cs
@@ -7,6 +7,9 @@ using GoogleMapsApi.Engine.JsonConverters;
 
 namespace GoogleMapsApi.Entities.PlacesDetails.Response
 {
+    /// <summary>
+    /// Response from the Google Place Details API containing the full record for the requested place.
+    /// </summary>
     public class PlacesDetailsResponse : IResponseFor<PlacesDetailsRequest>
     {
         /// <summary>

--- a/GoogleMapsApi/Entities/PlacesFind/Response/PlacesFindResponse.cs
+++ b/GoogleMapsApi/Entities/PlacesFind/Response/PlacesFindResponse.cs
@@ -7,6 +7,9 @@ using GoogleMapsApi.Engine.JsonConverters;
 
 namespace GoogleMapsApi.Entities.PlacesFind.Response
 {
+    /// <summary>
+    /// Response from the Google Find Place API containing candidate places matching the input text.
+    /// </summary>
     public class PlacesFindResponse : IResponseFor<PlacesFindRequest>
     {
         [JsonPropertyName("status")]

--- a/GoogleMapsApi/Entities/PlacesNearBy/Response/PlacesNearByResponse.cs
+++ b/GoogleMapsApi/Entities/PlacesNearBy/Response/PlacesNearByResponse.cs
@@ -7,6 +7,9 @@ using GoogleMapsApi.Engine.JsonConverters;
 
 namespace GoogleMapsApi.Entities.PlacesNearBy.Response
 {
+	/// <summary>
+	/// Response from the Google Places Nearby Search API containing places near the requested location.
+	/// </summary>
 	public class PlacesNearByResponse : IResponseFor<PlacesNearByRequest>
 	{
 		/// <summary>

--- a/GoogleMapsApi/Entities/PlacesText/Request/PlacesTextRequest.cs
+++ b/GoogleMapsApi/Entities/PlacesText/Request/PlacesTextRequest.cs
@@ -4,6 +4,10 @@ using GoogleMapsApi.Entities.Common;
 
 namespace GoogleMapsApi.Entities.PlacesText.Request
 {
+    /// <summary>
+    /// Request for the Google Places Text Search API, which returns places matching a free-form text query,
+    /// optionally biased by location and radius.
+    /// </summary>
     public class PlacesTextRequest : MapsBaseRequest
     {
         protected internal override string BaseUrl

--- a/GoogleMapsApi/Entities/PlacesText/Response/PlacesTextResponse.cs
+++ b/GoogleMapsApi/Entities/PlacesText/Response/PlacesTextResponse.cs
@@ -7,6 +7,9 @@ using GoogleMapsApi.Engine.JsonConverters;
 
 namespace GoogleMapsApi.Entities.PlacesText.Response
 {
+    /// <summary>
+    /// Response from the Google Places Text Search API containing places matching the text query.
+    /// </summary>
     public class PlacesTextResponse : IResponseFor<PlacesTextRequest>
     {
         /// <summary>

--- a/GoogleMapsApi/Entities/TimeZone/Request/TimeZoneRequest.cs
+++ b/GoogleMapsApi/Entities/TimeZone/Request/TimeZoneRequest.cs
@@ -4,6 +4,10 @@ using GoogleMapsApi.Entities.Common;
 
 namespace GoogleMapsApi.Entities.TimeZone.Request
 {
+    /// <summary>
+    /// Request for the Google Time Zone API, which returns the time-zone identifier and UTC offset
+    /// (including any DST offset) for a given location and timestamp.
+    /// </summary>
     public class TimeZoneRequest : SignableRequest
     {
         protected internal override string BaseUrl

--- a/GoogleMapsApi/Entities/TimeZone/Response/TimeZoneResponse.cs
+++ b/GoogleMapsApi/Entities/TimeZone/Response/TimeZoneResponse.cs
@@ -6,8 +6,11 @@ using GoogleMapsApi.Engine.JsonConverters;
 
 namespace GoogleMapsApi.Entities.TimeZone.Response
 {
+    /// <summary>
+    /// Response from the Google Time Zone API containing the time-zone identifier, UTC offset, and DST offset for the queried location.
+    /// </summary>
     public class TimeZoneResponse : IResponseFor<TimeZoneRequest>
-    {        
+    {
         /// <summary>
         /// "status" contains metadata on the request.
         /// </summary>

--- a/GoogleMapsApi/GoogleMaps.cs
+++ b/GoogleMapsApi/GoogleMaps.cs
@@ -26,6 +26,10 @@ using System;
 
 namespace GoogleMapsApi
 {
+    /// <summary>
+    /// Static facade exposing strongly-typed accessors to every supported Google Maps Web Service.
+    /// Each property returns a singleton engine that handles request execution for a specific API.
+    /// </summary>
     public class GoogleMaps
 	{
 		/// <summary>Perform geocoding operations.</summary>

--- a/GoogleMapsApi/GoogleMapsApi.csproj
+++ b/GoogleMapsApi/GoogleMapsApi.csproj
@@ -21,6 +21,8 @@
 	<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 	<Nullable>enable</Nullable>
 	<TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+	<GenerateDocumentationFile>true</GenerateDocumentationFile>
+	<NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">

--- a/GoogleMapsApi/IEngineFacade.cs
+++ b/GoogleMapsApi/IEngineFacade.cs
@@ -7,6 +7,11 @@ namespace GoogleMapsApi
 {
     using Engine;
 
+    /// <summary>
+    /// Contract for a Google Maps API engine that executes a strongly-typed request and returns its matching response.
+    /// </summary>
+    /// <typeparam name="TRequest">The request type, deriving from <see cref="MapsBaseRequest"/>.</typeparam>
+    /// <typeparam name="TResponse">The response type returned for <typeparamref name="TRequest"/>.</typeparam>
     public interface IEngineFacade<in TRequest, TResponse>
         where TRequest : MapsBaseRequest, new()
         where TResponse : IResponseFor<TRequest>

--- a/GoogleMapsApi/StaticMaps/StaticMapsEngine.cs
+++ b/GoogleMapsApi/StaticMaps/StaticMapsEngine.cs
@@ -22,6 +22,11 @@ namespace GoogleMapsApi.StaticMaps
 			BaseUrl = @"maps.google.com/maps/api/staticmap";
 		}
 
+		/// <summary>
+		/// Builds the Google Static Maps URL for the given request, including center, zoom, size, markers, paths, and style parameters.
+		/// </summary>
+		/// <param name="request">The static map request to serialize.</param>
+		/// <returns>The fully composed Static Maps URL.</returns>
 		public string GenerateStaticMapURL(StaticMapRequest request)
 		{
 			string scheme = request.IsSSL ? "https://" : "http://";


### PR DESCRIPTION
## Summary

Enables XML documentation generation on the main library so the NuGet package ships an `.xml` file consumed by IntelliSense and DocFX. Adds `///` summaries to the highest-value public surface so the most-used types render with descriptions in tooling immediately.

## What changed

- `GoogleMapsApi/GoogleMapsApi.csproj`
  - `<GenerateDocumentationFile>true</GenerateDocumentationFile>`
  - `<NoWarn>$(NoWarn);CS1591</NoWarn>` to silence missing-doc warnings repo-wide while coverage is filled in incrementally (otherwise the build floods with hundreds of warnings on undocumented entity properties)
- Doc comments added to:
  - `GoogleMaps` (static facade class)
  - `EngineFacade<TRequest, TResponse>` (filled in empty `typeparam` tags)
  - `IEngineFacade<TRequest, TResponse>`
  - `MapsBaseRequest` (class, ctor, `BaseUrl`, `GetQueryStringParameters`, `GetUri`)
  - `IResponseFor<T>`
  - Every top-level Request entry class: `GeocodingRequest`, `DirectionsRequest`, `DistanceMatrixRequest`, `TimeZoneRequest`, `PlacesTextRequest`, `PlacesDetailsRequest`
  - Every top-level Response class: `GeocodingResponse`, `DirectionsResponse`, `DistanceMatrixResponse`, `ElevationResponse`, `TimeZoneResponse`, `PlacesResponse`, `PlacesTextResponse`, `PlacesNearByResponse`, `PlacesFindResponse`, `PlacesDetailsResponse`, `PlaceAutocompleteResponse`
  - `StaticMapsEngine.GenerateStaticMapURL`
- Escaped a few stray `&` characters in pre-existing comments (`DistanceMatrixRequest`, `VehicleType`) that would otherwise produce `CS1570` once doc generation is on.

## Partial coverage strategy

Documenting every nested entity property (e.g. `Result.Geometry.Location.Lat`) in one PR is unrealistic and would dwarf review. `CS1591` is suppressed so the build stays clean, and follow-up PRs can fill in deep entity-tree docs incrementally without re-enabling the warning each time.

## What's deferred

- Deep nested DTO properties under `Entities/*/Response/`
- Internal types and helper enums beyond the entry classes
- The test project intentionally left untouched (no `GenerateDocumentationFile`)

## Why this matters

This unblocks the planned DocFX site PR: the XML file is now produced and the most prominent types have human-readable descriptions, so the generated site won't be a wall of bare type names.

## Test plan

- [x] `dotnet build` succeeds with 0 warnings / 0 errors
- [x] `bin/<tfm>/GoogleMapsApi.xml` is generated
- [x] Test project unchanged
- [ ] CI passes across all target frameworks