### PR TITLE
🔧 ci: pin ossf/scorecard-action to v2.4.3 (fixes broken badge)

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -27,7 +27,7 @@ jobs:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@v2
+        uses: ossf/scorecard-action@v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
## Problem

The OpenSSF Scorecard badge in the README shows **"invalid repo path"** because the Scorecard workflow has never completed successfully.

Run logs from the failures on master ([example](https://github.com/maximn/google-maps/actions/runs/26371913405)) show:

> ##[error]Unable to resolve action \`ossf/scorecard-action@v2\`, unable to find version \`v2\`

## Root cause

Unlike `actions/checkout`, `github/codeql-action`, etc., the `ossf/scorecard-action` repo does **not** publish a rolling major-version tag — only specific patch tags (`v2.4.3`, `v2.4.2`, …). The workflow's `uses: ossf/scorecard-action@v2` therefore can't resolve at job-start and the job aborts before any analysis runs. With no analysis runs, scorecard.dev has no data for the repo, and the badge endpoint at `api.scorecard.dev/projects/.../badge` returns the "invalid repo path" SVG.

## Fix

Pin to `ossf/scorecard-action@v2.4.3` (latest). Matches the project's existing convention of major-pinning where supported, and pins to the exact tag where it isn't.

## After merge

1. Trigger the workflow once via **Actions → Scorecard supply-chain security → Run workflow** (or wait for the next push to `master` / the weekly cron).
2. First successful run publishes results to scorecard.dev via the OIDC token (`publish_results: true` is already set).
3. Badge + click-through (`scorecard.dev/viewer/?uri=github.com/maximn/google-maps`) both resolve.

## Test plan

- [ ] Manually dispatch the workflow after merge and confirm green
- [ ] Confirm SARIF appears under Security → Code scanning
- [ ] Confirm README badge renders a numeric score (no longer "invalid repo path")