### PR TITLE
🔒 ci: replace pull_request_target with pull_request to fix Scorecard Dangerous-Workflow

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -3,7 +3,7 @@ name: .NET
 on:
   push:
     branches: [ master ]
-  pull_request_target:
+  pull_request:
 
 permissions:
   contents: read
@@ -18,8 +18,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-      with:
-        ref: ${{ github.event.pull_request.head.sha || github.sha }}
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:


### PR DESCRIPTION
## Summary

`.github/workflows/dotnet.yml` previously used `pull_request_target:` and then explicitly checked out the PR head SHA via `ref: ${{ github.event.pull_request.head.sha || github.sha }}`. That combination — base-branch workflow + secrets + PR-head code — is the canonical pwn-request pattern flagged by **OpenSSF Scorecard** as **Dangerous-Workflow (Critical weight, score 0)**.

This PR:

- Switches the trigger from `pull_request_target` to `pull_request`.
- Drops the explicit `with: ref: …` from `actions/checkout`; the default merge ref is correct and safe under `pull_request`.
- Keeps the same-repo `if:` guard. It's no longer security-critical (the trigger swap is what hardens the workflow), but tests need `GOOGLE_API_KEY` which GitHub correctly withholds from fork PRs, so the guard avoids noisy failures.

## Background

GitHub Security Lab has a good writeup of the `pull_request_target` foot-gun and the broader "pwn-request" class of vulnerabilities:

- https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

Short version: `pull_request_target` runs the workflow defined on the **base** branch with **read/write** secrets, which is normally safe — but checking out the PR head SHA into that privileged context lets untrusted PR code execute (build scripts, npm/dotnet pre/post hooks, etc.) with the secrets in the environment. Scorecard's static analyzer flags any `pull_request_target` workflow that touches the PR head as Critical, regardless of additional guards.

## Risk analysis

**Before this PR**

- Trigger: `pull_request_target` → workflow runs from base branch with full secrets.
- Checkout: `ref: github.event.pull_request.head.sha` → PR-head code is materialized into the privileged runner.
- Mitigation present: `if: github.event.pull_request.head.repo.full_name == github.repository` skipped fork PRs.
- Net: **not exploitable today** (the `if:` guard blocks the fork-PR case), but the configuration is one edit away from a critical secret-exfiltration vulnerability, and Scorecard cannot credit the guard via static analysis — hence the score of 0 on the Dangerous-Workflow check.

**After this PR**

- Trigger: `pull_request` → workflow runs from the PR head's workflow file, with fork-PR secrets correctly restricted by GitHub (only `GITHUB_TOKEN` with read-only contents, no repo secrets).
- Checkout: default (merge ref) — what tests actually want to validate.
- Same-repo `if:` guard retained as hygiene (skip fork-PR CI to avoid `GOOGLE_API_KEY`-missing test failures).
- Net: dangerous pattern removed, Scorecard Dangerous-Workflow finding cleared, behavior for same-repo PRs unchanged.

## Test plan

- [ ] Merge a same-repo PR (e.g. this one) → CI runs, has access to `GOOGLE_API_KEY`, build + tests pass.
- [ ] Open a PR from a fork → `build` job is skipped by the `if:` guard (no noisy failures from missing secret).
- [ ] Push to `master` → CI runs as before via the `push` trigger.
- [ ] OpenSSF Scorecard re-run shows Dangerous-Workflow lifted off 0.