### PR TITLE
✨ ci: add SLSA provenance attestations + GitHub Release to NuGet publish

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -21,6 +21,10 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write       # create GitHub Release
+      id-token: write       # Sigstore OIDC
+      attestations: write   # GitHub attestations API
 
     steps:
       - uses: actions/checkout@v6
@@ -54,6 +58,13 @@ jobs:
       - name: Pack
         run: dotnet pack --configuration Release --no-build --output . -p:Version=${{ steps.get_version.outputs.VERSION }}
 
+      - name: Attest build provenance
+        if: github.event_name == 'push' || inputs.dry_run == false
+        id: attest
+        uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f  # v3.2.0
+        with:
+          subject-path: '*.nupkg'
+
       - name: Upload nupkg artifact
         if: github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v7
@@ -64,3 +75,15 @@ jobs:
       - name: Publish NuGet
         if: github.event_name == 'push' || inputs.dry_run == false
         run: dotnet nuget push *.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+
+      - name: Create GitHub Release
+        if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.get_version.outputs.VERSION }}
+          ATTESTATION_BUNDLE: ${{ steps.attest.outputs.bundle-path }}
+        run: |
+          gh release create "v${VERSION}" \
+            --title "v${VERSION}" \
+            --generate-notes \
+            ./*.nupkg "${ATTESTATION_BUNDLE}"


### PR DESCRIPTION
## Summary

GitHub Releases are now created on tag push, with Sigstore-signed SLSA build provenance attestations attached alongside the `.nupkg`. Closes the OpenSSF Scorecard **Signed-Releases** gap (currently `n/a` → expected `10`).

## What changed

- Added job-level permissions (`contents: write`, `id-token: write`, `attestations: write`) on the `publish:` job; kept workflow-level `permissions: contents: read` as the secure default.
- After Pack, run `actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f` (v3.2.0, SHA-pinned) to produce a Sigstore-signed `.intoto.jsonl` attestation bundle for every `*.nupkg`.
- On tag push, create a GitHub Release via `gh release create` (no extra action dep — smaller supply-chain surface), attaching both the nupkg(s) and the attestation bundle.
- Workflow_dispatch with `dry_run=true` still skips the publish and release steps; attestation runs only when actually publishing.

## What this enables

- Consumers can verify provenance with:
  ```bash
  gh attestation verify --owner maximn <file.nupkg>
  ```
- Scorecard's static `Signed-Releases` check recognizes `.intoto.jsonl` files attached to GitHub Releases and will pick this up on the next run after a release exists.

## Trade-offs

Minimal — adds roughly 30 seconds to the publish workflow. Downstream consumers who don't care about signatures are unaffected; the nupkg on NuGet.org is unchanged.

## Decisions

- **Pinned `attest-build-provenance` to commit SHA `96278af` (v3.2.0)** despite the rest of the repo using tag-pinning. Signing actions are security-critical and SHA-pinning prevents tag re-pointing attacks; this is consistent with OpenSSF best practice for any action that touches OIDC tokens or signs artifacts.
- **Used `gh release create` over `softprops/action-gh-release` or similar** to minimize the supply-chain surface — `gh` ships on the runner.

## Test plan

- [ ] Trigger workflow_dispatch with a test version + `dry_run=true`; verify the attestation step is skipped (current `if:` guards `push || dry_run == false`).
- [ ] Trigger workflow_dispatch with `dry_run=false`; verify attestation step succeeds and produces a bundle path output.
- [ ] On next real tag push (e.g. `v1.4.6`), verify a GitHub Release is created with the `.nupkg` and `.intoto.jsonl` attached.
- [ ] Run `gh attestation verify --owner maximn <downloaded.nupkg>` against the released artifact.
- [ ] Re-run Scorecard workflow after the first release exists; confirm Signed-Releases score is no longer `n/a`.