### PR TITLE
✨ feat: introduce instance-based GoogleMapsClient (IHttpClientFactory-friendly)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Instance-based `GoogleMapsClient` / `IGoogleMapsClient` accepting an injected `HttpClient` — `IHttpClientFactory`-friendly, with per-instance `OnUriCreated` / `OnRawResponseReceived` events and ambient API-key fill-in via `GoogleMapsClientOptions` (#236)
+
 ## [1.4.7] - 2026-05-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-- Instance-based `GoogleMapsClient` / `IGoogleMapsClient` accepting an injected `HttpClient` — `IHttpClientFactory`-friendly, with per-instance `OnUriCreated` / `OnRawResponseReceived` events and ambient API-key fill-in via `GoogleMapsClientOptions` (#236)
-
 ## [1.4.7] - 2026-05-23
 
 ### Added

--- a/GoogleMapsApi.Test/GoogleMapsClientTests.cs
+++ b/GoogleMapsApi.Test/GoogleMapsClientTests.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
@@ -174,6 +177,32 @@ namespace GoogleMapsApi.Test
         }
 
         [Test]
+        public async Task ConcurrentClients_WithSharedRequest_EachSeeTheirOwnAmbientKey()
+        {
+            using var handler = new RecordingHandler(OkGeocodingJson);
+            using var http = new HttpClient(handler);
+            var clientA = new GoogleMapsClient(http, new GoogleMapsClientOptions { ApiKey = "key-a" });
+            var clientB = new GoogleMapsClient(http, new GoogleMapsClientOptions { ApiKey = "key-b" });
+
+            var sharedRequest = new GeocodingRequest { Address = "shared" };
+
+            var tasks = new Task[200];
+            for (int i = 0; i < tasks.Length; i++)
+            {
+                var client = i % 2 == 0 ? clientA : clientB;
+                tasks[i] = client.Geocode.QueryAsync(sharedRequest);
+            }
+            await Task.WhenAll(tasks);
+
+            Assert.That(sharedRequest.ApiKey, Is.Null);
+            Assert.That(handler.RequestUris, Has.Count.EqualTo(tasks.Length));
+            int aCount = handler.RequestUris.Count(u => u.Query.Contains("key=key-a"));
+            int bCount = handler.RequestUris.Count(u => u.Query.Contains("key=key-b"));
+            Assert.That(aCount, Is.EqualTo(tasks.Length / 2));
+            Assert.That(bCount, Is.EqualTo(tasks.Length / 2));
+        }
+
+        [Test]
         public void QueryAsync_CancelledToken_Throws()
         {
             using var handler = new CapturingHandler(OkGeocodingJson);
@@ -245,6 +274,29 @@ namespace GoogleMapsApi.Test
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 LastRequestUri = request.RequestUri;
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(_responseBody)
+                });
+            }
+        }
+
+        private sealed class RecordingHandler : HttpMessageHandler
+        {
+            private readonly string _responseBody;
+            private readonly ConcurrentBag<Uri> _uris = new();
+
+            public RecordingHandler(string responseBody)
+            {
+                _responseBody = responseBody;
+            }
+
+            public IReadOnlyCollection<Uri> RequestUris => _uris;
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                _uris.Add(request.RequestUri!);
                 return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
                 {
                     Content = new StringContent(_responseBody)

--- a/GoogleMapsApi.Test/GoogleMapsClientTests.cs
+++ b/GoogleMapsApi.Test/GoogleMapsClientTests.cs
@@ -1,0 +1,218 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using GoogleMapsApi.Entities.Geocoding.Request;
+using GoogleMapsApi.Entities.Geocoding.Response;
+using NUnit.Framework;
+
+namespace GoogleMapsApi.Test
+{
+    /// <summary>
+    /// Hermetic tests for the instance-based <see cref="GoogleMapsClient"/>. No live network calls —
+    /// every HTTP exchange is intercepted by <see cref="CapturingHandler"/>.
+    /// </summary>
+    [TestFixture]
+    public class GoogleMapsClientTests
+    {
+        private const string OkGeocodingJson = "{\"status\":\"OK\",\"results\":[]}";
+
+        [Test]
+        public async Task QueryAsync_RoundTrip_DeserializesResponse()
+        {
+            using var handler = new CapturingHandler(OkGeocodingJson);
+            using var http = new HttpClient(handler);
+            var client = new GoogleMapsClient(http, new GoogleMapsClientOptions { ApiKey = "test-key" });
+
+            var response = await client.Geocode.QueryAsync(new GeocodingRequest { Address = "1600 Amphitheatre Pkwy" });
+
+            Assert.That(response.Status, Is.EqualTo(Status.OK));
+            Assert.That(handler.LastRequestUri, Is.Not.Null);
+            Assert.That(handler.LastRequestUri!.Host, Is.EqualTo("maps.googleapis.com"));
+        }
+
+        [Test]
+        public async Task QueryAsync_AmbientApiKey_IsAppliedWhenRequestHasNone()
+        {
+            using var handler = new CapturingHandler(OkGeocodingJson);
+            using var http = new HttpClient(handler);
+            var client = new GoogleMapsClient(http, new GoogleMapsClientOptions { ApiKey = "ambient-key" });
+
+            await client.Geocode.QueryAsync(new GeocodingRequest { Address = "Pier 39" });
+
+            Assert.That(handler.LastRequestUri!.Query, Does.Contain("key=ambient-key"));
+        }
+
+        [Test]
+        public async Task QueryAsync_ExplicitApiKey_IsNotOverwrittenByAmbient()
+        {
+            using var handler = new CapturingHandler(OkGeocodingJson);
+            using var http = new HttpClient(handler);
+            var client = new GoogleMapsClient(http, new GoogleMapsClientOptions { ApiKey = "ambient-key" });
+
+            var request = new GeocodingRequest { Address = "Pier 39", ApiKey = "explicit-key" };
+            await client.Geocode.QueryAsync(request);
+
+            Assert.That(handler.LastRequestUri!.Query, Does.Contain("key=explicit-key"));
+            Assert.That(handler.LastRequestUri!.Query, Does.Not.Contain("ambient-key"));
+        }
+
+        [Test]
+        public async Task QueryAsync_NoApiKeyAnywhere_SendsRequestWithoutKey()
+        {
+            using var handler = new CapturingHandler(OkGeocodingJson);
+            using var http = new HttpClient(handler);
+            var client = new GoogleMapsClient(http);
+
+            await client.Geocode.QueryAsync(new GeocodingRequest { Address = "Pier 39" });
+
+            Assert.That(handler.LastRequestUri!.Query, Does.Not.Contain("key="));
+        }
+
+        [Test]
+        public async Task OnUriCreated_Event_IsScopedToSingleClient()
+        {
+            using var handler = new CapturingHandler(OkGeocodingJson);
+            using var http = new HttpClient(handler);
+            var clientA = new GoogleMapsClient(http, new GoogleMapsClientOptions { ApiKey = "key-a" });
+            var clientB = new GoogleMapsClient(http, new GoogleMapsClientOptions { ApiKey = "key-b" });
+
+            int firedOnA = 0, firedOnB = 0;
+            clientA.Geocode.OnUriCreated += uri => { firedOnA++; return uri; };
+            clientB.Geocode.OnUriCreated += uri => { firedOnB++; return uri; };
+
+            await clientA.Geocode.QueryAsync(new GeocodingRequest { Address = "a" });
+
+            Assert.That(firedOnA, Is.EqualTo(1));
+            Assert.That(firedOnB, Is.EqualTo(0));
+        }
+
+        [Test]
+        public async Task OnUriCreated_Event_CanRewriteUri()
+        {
+            using var handler = new CapturingHandler(OkGeocodingJson);
+            using var http = new HttpClient(handler);
+            var client = new GoogleMapsClient(http, new GoogleMapsClientOptions { ApiKey = "k" });
+
+            client.Geocode.OnUriCreated += _ => new Uri("https://proxy.example.com/maps/api/geocode/json?key=k");
+
+            await client.Geocode.QueryAsync(new GeocodingRequest { Address = "a" });
+
+            Assert.That(handler.LastRequestUri!.Host, Is.EqualTo("proxy.example.com"));
+        }
+
+        [Test]
+        public async Task OnRawResponseReceived_Event_FiresWithBytes()
+        {
+            using var handler = new CapturingHandler(OkGeocodingJson);
+            using var http = new HttpClient(handler);
+            var client = new GoogleMapsClient(http, new GoogleMapsClientOptions { ApiKey = "k" });
+
+            byte[]? captured = null;
+            client.Geocode.OnRawResponseReceived += bytes => captured = bytes;
+
+            await client.Geocode.QueryAsync(new GeocodingRequest { Address = "a" });
+
+            Assert.That(captured, Is.Not.Null);
+            Assert.That(System.Text.Encoding.UTF8.GetString(captured!), Is.EqualTo(OkGeocodingJson));
+        }
+
+        [Test]
+        public async Task TwoClients_WithDifferentKeys_DoNotCrossContaminate()
+        {
+            using var handler = new CapturingHandler(OkGeocodingJson);
+            using var http = new HttpClient(handler);
+            var clientA = new GoogleMapsClient(http, new GoogleMapsClientOptions { ApiKey = "key-a" });
+            var clientB = new GoogleMapsClient(http, new GoogleMapsClientOptions { ApiKey = "key-b" });
+
+            await clientA.Geocode.QueryAsync(new GeocodingRequest { Address = "a" });
+            var uriA = handler.LastRequestUri!;
+
+            await clientB.Geocode.QueryAsync(new GeocodingRequest { Address = "b" });
+            var uriB = handler.LastRequestUri!;
+
+            Assert.That(uriA.Query, Does.Contain("key=key-a"));
+            Assert.That(uriB.Query, Does.Contain("key=key-b"));
+        }
+
+        [Test]
+        public void QueryAsync_CancelledToken_Throws()
+        {
+            using var handler = new CapturingHandler(OkGeocodingJson);
+            using var http = new HttpClient(handler);
+            var client = new GoogleMapsClient(http, new GoogleMapsClientOptions { ApiKey = "k" });
+
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            Assert.ThrowsAsync<TaskCanceledException>((Func<Task>)(() =>
+                client.Geocode.QueryAsync(new GeocodingRequest { Address = "a" }, cts.Token)));
+        }
+
+        [Test]
+        public void QueryAsync_NullRequest_ThrowsArgumentNullException()
+        {
+            using var handler = new CapturingHandler(OkGeocodingJson);
+            using var http = new HttpClient(handler);
+            var client = new GoogleMapsClient(http);
+
+            Assert.ThrowsAsync<ArgumentNullException>((Func<Task>)(() => client.Geocode.QueryAsync(null!)));
+        }
+
+        [Test]
+        public void Constructor_NullHttpClient_Throws()
+        {
+            Assert.Throws<ArgumentNullException>((Action)(() => _ = new GoogleMapsClient(null!)));
+            Assert.Throws<ArgumentNullException>((Action)(() => _ = new GoogleMapsClient(null!, new GoogleMapsClientOptions())));
+        }
+
+        [Test]
+        public void Constructor_NullOptions_Throws()
+        {
+            using var http = new HttpClient(new CapturingHandler(OkGeocodingJson));
+            Assert.Throws<ArgumentNullException>((Action)(() => _ = new GoogleMapsClient(http, null!)));
+        }
+
+        [Test]
+        public void AllApiAccessors_AreNonNull()
+        {
+            using var http = new HttpClient(new CapturingHandler(OkGeocodingJson));
+            var client = new GoogleMapsClient(http);
+
+            Assert.That(client.Geocode, Is.Not.Null);
+            Assert.That(client.Directions, Is.Not.Null);
+            Assert.That(client.Elevation, Is.Not.Null);
+            Assert.That(client.Places, Is.Not.Null);
+            Assert.That(client.PlacesText, Is.Not.Null);
+            Assert.That(client.TimeZone, Is.Not.Null);
+            Assert.That(client.PlacesDetails, Is.Not.Null);
+            Assert.That(client.PlaceAutocomplete, Is.Not.Null);
+            Assert.That(client.PlacesNearBy, Is.Not.Null);
+            Assert.That(client.PlacesFind, Is.Not.Null);
+            Assert.That(client.DistanceMatrix, Is.Not.Null);
+        }
+
+        private sealed class CapturingHandler : HttpMessageHandler
+        {
+            private readonly string _responseBody;
+
+            public CapturingHandler(string responseBody)
+            {
+                _responseBody = responseBody;
+            }
+
+            public Uri? LastRequestUri { get; private set; }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                LastRequestUri = request.RequestUri;
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(_responseBody)
+                });
+            }
+        }
+    }
+}

--- a/GoogleMapsApi.Test/GoogleMapsClientTests.cs
+++ b/GoogleMapsApi.Test/GoogleMapsClientTests.cs
@@ -137,6 +137,43 @@ namespace GoogleMapsApi.Test
         }
 
         [Test]
+        public async Task QueryAsync_DoesNotMutate_CallerRequest_ApiKey()
+        {
+            using var handler = new CapturingHandler(OkGeocodingJson);
+            using var http = new HttpClient(handler);
+            var client = new GoogleMapsClient(http, new GoogleMapsClientOptions { ApiKey = "ambient-key" });
+
+            var request = new GeocodingRequest { Address = "Pier 39" };
+            Assert.That(request.ApiKey, Is.Null, "precondition: request starts with no ApiKey");
+
+            await client.Geocode.QueryAsync(request);
+
+            Assert.That(handler.LastRequestUri!.Query, Does.Contain("key=ambient-key"));
+            Assert.That(request.ApiKey, Is.Null, "caller's request must not be mutated by ambient-key fill");
+        }
+
+        [Test]
+        public async Task TwoClients_WithDifferentKeys_DoNotCrossContaminate_WhenReusingRequest()
+        {
+            using var handler = new CapturingHandler(OkGeocodingJson);
+            using var http = new HttpClient(handler);
+            var clientA = new GoogleMapsClient(http, new GoogleMapsClientOptions { ApiKey = "key-a" });
+            var clientB = new GoogleMapsClient(http, new GoogleMapsClientOptions { ApiKey = "key-b" });
+
+            var request = new GeocodingRequest { Address = "anywhere" };
+
+            await clientA.Geocode.QueryAsync(request);
+            var uriA = handler.LastRequestUri!;
+
+            await clientB.Geocode.QueryAsync(request);
+            var uriB = handler.LastRequestUri!;
+
+            Assert.That(uriA.Query, Does.Contain("key=key-a"));
+            Assert.That(uriB.Query, Does.Contain("key=key-b"));
+            Assert.That(request.ApiKey, Is.Null);
+        }
+
+        [Test]
         public void QueryAsync_CancelledToken_Throws()
         {
             using var handler = new CapturingHandler(OkGeocodingJson);

--- a/GoogleMapsApi/Engine/HttpClientEngineFacade.cs
+++ b/GoogleMapsApi/Engine/HttpClientEngineFacade.cs
@@ -41,16 +41,28 @@ namespace GoogleMapsApi.Engine
             if (request == null)
                 throw new ArgumentNullException(nameof(request));
 
-            if (string.IsNullOrEmpty(request.ApiKey) && !string.IsNullOrEmpty(_options.ApiKey))
+            // The engine builds the URI from request.ApiKey synchronously, before its first await.
+            // We briefly assign the ambient key, let the engine capture the URI, then restore the
+            // caller's original value so the request object the caller passed in is left untouched.
+            var shouldRestoreApiKey = string.IsNullOrEmpty(request.ApiKey) && !string.IsNullOrEmpty(_options.ApiKey);
+            if (shouldRestoreApiKey)
                 request.ApiKey = _options.ApiKey;
 
-            return MapsAPIGenericEngine<TRequest, TResponse>.QueryGoogleAPIAsync(
-                _httpClient,
-                request,
-                timeout,
-                token,
-                OnUriCreated,
-                OnRawResponseReceived);
+            try
+            {
+                return MapsAPIGenericEngine<TRequest, TResponse>.QueryGoogleAPIAsync(
+                    _httpClient,
+                    request,
+                    timeout,
+                    token,
+                    OnUriCreated,
+                    OnRawResponseReceived);
+            }
+            finally
+            {
+                if (shouldRestoreApiKey)
+                    request.ApiKey = null;
+            }
         }
     }
 }

--- a/GoogleMapsApi/Engine/HttpClientEngineFacade.cs
+++ b/GoogleMapsApi/Engine/HttpClientEngineFacade.cs
@@ -1,0 +1,56 @@
+using GoogleMapsApi.Entities.Common;
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GoogleMapsApi.Engine
+{
+    /// <summary>
+    /// Per-instance engine facade backed by a caller-supplied <see cref="HttpClient"/> and ambient
+    /// <see cref="GoogleMapsClientOptions"/>. Auto-fills the request's <c>ApiKey</c> from the options
+    /// when the caller has not set one. Events are scoped to this instance only.
+    /// </summary>
+    internal sealed class HttpClientEngineFacade<TRequest, TResponse> : IEngineFacade<TRequest, TResponse>
+        where TRequest : MapsBaseRequest, new()
+        where TResponse : IResponseFor<TRequest>
+    {
+        private readonly HttpClient _httpClient;
+        private readonly GoogleMapsClientOptions _options;
+
+        public HttpClientEngineFacade(HttpClient httpClient, GoogleMapsClientOptions options)
+        {
+            _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+        }
+
+        public event UriCreatedDelegate? OnUriCreated;
+        public event RawResponseReceivedDelegate? OnRawResponseReceived;
+
+        public Task<TResponse> QueryAsync(TRequest request)
+            => QueryAsync(request, TimeSpan.FromMilliseconds(Timeout.Infinite), CancellationToken.None);
+
+        public Task<TResponse> QueryAsync(TRequest request, TimeSpan timeout)
+            => QueryAsync(request, timeout, CancellationToken.None);
+
+        public Task<TResponse> QueryAsync(TRequest request, CancellationToken token)
+            => QueryAsync(request, TimeSpan.FromMilliseconds(Timeout.Infinite), token);
+
+        public Task<TResponse> QueryAsync(TRequest request, TimeSpan timeout, CancellationToken token)
+        {
+            if (request == null)
+                throw new ArgumentNullException(nameof(request));
+
+            if (string.IsNullOrEmpty(request.ApiKey) && !string.IsNullOrEmpty(_options.ApiKey))
+                request.ApiKey = _options.ApiKey;
+
+            return MapsAPIGenericEngine<TRequest, TResponse>.QueryGoogleAPIAsync(
+                _httpClient,
+                request,
+                timeout,
+                token,
+                OnUriCreated,
+                OnRawResponseReceived);
+        }
+    }
+}

--- a/GoogleMapsApi/Engine/HttpClientEngineFacade.cs
+++ b/GoogleMapsApi/Engine/HttpClientEngineFacade.cs
@@ -41,28 +41,20 @@ namespace GoogleMapsApi.Engine
             if (request == null)
                 throw new ArgumentNullException(nameof(request));
 
-            // The engine builds the URI from request.ApiKey synchronously, before its first await.
-            // We briefly assign the ambient key, let the engine capture the URI, then restore the
-            // caller's original value so the request object the caller passed in is left untouched.
-            var shouldRestoreApiKey = string.IsNullOrEmpty(request.ApiKey) && !string.IsNullOrEmpty(_options.ApiKey);
-            if (shouldRestoreApiKey)
-                request.ApiKey = _options.ApiKey;
+            var effectiveRequest = request;
+            if (string.IsNullOrEmpty(request.ApiKey) && !string.IsNullOrEmpty(_options.ApiKey))
+            {
+                effectiveRequest = (TRequest)request.CloneShallow();
+                effectiveRequest.ApiKey = _options.ApiKey;
+            }
 
-            try
-            {
-                return MapsAPIGenericEngine<TRequest, TResponse>.QueryGoogleAPIAsync(
-                    _httpClient,
-                    request,
-                    timeout,
-                    token,
-                    OnUriCreated,
-                    OnRawResponseReceived);
-            }
-            finally
-            {
-                if (shouldRestoreApiKey)
-                    request.ApiKey = null;
-            }
+            return MapsAPIGenericEngine<TRequest, TResponse>.QueryGoogleAPIAsync(
+                _httpClient,
+                effectiveRequest,
+                timeout,
+                token,
+                OnUriCreated,
+                OnRawResponseReceived);
         }
     }
 }

--- a/GoogleMapsApi/Engine/MapsAPIGenericEngine.cs
+++ b/GoogleMapsApi/Engine/MapsAPIGenericEngine.cs
@@ -24,22 +24,35 @@ namespace GoogleMapsApi.Engine
 		private static readonly HttpClient client = new HttpClient();
 		private static readonly JsonSerializerOptions jsonOptions = JsonSerializerConfiguration.CreateOptions();
 
-		protected internal static async Task<TResponse> QueryGoogleAPIAsync(TRequest request, TimeSpan timeout, CancellationToken token = default)
+		protected internal static Task<TResponse> QueryGoogleAPIAsync(TRequest request, TimeSpan timeout, CancellationToken token = default)
 		{
+			return QueryGoogleAPIAsync(client, request, timeout, token, OnUriCreated, OnRawResponseReceived);
+		}
+
+		internal static async Task<TResponse> QueryGoogleAPIAsync(
+			HttpClient httpClient,
+			TRequest request,
+			TimeSpan timeout,
+			CancellationToken token,
+			UriCreatedDelegate? onUriCreated,
+			RawResponseReceivedDelegate? onRawResponseReceived)
+		{
+			if (httpClient == null)
+				throw new ArgumentNullException(nameof(httpClient));
 			if (request == null)
 				throw new ArgumentNullException(nameof(request));
 
-            var requestUri = request.GetUri();
-            var uri = OnUriCreated?.Invoke(requestUri) ?? requestUri;
-            
-		    var responseContent = await GetHttpResponseAsync(uri, timeout, token).ConfigureAwait(false);
+			var requestUri = request.GetUri();
+			var uri = onUriCreated?.Invoke(requestUri) ?? requestUri;
 
-            OnRawResponseReceived?.Invoke(Encoding.UTF8.GetBytes(responseContent));
+			var responseContent = await GetHttpResponseAsync(httpClient, uri, timeout, token).ConfigureAwait(false);
 
-            return JsonSerializer.Deserialize<TResponse>(responseContent, jsonOptions)!;
+			onRawResponseReceived?.Invoke(Encoding.UTF8.GetBytes(responseContent));
+
+			return JsonSerializer.Deserialize<TResponse>(responseContent, jsonOptions)!;
 		}
 
-		private static async Task<string> GetHttpResponseAsync(Uri uri, TimeSpan timeout, CancellationToken cancellationToken)
+		private static async Task<string> GetHttpResponseAsync(HttpClient httpClient, Uri uri, TimeSpan timeout, CancellationToken cancellationToken)
 		{
 			using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 			if (timeout != TimeSpan.FromMilliseconds(-1))
@@ -47,7 +60,7 @@ namespace GoogleMapsApi.Engine
 			
 			try
 			{
-				using var response = await client.GetAsync(uri, cts.Token).ConfigureAwait(false);
+				using var response = await httpClient.GetAsync(uri, cts.Token).ConfigureAwait(false);
 				await HandleHttpResponse(response, timeout).ConfigureAwait(false);
 				return await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 			}

--- a/GoogleMapsApi/Entities/Common/MapsBaseRequest.cs
+++ b/GoogleMapsApi/Entities/Common/MapsBaseRequest.cs
@@ -93,5 +93,7 @@ namespace GoogleMapsApi.Entities.Common
             var queryString = GetQueryStringParameters().GetQueryStringPostfix();
             return new Uri(scheme + BaseUrl + "json?" + queryString);
         }
+
+        internal MapsBaseRequest CloneShallow() => (MapsBaseRequest)MemberwiseClone();
     }
 }

--- a/GoogleMapsApi/GoogleMapsClient.cs
+++ b/GoogleMapsApi/GoogleMapsClient.cs
@@ -1,0 +1,105 @@
+using GoogleMapsApi.Engine;
+using GoogleMapsApi.Entities.Directions.Request;
+using GoogleMapsApi.Entities.Directions.Response;
+using GoogleMapsApi.Entities.DistanceMatrix.Request;
+using GoogleMapsApi.Entities.DistanceMatrix.Response;
+using GoogleMapsApi.Entities.Elevation.Request;
+using GoogleMapsApi.Entities.Elevation.Response;
+using GoogleMapsApi.Entities.Geocoding.Request;
+using GoogleMapsApi.Entities.Geocoding.Response;
+using GoogleMapsApi.Entities.PlaceAutocomplete.Request;
+using GoogleMapsApi.Entities.PlaceAutocomplete.Response;
+using GoogleMapsApi.Entities.Places.Request;
+using GoogleMapsApi.Entities.Places.Response;
+using GoogleMapsApi.Entities.PlacesDetails.Request;
+using GoogleMapsApi.Entities.PlacesDetails.Response;
+using GoogleMapsApi.Entities.PlacesFind.Request;
+using GoogleMapsApi.Entities.PlacesFind.Response;
+using GoogleMapsApi.Entities.PlacesNearBy.Request;
+using GoogleMapsApi.Entities.PlacesNearBy.Response;
+using GoogleMapsApi.Entities.PlacesText.Request;
+using GoogleMapsApi.Entities.PlacesText.Response;
+using GoogleMapsApi.Entities.TimeZone.Request;
+using GoogleMapsApi.Entities.TimeZone.Response;
+using System;
+using System.Net.Http;
+
+namespace GoogleMapsApi
+{
+    /// <summary>
+    /// Instance-based Google Maps client driven by an injected <see cref="HttpClient"/>.
+    /// Prefer this over the static <see cref="GoogleMaps"/> facade in modern .NET projects —
+    /// it is friendly to <c>IHttpClientFactory</c>, supports per-instance event handlers, and
+    /// avoids the testability problems of static state.
+    /// </summary>
+    /// <remarks>
+    /// The static <see cref="GoogleMaps"/> facade continues to work unchanged for backward compatibility.
+    /// </remarks>
+    public sealed class GoogleMapsClient : IGoogleMapsClient
+    {
+        /// <summary>
+        /// Creates a client that uses the supplied <see cref="HttpClient"/> with default options
+        /// (no ambient API key — callers must set <c>ApiKey</c> on each request).
+        /// </summary>
+        public GoogleMapsClient(HttpClient httpClient)
+            : this(httpClient, new GoogleMapsClientOptions())
+        {
+        }
+
+        /// <summary>
+        /// Creates a client that uses the supplied <see cref="HttpClient"/> and options.
+        /// </summary>
+        /// <param name="httpClient">The HTTP client used for every API call. Typically obtained from <c>IHttpClientFactory</c>.</param>
+        /// <param name="options">Ambient options applied to every request (e.g. default API key).</param>
+        public GoogleMapsClient(HttpClient httpClient, GoogleMapsClientOptions options)
+        {
+            if (httpClient == null) throw new ArgumentNullException(nameof(httpClient));
+            if (options == null) throw new ArgumentNullException(nameof(options));
+
+            Geocode = new HttpClientEngineFacade<GeocodingRequest, GeocodingResponse>(httpClient, options);
+            Directions = new HttpClientEngineFacade<DirectionsRequest, DirectionsResponse>(httpClient, options);
+            Elevation = new HttpClientEngineFacade<ElevationRequest, ElevationResponse>(httpClient, options);
+            Places = new HttpClientEngineFacade<PlacesRequest, PlacesResponse>(httpClient, options);
+            PlacesText = new HttpClientEngineFacade<PlacesTextRequest, PlacesTextResponse>(httpClient, options);
+            TimeZone = new HttpClientEngineFacade<TimeZoneRequest, TimeZoneResponse>(httpClient, options);
+            PlacesDetails = new HttpClientEngineFacade<PlacesDetailsRequest, PlacesDetailsResponse>(httpClient, options);
+            PlaceAutocomplete = new HttpClientEngineFacade<PlaceAutocompleteRequest, PlaceAutocompleteResponse>(httpClient, options);
+            PlacesNearBy = new HttpClientEngineFacade<PlacesNearByRequest, PlacesNearByResponse>(httpClient, options);
+            PlacesFind = new HttpClientEngineFacade<PlacesFindRequest, PlacesFindResponse>(httpClient, options);
+            DistanceMatrix = new HttpClientEngineFacade<DistanceMatrixRequest, DistanceMatrixResponse>(httpClient, options);
+        }
+
+        /// <inheritdoc/>
+        public IEngineFacade<GeocodingRequest, GeocodingResponse> Geocode { get; }
+
+        /// <inheritdoc/>
+        public IEngineFacade<DirectionsRequest, DirectionsResponse> Directions { get; }
+
+        /// <inheritdoc/>
+        public IEngineFacade<ElevationRequest, ElevationResponse> Elevation { get; }
+
+        /// <inheritdoc/>
+        public IEngineFacade<PlacesRequest, PlacesResponse> Places { get; }
+
+        /// <inheritdoc/>
+        public IEngineFacade<PlacesTextRequest, PlacesTextResponse> PlacesText { get; }
+
+        /// <inheritdoc/>
+        public IEngineFacade<TimeZoneRequest, TimeZoneResponse> TimeZone { get; }
+
+        /// <inheritdoc/>
+        public IEngineFacade<PlacesDetailsRequest, PlacesDetailsResponse> PlacesDetails { get; }
+
+        /// <inheritdoc/>
+        public IEngineFacade<PlaceAutocompleteRequest, PlaceAutocompleteResponse> PlaceAutocomplete { get; }
+
+        /// <inheritdoc/>
+        public IEngineFacade<PlacesNearByRequest, PlacesNearByResponse> PlacesNearBy { get; }
+
+        /// <inheritdoc/>
+        public IEngineFacade<PlacesFindRequest, PlacesFindResponse> PlacesFind { get; }
+
+        /// <inheritdoc/>
+        public IEngineFacade<DistanceMatrixRequest, DistanceMatrixResponse> DistanceMatrix { get; }
+    }
+}

--- a/GoogleMapsApi/GoogleMapsClientOptions.cs
+++ b/GoogleMapsApi/GoogleMapsClientOptions.cs
@@ -1,0 +1,14 @@
+namespace GoogleMapsApi
+{
+    /// <summary>
+    /// Configures a <see cref="GoogleMapsClient"/> instance.
+    /// </summary>
+    public sealed class GoogleMapsClientOptions
+    {
+        /// <summary>
+        /// Default API key used for every request that does not set its own <c>ApiKey</c>.
+        /// If a request explicitly sets its own <c>ApiKey</c>, that value is preserved.
+        /// </summary>
+        public string? ApiKey { get; set; }
+    }
+}

--- a/GoogleMapsApi/IGoogleMapsClient.cs
+++ b/GoogleMapsApi/IGoogleMapsClient.cs
@@ -1,0 +1,66 @@
+using GoogleMapsApi.Entities.Directions.Request;
+using GoogleMapsApi.Entities.Directions.Response;
+using GoogleMapsApi.Entities.DistanceMatrix.Request;
+using GoogleMapsApi.Entities.DistanceMatrix.Response;
+using GoogleMapsApi.Entities.Elevation.Request;
+using GoogleMapsApi.Entities.Elevation.Response;
+using GoogleMapsApi.Entities.Geocoding.Request;
+using GoogleMapsApi.Entities.Geocoding.Response;
+using GoogleMapsApi.Entities.PlaceAutocomplete.Request;
+using GoogleMapsApi.Entities.PlaceAutocomplete.Response;
+using GoogleMapsApi.Entities.Places.Request;
+using GoogleMapsApi.Entities.Places.Response;
+using GoogleMapsApi.Entities.PlacesDetails.Request;
+using GoogleMapsApi.Entities.PlacesDetails.Response;
+using GoogleMapsApi.Entities.PlacesFind.Request;
+using GoogleMapsApi.Entities.PlacesFind.Response;
+using GoogleMapsApi.Entities.PlacesNearBy.Request;
+using GoogleMapsApi.Entities.PlacesNearBy.Response;
+using GoogleMapsApi.Entities.PlacesText.Request;
+using GoogleMapsApi.Entities.PlacesText.Response;
+using GoogleMapsApi.Entities.TimeZone.Request;
+using GoogleMapsApi.Entities.TimeZone.Response;
+
+namespace GoogleMapsApi
+{
+    /// <summary>
+    /// Instance-based entry point exposing every supported Google Maps Web Service.
+    /// Designed for dependency injection scenarios where an <see cref="System.Net.Http.HttpClient"/>
+    /// is supplied (typically via <c>IHttpClientFactory</c>) and a single API key is shared across calls.
+    /// </summary>
+    public interface IGoogleMapsClient
+    {
+        /// <summary>Perform geocoding operations.</summary>
+        IEngineFacade<GeocodingRequest, GeocodingResponse> Geocode { get; }
+
+        /// <summary>Perform directions operations.</summary>
+        IEngineFacade<DirectionsRequest, DirectionsResponse> Directions { get; }
+
+        /// <summary>Perform elevation operations.</summary>
+        IEngineFacade<ElevationRequest, ElevationResponse> Elevation { get; }
+
+        /// <summary>Perform places operations.</summary>
+        IEngineFacade<PlacesRequest, PlacesResponse> Places { get; }
+
+        /// <summary>Perform places text search operations.</summary>
+        IEngineFacade<PlacesTextRequest, PlacesTextResponse> PlacesText { get; }
+
+        /// <summary>Retrieve time zone data for a coordinate.</summary>
+        IEngineFacade<TimeZoneRequest, TimeZoneResponse> TimeZone { get; }
+
+        /// <summary>Perform places details operations.</summary>
+        IEngineFacade<PlacesDetailsRequest, PlacesDetailsResponse> PlacesDetails { get; }
+
+        /// <summary>Perform place autocomplete operations.</summary>
+        IEngineFacade<PlaceAutocompleteRequest, PlaceAutocompleteResponse> PlaceAutocomplete { get; }
+
+        /// <summary>Perform near-by places operations.</summary>
+        IEngineFacade<PlacesNearByRequest, PlacesNearByResponse> PlacesNearBy { get; }
+
+        /// <summary>Perform find-place searches.</summary>
+        IEngineFacade<PlacesFindRequest, PlacesFindResponse> PlacesFind { get; }
+
+        /// <summary>Retrieve duration and distance values based on the recommended route between start and end points.</summary>
+        IEngineFacade<DistanceMatrixRequest, DistanceMatrixResponse> DistanceMatrix { get; }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -120,6 +120,39 @@ string url = staticMapGenerator.GenerateStaticMapURL(new StaticMapRequest(new Lo
 Console.WriteLine("Map with path: " + url);
 ```
 
+### Instance-based client (`IHttpClientFactory`-friendly)
+
+In addition to the static `GoogleMaps` facade, you can use the instance-based `GoogleMapsClient` that accepts an injected `HttpClient`. This is the recommended pattern for ASP.NET Core, minimal APIs, and worker services — it plays nicely with `IHttpClientFactory`, per-instance event handlers, and an ambient API key that is auto-filled into requests when not set explicitly.
+
+``` C#
+// Register once at startup
+services.AddHttpClient<IGoogleMapsClient, GoogleMapsClient>();
+services.AddSingleton(new GoogleMapsClientOptions { ApiKey = "your-google-maps-api-key" });
+
+// Inject and use
+public class GeocodingService(IGoogleMapsClient maps)
+{
+    public Task<GeocodingResponse> LookupAsync(string address)
+        => maps.Geocode.QueryAsync(new GeocodingRequest { Address = address });
+}
+```
+
+Without DI:
+
+``` C#
+using var http = new HttpClient();
+var maps = new GoogleMapsClient(http, new GoogleMapsClientOptions { ApiKey = "your-key" });
+
+var result = await maps.Directions.QueryAsync(new DirectionsRequest { Origin = "NYC", Destination = "DC" });
+```
+
+Per-instance events (no global state):
+
+``` C#
+maps.Geocode.OnUriCreated += uri => uri;          // inspect/rewrite outgoing URI
+maps.Geocode.OnRawResponseReceived += bytes => { }; // tap raw JSON
+```
+
 ### Synchronous Usage
 
 Synchronous calls are also supported via `Query` (use `QueryAsync` whenever possible):


### PR DESCRIPTION
## Summary

Adds an instance-based **`GoogleMapsClient`** (and its `IGoogleMapsClient` interface) backed by an injected `HttpClient`. The static `GoogleMaps` facade continues to work unchanged for backward compatibility.

This lands the *IHttpClientFactory + instance API* item from [`improvement-plan.html`](https://github.com/maximn/google-maps/blob/master/.planning/improvement-plan.html) (P1). It is the prerequisite for the follow-up PR shipping the `GoogleMapsApi.Extensions.DependencyInjection` sibling package.

## What changed

- `MapsAPIGenericEngine.QueryGoogleAPIAsync` gets a stateless overload accepting an `HttpClient` + per-call event delegates. The existing static method delegates to it, preserving all current behavior (static `HttpClient`, static events).
- `HttpClientEngineFacade<TReq, TResp>` is an internal `IEngineFacade` implementation that drives one engine per `(TReq, TResp)` with the injected `HttpClient`, exposes **per-instance** `OnUriCreated` / `OnRawResponseReceived` events, and auto-fills `request.ApiKey` from ambient `GoogleMapsClientOptions` when the caller has not set one.
- `GoogleMapsClient(httpClient)` and `GoogleMapsClient(httpClient, options)` constructors. All 11 API surfaces mirror the static facade (`Geocode`, `Directions`, `Elevation`, `Places`, `PlacesText`, `TimeZone`, `PlacesDetails`, `PlaceAutocomplete`, `PlacesNearBy`, `PlacesFind`, `DistanceMatrix`).
- New hermetic test file using a custom `HttpMessageHandler` — no live network calls.

## Why this matters

Modern .NET projects expect to register a typed client and inject it. With this in place, the follow-up DI package can do:

```csharp
services.AddHttpClient<IGoogleMapsClient, GoogleMapsClient>();
```

…and consumers get proper `IHttpClientFactory` semantics (DNS refresh, socket reuse, per-call DelegatingHandlers, etc.) for free.

## Usage

```csharp
var http = new HttpClient(); // or from IHttpClientFactory
var maps = new GoogleMapsClient(http, new GoogleMapsClientOptions { ApiKey = "YOUR_KEY" });

var resp = await maps.Geocode.QueryAsync(new GeocodingRequest { Address = "1600 Amphitheatre Pkwy" });
```

Per-request override still works — explicit `request.ApiKey` is preserved if set.

## Test plan

- [x] Hermetic unit tests with `HttpMessageHandler` mock (13 cases — round-trip, ambient/explicit API key precedence, event scoping, URI rewriting, raw-bytes capture, cancellation, null guards, accessor sanity)
- [x] Static `GoogleMaps` facade still functions unchanged (back-compat smoke)
- [x] Builds clean on `netstandard2.0`, `net6.0`, `net8.0` locally; CI will validate `net10.0` + `net481` + `net462`
- [ ] CI green