### PR TITLE
🔒 ci: pin all GitHub Actions to commit SHA + add Renovate digest preset

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,16 +33,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Setup .NET
         if: matrix.build-mode == 'manual'
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7  # v5.2.0
         with:
           dotnet-version: 8.0.x
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa  # v4.36.0
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -54,6 +54,6 @@ jobs:
           dotnet build GoogleMapsApi/GoogleMapsApi.csproj --framework net8.0 --no-restore --configuration Release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa  # v4.36.0
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,10 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7  # v5.2.0
         with:
           dotnet-version: |
             8.0.x
@@ -44,10 +44,10 @@ jobs:
         run: docfx docs/docfx.json
 
       - name: Setup Pages
-        uses: actions/configure-pages@v6
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d  # v6.0.0
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3.0.1
         with:
           path: docs/_site
 
@@ -60,4 +60,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  # v5.0.0

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -17,11 +17,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         ref: ${{ github.event.pull_request.head.sha || github.sha }}
     - name: Setup .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7  # v5.2.0
       with:
         dotnet-version: |
           6.0.x
@@ -41,6 +41,6 @@ jobs:
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
     - name: TestGlance
       if: always()
-      uses: testglance/action@v1
+      uses: testglance/action@de3dd79416e362b938d22d66eeb4e5c89befad07  # v1
       with:
         github-token: ${{ github.token }}

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -23,10 +23,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7  # v5.2.0
         with:
           dotnet-version: |
             6.0.x
@@ -56,7 +56,7 @@ jobs:
 
       - name: Upload nupkg artifact
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: nupkg-${{ steps.get_version.outputs.VERSION }}
           path: '*.nupkg'

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -22,25 +22,25 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@v2.4.3
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a  # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa  # v4.36.0
         with:
           sarif_file: results.sarif

--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,8 @@
   "extends": [
     "config:recommended",
     ":dependencyDashboard",
-    ":semanticCommits"
+    ":semanticCommits",
+    "helpers:pinGitHubActionDigests"
   ],
   "minimumReleaseAge": "3 days",
   "packageRules": [


### PR DESCRIPTION
## Summary

Addresses the OpenSSF Scorecard **Pinned-Dependencies** finding (Medium weight, score 0 — 0/17 GitHub-owned, 0/2 third-party actions pinned).

Every `uses:` reference in `.github/workflows/*.yml` is now pinned to a full 40-char commit SHA with a `# vX.Y.Z` comment for human readability and Renovate tracking:

- `actions/checkout` → `de0fac2e…` (v6.0.2)
- `actions/setup-dotnet` → `c2fa09f4…` (v5.2.0)
- `actions/upload-artifact` → `043fb46d…` (v7.0.1)
- `actions/configure-pages` → `45bfe019…` (v6.0.0)
- `actions/upload-pages-artifact` → `56afc609…` (v3.0.1)
- `actions/deploy-pages` → `cd2ce8fc…` (v5.0.0)
- `github/codeql-action/{init,analyze,upload-sarif}` → `7211b7c8…` (v4.36.0)
- `ossf/scorecard-action` → `4eaacf05…` (v2.4.3)
- `testglance/action` → `de3dd794…` (v1)

`renovate.json` now extends `helpers:pinGitHubActionDigests` so future updates keep digests pinned and auto-bump the version comment.

## Why

A floating tag (e.g. `@v6`) is mutable — a compromised action publisher can rewrite it and ship malicious code into our CI in a context with secrets (e.g. `NUGET_API_KEY`, `GOOGLE_API_KEY`). Pinning by SHA makes references immutable; reviewers see the digest in `git diff` whenever an action is updated.

## Trade-off

More dependency-update PR noise from Renovate now that it tracks digests too. Mitigated by the existing rule in `renovate.json`:

```json
{
  "matchManagers": ["github-actions"],
  "matchUpdateTypes": ["minor", "patch", "digest", "pin"],
  "automerge": true,
  "platformAutomerge": true
}
```

Non-major Action updates (including pure digest bumps) auto-merge, so the cost is bounded.

## Test plan

- [ ] Verify a sample workflow run (e.g. `.NET` on this PR) passes — the resolved SHAs must produce the same behavior as the floating tags.
- [ ] After merge, verify Renovate opens sane PRs (digest bumps with the version comment updated).
- [ ] Re-run OpenSSF Scorecard and confirm Pinned-Dependencies score increases.