### PR TITLE
fix(ci): handle pre-existing GitHub Release in nuget publish

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -76,14 +76,18 @@ jobs:
         if: github.event_name == 'push' || inputs.dry_run == false
         run: dotnet nuget push *.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
 
-      - name: Create GitHub Release
-        if: github.event_name == 'push'
+      - name: Create or update GitHub Release
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false)
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ steps.get_version.outputs.VERSION }}
           ATTESTATION_BUNDLE: ${{ steps.attest.outputs.bundle-path }}
         run: |
-          gh release create "v${VERSION}" \
-            --title "v${VERSION}" \
-            --generate-notes \
-            ./*.nupkg "${ATTESTATION_BUNDLE}"
+          if gh release view "v${VERSION}" >/dev/null 2>&1; then
+            gh release upload "v${VERSION}" ./*.nupkg "${ATTESTATION_BUNDLE}" --clobber
+          else
+            gh release create "v${VERSION}" \
+              --title "v${VERSION}" \
+              --generate-notes \
+              ./*.nupkg "${ATTESTATION_BUNDLE}"
+          fi


### PR DESCRIPTION
## Summary

The v1.4.8 publish [failed](https://github.com/maximn/google-maps/actions/runs/26372603948/job/77627302806) at the new `Create GitHub Release` step (added in #235) because `release.sh` creates the GitHub Release locally **before** pushing the tag, so by the time the workflow's `gh release create` runs, the release already exists.

This PR switches the step to a **create-or-upload** pattern:
- If the release already exists → upload nupkg + attestation with `--clobber`
- Otherwise → create it (original behavior)

Also extends the step's gating to run on `workflow_dispatch` (non-dry-run), so missing assets can be reattached retroactively without a re-tag.

## Verification

- Triggered `workflow_dispatch` for v1.4.8 from this branch → succeeded
- v1.4.8 release now has the missing `.nupkg` and `attestation.json` attached: https://github.com/maximn/google-maps/releases/tag/v1.4.8

## Test plan

- [x] `workflow_dispatch` against existing release attaches assets via `gh release upload --clobber`
- [x] Next tag push (v1.4.9+) follows the same path and succeeds when `release.sh` pre-creates the release