### PR TITLE
feat(engine): allow POST requests via virtual GetRequestBody hook

### DIFF
--- a/GoogleMapsApi.Test/EnginePostSupportTests.cs
+++ b/GoogleMapsApi.Test/EnginePostSupportTests.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using GoogleMapsApi.Engine;
+using GoogleMapsApi.Entities.Common;
+using GoogleMapsApi.Entities.Geocoding.Request;
+using GoogleMapsApi.Entities.Geocoding.Response;
+using NUnit.Framework;
+
+namespace GoogleMapsApi.Test
+{
+    [TestFixture]
+    public class EnginePostSupportTests
+    {
+        [Test]
+        public async Task RequestWithNullBody_UsesGet_GeocodingRegression()
+        {
+            var handler = new RecordingHandler("{\"status\":\"ZERO_RESULTS\",\"results\":[]}");
+            using var http = new HttpClient(handler);
+
+            var request = new GeocodingRequest { Address = "anywhere", ApiKey = "k" };
+
+            await MapsAPIGenericEngine<GeocodingRequest, GeocodingResponse>.QueryGoogleAPIAsync(
+                http, request, TimeSpan.FromMilliseconds(-1), CancellationToken.None, null, null);
+
+            Assert.That(handler.LastMethod, Is.EqualTo(HttpMethod.Get));
+            Assert.That(handler.LastRequestBody, Is.Null);
+        }
+
+        [Test]
+        public async Task RequestWithBody_UsesPost_AndSendsJsonContent()
+        {
+            var handler = new RecordingHandler("{\"ok\":true}");
+            using var http = new HttpClient(handler);
+
+            var request = new PostProbeRequest { Payload = "{\"hello\":\"world\"}", ApiKey = "k" };
+
+            await MapsAPIGenericEngine<PostProbeRequest, PostProbeResponse>.QueryGoogleAPIAsync(
+                http, request, TimeSpan.FromMilliseconds(-1), CancellationToken.None, null, null);
+
+            Assert.That(handler.LastMethod, Is.EqualTo(HttpMethod.Post));
+            Assert.That(handler.LastRequestBody, Is.EqualTo("{\"hello\":\"world\"}"));
+            Assert.That(handler.LastContentType, Is.EqualTo("application/json"));
+        }
+
+        private sealed class RecordingHandler : HttpMessageHandler
+        {
+            private readonly string _responseJson;
+
+            public RecordingHandler(string responseJson) { _responseJson = responseJson; }
+
+            public HttpMethod? LastMethod { get; private set; }
+            public string? LastRequestBody { get; private set; }
+            public string? LastContentType { get; private set; }
+
+            protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                LastMethod = request.Method;
+                if (request.Content != null)
+                {
+                    LastRequestBody = await request.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    LastContentType = request.Content.Headers.ContentType?.MediaType;
+                }
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(_responseJson, Encoding.UTF8, "application/json")
+                };
+            }
+        }
+
+        public sealed class PostProbeRequest : MapsBaseRequest
+        {
+            public string Payload { get; set; } = "{}";
+
+            protected internal override HttpContent? GetRequestBody()
+                => new StringContent(Payload, Encoding.UTF8, "application/json");
+        }
+
+        public sealed class PostProbeResponse : IResponseFor<PostProbeRequest>
+        {
+            public bool Ok { get; set; }
+        }
+    }
+}

--- a/GoogleMapsApi/Engine/MapsAPIGenericEngine.cs
+++ b/GoogleMapsApi/Engine/MapsAPIGenericEngine.cs
@@ -45,22 +45,33 @@ namespace GoogleMapsApi.Engine
 			var requestUri = request.GetUri();
 			var uri = onUriCreated?.Invoke(requestUri) ?? requestUri;
 
-			var responseContent = await GetHttpResponseAsync(httpClient, uri, timeout, token).ConfigureAwait(false);
+			var body = request.GetRequestBody();
+			string responseContent;
+			try
+			{
+				responseContent = await GetHttpResponseAsync(httpClient, uri, body, timeout, token).ConfigureAwait(false);
+			}
+			finally
+			{
+				body?.Dispose();
+			}
 
 			onRawResponseReceived?.Invoke(Encoding.UTF8.GetBytes(responseContent));
 
 			return JsonSerializer.Deserialize<TResponse>(responseContent, jsonOptions)!;
 		}
 
-		private static async Task<string> GetHttpResponseAsync(HttpClient httpClient, Uri uri, TimeSpan timeout, CancellationToken cancellationToken)
+		private static async Task<string> GetHttpResponseAsync(HttpClient httpClient, Uri uri, HttpContent? body, TimeSpan timeout, CancellationToken cancellationToken)
 		{
 			using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 			if (timeout != TimeSpan.FromMilliseconds(-1))
 				cts.CancelAfter(timeout);
-			
+
 			try
 			{
-				using var response = await httpClient.GetAsync(uri, cts.Token).ConfigureAwait(false);
+				using var response = body == null
+					? await httpClient.GetAsync(uri, cts.Token).ConfigureAwait(false)
+					: await httpClient.PostAsync(uri, body, cts.Token).ConfigureAwait(false);
 				await HandleHttpResponse(response, timeout).ConfigureAwait(false);
 				return await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 			}

--- a/GoogleMapsApi/Entities/Common/MapsBaseRequest.cs
+++ b/GoogleMapsApi/Entities/Common/MapsBaseRequest.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Net;
+using System.Net.Http;
 using System.Linq;
 
 namespace GoogleMapsApi.Entities.Common
@@ -93,6 +94,15 @@ namespace GoogleMapsApi.Entities.Common
             var queryString = GetQueryStringParameters().GetQueryStringPostfix();
             return new Uri(scheme + BaseUrl + "json?" + queryString);
         }
+
+        /// <summary>
+        /// Builds the body to send with this request, or <c>null</c> for endpoints that use GET with
+        /// query-string parameters only. Derived requests that target POST-based endpoints (for example,
+        /// Address Validation) override this to return a JSON <see cref="HttpContent"/>; when the engine
+        /// sees a non-null body it issues a POST instead of a GET.
+        /// </summary>
+        /// <returns>The HTTP content to send, or <c>null</c> for a GET request.</returns>
+        protected internal virtual HttpContent? GetRequestBody() => null;
 
         internal MapsBaseRequest CloneShallow() => (MapsBaseRequest)MemberwiseClone();
     }

--- a/GoogleMapsApi/GoogleMapsApi.csproj
+++ b/GoogleMapsApi/GoogleMapsApi.csproj
@@ -35,6 +35,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="GoogleMapsApi.Test" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="All"/>
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Adds POST request support to `MapsAPIGenericEngine` via a new virtual hook
`MapsBaseRequest.GetRequestBody()` returning `HttpContent?` (null by default).
When a request returns non-null content, the engine issues a POST with that
body; otherwise it continues to issue the existing GET against the URL
produced by `GetUri()`.

This is groundwork for upcoming POST-based APIs — Address Validation
(stacked PR follows), and later Routes API + Places API (New). No public
API change for existing callers; the GET path through every shipping API
is bytes-identical.

### Change surface

- `MapsBaseRequest.GetRequestBody()` — new `protected internal virtual` hook
- `MapsAPIGenericEngine.QueryGoogleAPIAsync` — branches `PostAsync` vs `GetAsync`
  based on body presence; disposes the body in a `finally` to guard against
  exceptions before the request is dispatched
- `InternalsVisibleTo("GoogleMapsApi.Test")` — enables white-box tests of
  the internal engine entry point

### Tests

Two new unit tests under `EnginePostSupportTests.cs`, both driven by a
fake `HttpMessageHandler` (no network):

- `RequestWithNullBody_UsesGet_GeocodingRegression` — confirms the GET
  path for existing APIs is unchanged
- `RequestWithBody_UsesPost_AndSendsJsonContent` — confirms POST is used
  when a body is provided, content-type is `application/json`, and the
  body bytes round-trip

## Test plan

- [x] `dotnet build` clean across all 6 TFMs (net462, net481, netstandard2.0, net6.0, net8.0, net10.0)
- [x] All 125 existing non-integration unit tests still pass on net10.0 and net8.0
- [x] 2 new engine tests pass
- [ ] Live Geocoding integration test should still pass (requires GOOGLE_API_KEY)