### PR TITLE
feat(routes): add Routes API support (modern Directions replacement)

### DIFF
--- a/GoogleMapsApi.Test/IntegrationTests/RoutesTests.cs
+++ b/GoogleMapsApi.Test/IntegrationTests/RoutesTests.cs
@@ -1,0 +1,103 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using GoogleMapsApi.Entities.Routes.Request;
+using NUnit.Framework;
+
+namespace GoogleMapsApi.Test.IntegrationTests
+{
+    [TestFixture]
+    public class RoutesTests : BaseTestIntegration
+    {
+        [Test]
+        public async Task ComputeRoutes_SimpleAddressToAddress_ReturnsRoute()
+        {
+            var request = new RoutesRequest
+            {
+                ApiKey = ApiKey,
+                Origin = Waypoint.FromAddress("285 Bedford Ave, Brooklyn, NY, USA"),
+                Destination = Waypoint.FromAddress("185 Broadway Ave, Manhattan, NY, USA"),
+            };
+
+            var response = await GoogleMaps.Routes.QueryAsync(request);
+
+            Assert.That(response.Routes, Is.Not.Null.And.Not.Empty);
+            var route = response.Routes![0];
+            Assert.That(route.DistanceMeters, Is.Not.Null.And.GreaterThan(0));
+            Assert.That(route.DurationSeconds, Is.Not.Null.And.GreaterThan(0));
+            Assert.That(route.Polyline!.EncodedPolyline, Is.Not.Null.And.Not.Empty);
+            Assert.That(route.Polyline.DecodedPoints, Is.Not.Empty);
+        }
+
+        [Test]
+        public async Task ComputeRoutes_WithIntermediateWaypoint_ReturnsMultipleLegs()
+        {
+            var request = new RoutesRequest
+            {
+                ApiKey = ApiKey,
+                Origin = Waypoint.FromAddress("New York, NY, USA"),
+                Destination = Waypoint.FromAddress("Miami, FL, USA"),
+                Intermediates = new List<Waypoint> { Waypoint.FromAddress("Philadelphia, PA, USA") },
+            };
+
+            var response = await GoogleMaps.Routes.QueryAsync(request);
+
+            Assert.That(response.Routes, Is.Not.Null.And.Not.Empty);
+            Assert.That(response.Routes![0].Legs, Has.Count.EqualTo(2),
+                "One intermediate waypoint should produce two legs.");
+        }
+
+        [Test]
+        public async Task ComputeRoutes_TrafficAware_ReturnsRoute()
+        {
+            var request = new RoutesRequest
+            {
+                ApiKey = ApiKey,
+                Origin = Waypoint.FromAddress("Brooklyn, NY, USA"),
+                Destination = Waypoint.FromAddress("Newark, NJ, USA"),
+                RoutingPreference = RoutingPreference.TrafficAware,
+            };
+
+            var response = await GoogleMaps.Routes.QueryAsync(request);
+
+            Assert.That(response.Routes, Is.Not.Null.And.Not.Empty);
+            Assert.That(response.Routes![0].DurationSeconds, Is.Not.Null.And.GreaterThan(0));
+        }
+
+        [Test]
+        public async Task ComputeRoutes_AlternativeRoutes_ReturnsMoreThanOne()
+        {
+            var request = new RoutesRequest
+            {
+                ApiKey = ApiKey,
+                Origin = Waypoint.FromAddress("Brooklyn, NY, USA"),
+                Destination = Waypoint.FromAddress("Manhattan, NY, USA"),
+                ComputeAlternativeRoutes = true,
+            };
+
+            var response = await GoogleMaps.Routes.QueryAsync(request);
+
+            Assert.That(response.Routes, Is.Not.Null.And.Not.Empty);
+            // Routes API returns 1-3 routes when alternatives are enabled; can't strictly require >1
+            // because some O/D pairs only have one viable route. Just confirm the request was accepted.
+            Assert.That(response.Routes!.All(r => r.DistanceMeters > 0), Is.True);
+        }
+
+        [Test]
+        public async Task ComputeRoutes_AvoidTolls_ReturnsRoute()
+        {
+            var request = new RoutesRequest
+            {
+                ApiKey = ApiKey,
+                Origin = Waypoint.FromAddress("New York, NY, USA"),
+                Destination = Waypoint.FromAddress("Boston, MA, USA"),
+                RouteModifiers = new RouteModifiers { AvoidTolls = true },
+            };
+
+            var response = await GoogleMaps.Routes.QueryAsync(request);
+
+            Assert.That(response.Routes, Is.Not.Null.And.Not.Empty);
+            Assert.That(response.Routes![0].DistanceMeters, Is.Not.Null.And.GreaterThan(0));
+        }
+    }
+}

--- a/GoogleMapsApi.Test/RoutesUnitTests.cs
+++ b/GoogleMapsApi.Test/RoutesUnitTests.cs
@@ -1,0 +1,246 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using GoogleMapsApi.Engine;
+using GoogleMapsApi.Entities.Routes.Request;
+using GoogleMapsApi.Entities.Routes.Response;
+using NUnit.Framework;
+
+namespace GoogleMapsApi.Test
+{
+    [TestFixture]
+    public class RoutesUnitTests
+    {
+        [Test]
+        public void GetUri_TargetsRoutesHost_WithKeyAndFieldsInQueryString()
+        {
+            var request = new RoutesRequest
+            {
+                ApiKey = "abc 123",
+                Origin = Waypoint.FromAddress("a"),
+                Destination = Waypoint.FromAddress("b"),
+                FieldMask = "routes.duration,routes.distanceMeters",
+            };
+
+            var uri = request.GetUri();
+
+            Assert.That(uri.Host, Is.EqualTo("routes.googleapis.com"));
+            Assert.That(uri.AbsolutePath, Is.EqualTo("/directions/v2:computeRoutes"));
+            Assert.That(uri.Query, Does.Contain("key=abc%20123"));
+            Assert.That(uri.Query, Does.Contain("$fields=routes.duration%2Croutes.distanceMeters"));
+        }
+
+        [Test]
+        public void GetUri_MissingApiKey_Throws()
+        {
+            var request = new RoutesRequest();
+            Assert.Throws<InvalidOperationException>(() => request.GetUri());
+        }
+
+        [Test]
+        public void GetUri_MissingFieldMask_Throws()
+        {
+            var request = new RoutesRequest { ApiKey = "k", FieldMask = "" };
+            Assert.Throws<InvalidOperationException>(() => request.GetUri());
+        }
+
+        [Test]
+        public void DefaultFieldMask_IsPopulatedAndIncludesCommonShape()
+        {
+            var request = new RoutesRequest();
+            Assert.That(request.FieldMask, Is.Not.Null.And.Not.Empty);
+            Assert.That(request.FieldMask, Does.Contain("routes.duration"));
+            Assert.That(request.FieldMask, Does.Contain("routes.distanceMeters"));
+            Assert.That(request.FieldMask, Does.Contain("routes.polyline.encodedPolyline"));
+        }
+
+        [Test]
+        public async Task QueryAsync_IssuesPost_WithJsonBody_AndCanonicalFields()
+        {
+            var canned = "{\"routes\":[{\"distanceMeters\":1234,\"duration\":\"567s\"}]}";
+            var handler = new RecordingHandler(canned);
+            using var http = new HttpClient(handler);
+
+            var request = new RoutesRequest
+            {
+                ApiKey = "k",
+                Origin = Waypoint.FromAddress("San Francisco, CA"),
+                Destination = Waypoint.FromAddress("Mountain View, CA"),
+                TravelMode = RoutesTravelMode.Drive,
+                RoutingPreference = RoutingPreference.TrafficAware,
+                ComputeAlternativeRoutes = true,
+                RouteModifiers = new RouteModifiers { AvoidTolls = true },
+            };
+
+            var response = await MapsAPIGenericEngine<RoutesRequest, RoutesResponse>
+                .QueryGoogleAPIAsync(http, request, TimeSpan.FromMilliseconds(-1), CancellationToken.None, null, null);
+
+            Assert.That(handler.LastMethod, Is.EqualTo(HttpMethod.Post));
+            Assert.That(handler.LastContentType, Is.EqualTo("application/json"));
+            Assert.That(handler.LastUri!.Host, Is.EqualTo("routes.googleapis.com"));
+
+            using var body = JsonDocument.Parse(handler.LastRequestBody!);
+            var root = body.RootElement;
+
+            Assert.That(root.GetProperty("origin").GetProperty("address").GetString(), Is.EqualTo("San Francisco, CA"));
+            Assert.That(root.GetProperty("destination").GetProperty("address").GetString(), Is.EqualTo("Mountain View, CA"));
+            Assert.That(root.GetProperty("travelMode").GetString(), Is.EqualTo("DRIVE"));
+            Assert.That(root.GetProperty("routingPreference").GetString(), Is.EqualTo("TRAFFIC_AWARE"));
+            Assert.That(root.GetProperty("computeAlternativeRoutes").GetBoolean(), Is.True);
+            Assert.That(root.GetProperty("routeModifiers").GetProperty("avoidTolls").GetBoolean(), Is.True);
+
+            Assert.That(response.Routes, Has.Count.EqualTo(1));
+            Assert.That(response.Routes![0].DistanceMeters, Is.EqualTo(1234));
+            Assert.That(response.Routes[0].Duration, Is.EqualTo("567s"));
+            Assert.That(response.Routes[0].DurationSeconds, Is.EqualTo(567d));
+        }
+
+        [Test]
+        public async Task QueryAsync_OmitsUnsetOptionalFields()
+        {
+            var handler = new RecordingHandler("{\"routes\":[]}");
+            using var http = new HttpClient(handler);
+
+            var request = new RoutesRequest
+            {
+                ApiKey = "k",
+                Origin = Waypoint.FromAddress("A"),
+                Destination = Waypoint.FromAddress("B"),
+            };
+
+            await MapsAPIGenericEngine<RoutesRequest, RoutesResponse>
+                .QueryGoogleAPIAsync(http, request, TimeSpan.FromMilliseconds(-1), CancellationToken.None, null, null);
+
+            using var body = JsonDocument.Parse(handler.LastRequestBody!);
+            var root = body.RootElement;
+
+            Assert.That(root.TryGetProperty("routingPreference", out _), Is.False);
+            Assert.That(root.TryGetProperty("computeAlternativeRoutes", out _), Is.False);
+            Assert.That(root.TryGetProperty("intermediates", out _), Is.False);
+            Assert.That(root.TryGetProperty("departureTime", out _), Is.False);
+            Assert.That(root.TryGetProperty("languageCode", out _), Is.False);
+        }
+
+        [Test]
+        public async Task QueryAsync_SerializesWaypointVariants()
+        {
+            var handler = new RecordingHandler("{\"routes\":[]}");
+            using var http = new HttpClient(handler);
+
+            var request = new RoutesRequest
+            {
+                ApiKey = "k",
+                Origin = Waypoint.FromCoordinates(37.7749, -122.4194),
+                Destination = Waypoint.FromPlaceId("ChIJj61dQgK6j4AR4GeTYWZsKWw"),
+                Intermediates = new List<Waypoint>
+                {
+                    Waypoint.FromAddress("Palo Alto, CA"),
+                },
+            };
+
+            await MapsAPIGenericEngine<RoutesRequest, RoutesResponse>
+                .QueryGoogleAPIAsync(http, request, TimeSpan.FromMilliseconds(-1), CancellationToken.None, null, null);
+
+            using var body = JsonDocument.Parse(handler.LastRequestBody!);
+            var root = body.RootElement;
+
+            var originLatLng = root.GetProperty("origin").GetProperty("location").GetProperty("latLng");
+            Assert.That(originLatLng.GetProperty("latitude").GetDouble(), Is.EqualTo(37.7749));
+            Assert.That(originLatLng.GetProperty("longitude").GetDouble(), Is.EqualTo(-122.4194));
+
+            Assert.That(root.GetProperty("destination").GetProperty("placeId").GetString(), Is.EqualTo("ChIJj61dQgK6j4AR4GeTYWZsKWw"));
+            Assert.That(root.GetProperty("intermediates")[0].GetProperty("address").GetString(), Is.EqualTo("Palo Alto, CA"));
+        }
+
+        [Test]
+        public async Task QueryAsync_DepartureAndArrivalTime_AreMutuallyExclusive()
+        {
+            var handler = new RecordingHandler("{}");
+            using var http = new HttpClient(handler);
+
+            var request = new RoutesRequest
+            {
+                ApiKey = "k",
+                Origin = Waypoint.FromAddress("A"),
+                Destination = Waypoint.FromAddress("B"),
+                DepartureTime = DateTimeOffset.UtcNow,
+                ArrivalTime = DateTimeOffset.UtcNow.AddHours(1),
+            };
+
+            Assert.ThrowsAsync<InvalidOperationException>(async () =>
+                await MapsAPIGenericEngine<RoutesRequest, RoutesResponse>
+                    .QueryGoogleAPIAsync(http, request, TimeSpan.FromMilliseconds(-1), CancellationToken.None, null, null));
+        }
+
+        [Test]
+        public void Response_DeserializesEncodedPolylineAndDecodesPoints()
+        {
+            // "mz~tF~uflVqAaC" — a short encoded polyline (4 points around lat 37, lng -122).
+            const string encoded = "mz~tF~uflVqAaC";
+            var json = "{\"routes\":[{\"polyline\":{\"encodedPolyline\":\"" + encoded + "\"}}]}";
+
+            var options = JsonSerializerConfiguration.CreateOptions();
+            var response = JsonSerializer.Deserialize<RoutesResponse>(json, options);
+
+            Assert.That(response, Is.Not.Null);
+            Assert.That(response!.Routes, Has.Count.EqualTo(1));
+            Assert.That(response.Routes![0].Polyline!.EncodedPolyline, Is.EqualTo(encoded));
+            Assert.That(response.Routes[0].Polyline!.DecodedPoints, Is.Not.Empty);
+        }
+
+        [Test]
+        public void Response_DeserializesEnumsWithEnumMemberValues()
+        {
+            var json = "{\"routes\":[{\"routeLabels\":[\"DEFAULT_ROUTE\",\"FUEL_EFFICIENT\"]," +
+                       "\"legs\":[{\"steps\":[{\"navigationInstruction\":{\"maneuver\":\"TURN_LEFT\"}}]}]}]}";
+
+            var options = JsonSerializerConfiguration.CreateOptions();
+            var response = JsonSerializer.Deserialize<RoutesResponse>(json, options);
+
+            Assert.That(response!.Routes![0].RouteLabels, Is.EquivalentTo(new[] { RouteLabel.DefaultRoute, RouteLabel.FuelEfficient }));
+            Assert.That(response.Routes[0].Legs![0].Steps![0].NavigationInstruction!.Maneuver, Is.EqualTo(Maneuver.TurnLeft));
+        }
+
+        [Test]
+        public void DurationParser_HandlesFractionalAndMissingValues()
+        {
+            Assert.That(DurationParser.ToSeconds("123s"), Is.EqualTo(123d));
+            Assert.That(DurationParser.ToSeconds("12.5s"), Is.EqualTo(12.5d));
+            Assert.That(DurationParser.ToSeconds(null), Is.Null);
+            Assert.That(DurationParser.ToSeconds(""), Is.Null);
+            Assert.That(DurationParser.ToSeconds("garbage"), Is.Null);
+        }
+
+        private sealed class RecordingHandler : HttpMessageHandler
+        {
+            private readonly string _responseJson;
+
+            public RecordingHandler(string responseJson) { _responseJson = responseJson; }
+
+            public HttpMethod? LastMethod { get; private set; }
+            public Uri? LastUri { get; private set; }
+            public string? LastRequestBody { get; private set; }
+            public string? LastContentType { get; private set; }
+
+            protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                LastMethod = request.Method;
+                LastUri = request.RequestUri;
+                if (request.Content != null)
+                {
+                    LastRequestBody = await request.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    LastContentType = request.Content.Headers.ContentType?.MediaType;
+                }
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(_responseJson, Encoding.UTF8, "application/json")
+                };
+            }
+        }
+    }
+}

--- a/GoogleMapsApi/Entities/Common/EncodedPolylineDecoder.cs
+++ b/GoogleMapsApi/Entities/Common/EncodedPolylineDecoder.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using GoogleMapsApi.Entities.Directions.Response;
+
+namespace GoogleMapsApi.Entities.Common
+{
+    /// <summary>
+    /// Decodes Google's encoded-polyline string format into a sequence of <see cref="Location"/>s.
+    /// See <see href="https://developers.google.com/maps/documentation/utilities/polylinealgorithm"/>.
+    /// </summary>
+    internal static class EncodedPolylineDecoder
+    {
+        public static IReadOnlyList<Location> Decode(string? encoded)
+        {
+            if (string.IsNullOrEmpty(encoded))
+                return Array.Empty<Location>();
+
+            try
+            {
+                var poly = new List<Location>();
+                int index = 0;
+                int lat = 0;
+                int lng = 0;
+
+                while (index < encoded!.Length)
+                {
+                    int b, shift = 0, result = 0;
+                    do
+                    {
+                        b = encoded[index++] - 63;
+                        result |= (b & 0x1f) << shift;
+                        shift += 5;
+                    } while (b >= 0x20);
+                    int dlat = ((result & 1) != 0 ? ~(result >> 1) : (result >> 1));
+                    lat += dlat;
+
+                    shift = 0;
+                    result = 0;
+                    do
+                    {
+                        b = encoded[index++] - 63;
+                        result |= (b & 0x1f) << shift;
+                        shift += 5;
+                    } while (b >= 0x20);
+                    int dlng = ((result & 1) != 0 ? ~(result >> 1) : (result >> 1));
+                    lng += dlng;
+
+                    poly.Add(new Location(lat / 1E5, lng / 1E5));
+                }
+
+                return poly;
+            }
+            catch (Exception ex)
+            {
+                throw new PointsDecodingException("Couldn't decode points", encoded!, ex);
+            }
+        }
+    }
+}

--- a/GoogleMapsApi/Entities/Directions/Response/OverviewPolyline.cs
+++ b/GoogleMapsApi/Entities/Directions/Response/OverviewPolyline.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using GoogleMapsApi.Entities.Common;
 
+
 namespace GoogleMapsApi.Entities.Directions.Response
 {
 	/// <summary>
@@ -41,64 +42,8 @@ namespace GoogleMapsApi.Entities.Directions.Response
 			InitLazyPoints();
 		}
 
-		// Adapted from http://jeffreysambells.com/2010/05/27/decoding-polylines-from-google-maps-direction-api-with-java
-		// The algorithm explained here - https://developers.google.com/maps/documentation/utilities/polylinealgorithm
-		/// <summary>
-		/// 
-		/// </summary>
-		/// <returns></returns>
 		/// <exception cref="PointsDecodingException">Unexpectedly couldn't decode points</exception>
-		private IEnumerable<Location> DecodePoints()
-		{
-			IEnumerable<Location> points;
-
-			try
-			{
-				if (string.IsNullOrEmpty(EncodedPoints))
-				{
-					return new List<Location>();
-				}
-
-				var poly = new List<Location>();
-				int index = 0;
-				int lat = 0;
-				int lng = 0;
-
-				while (index < EncodedPoints!.Length)
-				{
-					int b, shift = 0, result = 0;
-					do
-					{
-						b = EncodedPoints[index++] - 63;
-						result |= (b & 0x1f) << shift;
-						shift += 5;
-					} while (b >= 0x20);
-					int dlat = ((result & 1) != 0 ? ~(result >> 1) : (result >> 1));
-					lat += dlat;
-
-					shift = 0;
-					result = 0;
-					do
-					{
-						b = EncodedPoints[index++] - 63;
-						result |= (b & 0x1f) << shift;
-						shift += 5;
-					} while (b >= 0x20);
-					int dlng = ((result & 1) != 0 ? ~(result >> 1) : (result >> 1));
-					lng += dlng;
-
-					poly.Add(new Location(lat / 1E5, lng / 1E5));
-				}
-
-				points = poly.ToArray();
-			}
-			catch (Exception ex)
-			{
-				throw new PointsDecodingException("Couldn't decode points", EncodedPoints!, ex);
-			}
-
-			return points;
-		}
+		private IEnumerable<Location> DecodePoints() => EncodedPolylineDecoder.Decode(EncodedPoints);
 
 		/// <summary>
 		/// The RAW data of points from Google

--- a/GoogleMapsApi/Entities/Routes/Request/ExtraComputation.cs
+++ b/GoogleMapsApi/Entities/Routes/Request/ExtraComputation.cs
@@ -1,0 +1,56 @@
+using System.Runtime.Serialization;
+
+namespace GoogleMapsApi.Entities.Routes.Request
+{
+    /// <summary>
+    /// Optional extra computations the Routes API can perform alongside the route. Each entry
+    /// incurs additional billing — request only what you need.
+    /// </summary>
+    public enum ExtraComputation
+    {
+        /// <summary>Unspecified; the API ignores this value.</summary>
+        [EnumMember(Value = "EXTRA_COMPUTATION_UNSPECIFIED")] Unspecified,
+
+        /// <summary>Include toll information for the route.</summary>
+        [EnumMember(Value = "TOLLS")] Tolls,
+
+        /// <summary>Include estimated fuel consumption for the route.</summary>
+        [EnumMember(Value = "FUEL_CONSUMPTION")] FuelConsumption,
+
+        /// <summary>Include traffic-aware polylines colored by congestion level.</summary>
+        [EnumMember(Value = "TRAFFIC_ON_POLYLINE")] TrafficOnPolyline,
+
+        /// <summary>Include HTML-formatted navigation instructions on each leg/step.</summary>
+        [EnumMember(Value = "HTML_FORMATTED_NAVIGATION_INSTRUCTIONS")] HtmlFormattedNavigationInstructions,
+    }
+
+    /// <summary>Reference route to compute alongside the default one.</summary>
+    public enum ReferenceRoute
+    {
+        /// <summary>Unspecified; the API ignores this value.</summary>
+        [EnumMember(Value = "REFERENCE_ROUTE_UNSPECIFIED")] Unspecified,
+
+        /// <summary>Compute a fuel-efficient alternative route.</summary>
+        [EnumMember(Value = "FUEL_EFFICIENT")] FuelEfficient,
+    }
+
+    /// <summary>
+    /// Traffic model used when <see cref="RoutesRequest.RoutingPreference"/> is
+    /// <see cref="Request.RoutingPreference.TrafficAware"/> or
+    /// <see cref="Request.RoutingPreference.TrafficAwareOptimal"/>.
+    /// </summary>
+    public enum TrafficModel
+    {
+        /// <summary>Unspecified; treated as <see cref="BestGuess"/>.</summary>
+        [EnumMember(Value = "TRAFFIC_MODEL_UNSPECIFIED")] Unspecified,
+
+        /// <summary>Use the best estimate of travel time given live and historical traffic.</summary>
+        [EnumMember(Value = "BEST_GUESS")] BestGuess,
+
+        /// <summary>Use the pessimistic estimate (longer than actual in most cases).</summary>
+        [EnumMember(Value = "PESSIMISTIC")] Pessimistic,
+
+        /// <summary>Use the optimistic estimate (shorter than actual in most cases).</summary>
+        [EnumMember(Value = "OPTIMISTIC")] Optimistic,
+    }
+}

--- a/GoogleMapsApi/Entities/Routes/Request/PolylineEncoding.cs
+++ b/GoogleMapsApi/Entities/Routes/Request/PolylineEncoding.cs
@@ -1,0 +1,20 @@
+using System.Runtime.Serialization;
+
+namespace GoogleMapsApi.Entities.Routes.Request
+{
+    /// <summary>Wire format of the polyline returned for each route.</summary>
+    public enum PolylineEncoding
+    {
+        /// <summary>Unspecified; the API uses <see cref="EncodedPolyline"/>.</summary>
+        [EnumMember(Value = "POLYLINE_ENCODING_UNSPECIFIED")] Unspecified,
+
+        /// <summary>
+        /// Google's encoded polyline algorithm — same compact string format the legacy
+        /// Directions API returns. Reusable with the library's existing polyline decoder.
+        /// </summary>
+        [EnumMember(Value = "ENCODED_POLYLINE")] EncodedPolyline,
+
+        /// <summary>GeoJSON LineString representation.</summary>
+        [EnumMember(Value = "GEO_JSON_LINESTRING")] GeoJsonLineString,
+    }
+}

--- a/GoogleMapsApi/Entities/Routes/Request/PolylineQuality.cs
+++ b/GoogleMapsApi/Entities/Routes/Request/PolylineQuality.cs
@@ -1,0 +1,17 @@
+using System.Runtime.Serialization;
+
+namespace GoogleMapsApi.Entities.Routes.Request
+{
+    /// <summary>Trade-off between polyline detail and response size.</summary>
+    public enum PolylineQuality
+    {
+        /// <summary>Unspecified; the API uses <see cref="Overview"/>.</summary>
+        [EnumMember(Value = "POLYLINE_QUALITY_UNSPECIFIED")] Unspecified,
+
+        /// <summary>High-fidelity polyline (more points, larger response).</summary>
+        [EnumMember(Value = "HIGH_QUALITY")] HighQuality,
+
+        /// <summary>Overview polyline suitable for display at city/regional zoom.</summary>
+        [EnumMember(Value = "OVERVIEW")] Overview,
+    }
+}

--- a/GoogleMapsApi/Entities/Routes/Request/RouteModifiers.cs
+++ b/GoogleMapsApi/Entities/Routes/Request/RouteModifiers.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
+
+namespace GoogleMapsApi.Entities.Routes.Request
+{
+    /// <summary>
+    /// Optional set of conditions that influence route generation — avoidances, vehicle info
+    /// (for emissions-aware routing), and toll passes.
+    /// </summary>
+    public sealed class RouteModifiers
+    {
+        /// <summary>Avoid toll roads where reasonable.</summary>
+        [JsonPropertyName("avoidTolls")]
+        public bool? AvoidTolls { get; set; }
+
+        /// <summary>Avoid highways where reasonable.</summary>
+        [JsonPropertyName("avoidHighways")]
+        public bool? AvoidHighways { get; set; }
+
+        /// <summary>Avoid ferries where reasonable.</summary>
+        [JsonPropertyName("avoidFerries")]
+        public bool? AvoidFerries { get; set; }
+
+        /// <summary>Avoid navigation indoors where reasonable. Walking only.</summary>
+        [JsonPropertyName("avoidIndoor")]
+        public bool? AvoidIndoor { get; set; }
+
+        /// <summary>
+        /// Vehicle information used for emissions-aware routing. Required when
+        /// <see cref="RoutesRequest.ExtraComputations"/> includes
+        /// <see cref="ExtraComputation.FuelConsumption"/>.
+        /// </summary>
+        [JsonPropertyName("vehicleInfo")]
+        public VehicleInfo? VehicleInfo { get; set; }
+
+        /// <summary>
+        /// Toll passes the vehicle holds. When supplied, the Routes API may return routes
+        /// behind toll-pass-only lanes.
+        /// </summary>
+        [JsonPropertyName("tollPasses")]
+        public List<string>? TollPasses { get; set; }
+    }
+
+    /// <summary>Vehicle attributes used for emissions-aware routing.</summary>
+    public sealed class VehicleInfo
+    {
+        /// <summary>Engine / emission type of the vehicle.</summary>
+        [JsonPropertyName("emissionType")]
+        public VehicleEmissionType? EmissionType { get; set; }
+    }
+
+    /// <summary>Vehicle emission/engine type.</summary>
+    public enum VehicleEmissionType
+    {
+        /// <summary>Unspecified; treated as <see cref="Gasoline"/>.</summary>
+        [EnumMember(Value = "VEHICLE_EMISSION_TYPE_UNSPECIFIED")] Unspecified,
+
+        /// <summary>Gasoline / petrol engine.</summary>
+        [EnumMember(Value = "GASOLINE")] Gasoline,
+
+        /// <summary>Electric vehicle.</summary>
+        [EnumMember(Value = "ELECTRIC")] Electric,
+
+        /// <summary>Hybrid (gasoline + electric).</summary>
+        [EnumMember(Value = "HYBRID")] Hybrid,
+
+        /// <summary>Diesel engine.</summary>
+        [EnumMember(Value = "DIESEL")] Diesel,
+    }
+}

--- a/GoogleMapsApi/Entities/Routes/Request/RoutesRequest.cs
+++ b/GoogleMapsApi/Entities/Routes/Request/RoutesRequest.cs
@@ -1,0 +1,184 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using GoogleMapsApi.Entities.Common;
+
+namespace GoogleMapsApi.Entities.Routes.Request
+{
+    /// <summary>
+    /// Request for the Google Routes API
+    /// (<c>POST https://routes.googleapis.com/directions/v2:computeRoutes</c>).
+    /// Modern replacement for the legacy Directions API: real-time traffic, eco-routing,
+    /// toll calculation, two-wheeled vehicle support, and route alternatives.
+    /// </summary>
+    /// <remarks>
+    /// The Routes API <strong>requires a field mask</strong>. <see cref="FieldMask"/> is
+    /// pre-populated with a reasonable default that mirrors what the legacy Directions API
+    /// returned; tighten it to reduce response size and cost. See
+    /// <see href="https://developers.google.com/maps/documentation/routes/choose_fields"/>.
+    /// </remarks>
+    public sealed class RoutesRequest : MapsBaseRequest
+    {
+        /// <summary>Default <see cref="FieldMask"/> — sized to roughly match what Directions returned.</summary>
+        public const string DefaultFieldMask =
+            "routes.duration,routes.distanceMeters,routes.polyline.encodedPolyline," +
+            "routes.legs.steps,routes.legs.distanceMeters,routes.legs.duration,routes.warnings";
+
+        /// <summary>
+        /// Comma-separated response field mask. <strong>Required by the Routes API</strong> —
+        /// requests with an empty mask are rejected. Passed in the URL as <c>$fields</c>.
+        /// </summary>
+        public string FieldMask { get; set; } = DefaultFieldMask;
+
+        /// <summary>Origin waypoint. Required.</summary>
+        public Waypoint Origin { get; set; } = new Waypoint();
+
+        /// <summary>Destination waypoint. Required.</summary>
+        public Waypoint Destination { get; set; } = new Waypoint();
+
+        /// <summary>Intermediate waypoints, in order.</summary>
+        public List<Waypoint>? Intermediates { get; set; }
+
+        /// <summary>Travel mode. Defaults to <see cref="RoutesTravelMode.Drive"/>.</summary>
+        public RoutesTravelMode TravelMode { get; set; } = RoutesTravelMode.Drive;
+
+        /// <summary>
+        /// How traffic data should be applied. Only valid for <see cref="RoutesTravelMode.Drive"/>
+        /// and <see cref="RoutesTravelMode.TwoWheeler"/>.
+        /// </summary>
+        public RoutingPreference? RoutingPreference { get; set; }
+
+        /// <summary>Quality of the polyline returned for each route.</summary>
+        public PolylineQuality? PolylineQuality { get; set; }
+
+        /// <summary>Wire format of the polyline returned for each route.</summary>
+        public PolylineEncoding? PolylineEncoding { get; set; }
+
+        /// <summary>
+        /// Desired departure time in absolute time. Mutually exclusive with <see cref="ArrivalTime"/>.
+        /// Required for <see cref="RoutesTravelMode.Transit"/> unless <see cref="ArrivalTime"/> is set.
+        /// </summary>
+        public DateTimeOffset? DepartureTime { get; set; }
+
+        /// <summary>
+        /// Desired arrival time in absolute time. Transit only; mutually exclusive with <see cref="DepartureTime"/>.
+        /// </summary>
+        public DateTimeOffset? ArrivalTime { get; set; }
+
+        /// <summary>If true, the API may return up to two additional alternative routes.</summary>
+        public bool ComputeAlternativeRoutes { get; set; }
+
+        /// <summary>Conditions affecting the route (avoidances, vehicle info, toll passes).</summary>
+        public RouteModifiers? RouteModifiers { get; set; }
+
+        /// <summary>BCP-47 language code for the response (e.g. <c>"en-US"</c>).</summary>
+        public string? LanguageCode { get; set; }
+
+        /// <summary>Two-letter CLDR region code used for region-specific routing (e.g. <c>"US"</c>).</summary>
+        public string? RegionCode { get; set; }
+
+        /// <summary>Distance units for the response.</summary>
+        public Units? Units { get; set; }
+
+        /// <summary>If true and intermediates are supplied, reorder them to minimize total cost.</summary>
+        public bool OptimizeWaypointOrder { get; set; }
+
+        /// <summary>Optional reference routes to compute alongside the default route (e.g. fuel-efficient).</summary>
+        public List<ReferenceRoute>? RequestedReferenceRoutes { get; set; }
+
+        /// <summary>Optional extra computations (tolls, fuel consumption, traffic polyline).</summary>
+        public List<ExtraComputation>? ExtraComputations { get; set; }
+
+        /// <summary>Traffic model used when traffic-aware routing is enabled.</summary>
+        public TrafficModel? TrafficModel { get; set; }
+
+        /// <summary>Transit-specific preferences. <see cref="RoutesTravelMode.Transit"/> only.</summary>
+        public TransitPreferences? TransitPreferences { get; set; }
+
+        /// <inheritdoc/>
+        public override Uri GetUri()
+        {
+            if (string.IsNullOrWhiteSpace(ApiKey))
+                throw new InvalidOperationException("ApiKey is required for the Routes API.");
+            if (!IsSSL)
+                throw new ArgumentException("Routes API requires SSL [IsSSL = true].");
+            if (string.IsNullOrWhiteSpace(FieldMask))
+                throw new InvalidOperationException("FieldMask is required for the Routes API. See RoutesRequest.DefaultFieldMask for a starting point.");
+
+            return new Uri(
+                "https://routes.googleapis.com/directions/v2:computeRoutes" +
+                $"?key={Uri.EscapeDataString(ApiKey!)}" +
+                $"&$fields={Uri.EscapeDataString(FieldMask)}");
+        }
+
+        /// <inheritdoc/>
+        protected internal override HttpContent? GetRequestBody()
+        {
+            if (DepartureTime.HasValue && ArrivalTime.HasValue)
+                throw new InvalidOperationException("DepartureTime and ArrivalTime are mutually exclusive.");
+
+            var payload = new Payload
+            {
+                Origin = Origin,
+                Destination = Destination,
+                Intermediates = Intermediates is { Count: > 0 } ? Intermediates : null,
+                TravelMode = TravelMode != RoutesTravelMode.Unspecified ? TravelMode : (RoutesTravelMode?)null,
+                RoutingPreference = RoutingPreference,
+                PolylineQuality = PolylineQuality,
+                PolylineEncoding = PolylineEncoding,
+                DepartureTime = DepartureTime?.UtcDateTime.ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ"),
+                ArrivalTime = ArrivalTime?.UtcDateTime.ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ"),
+                ComputeAlternativeRoutes = ComputeAlternativeRoutes ? true : (bool?)null,
+                RouteModifiers = RouteModifiers,
+                LanguageCode = string.IsNullOrWhiteSpace(LanguageCode) ? null : LanguageCode,
+                RegionCode = string.IsNullOrWhiteSpace(RegionCode) ? null : RegionCode,
+                Units = Units,
+                OptimizeWaypointOrder = OptimizeWaypointOrder ? true : (bool?)null,
+                RequestedReferenceRoutes = RequestedReferenceRoutes is { Count: > 0 } ? RequestedReferenceRoutes : null,
+                ExtraComputations = ExtraComputations is { Count: > 0 } ? ExtraComputations : null,
+                TrafficModel = TrafficModel,
+                TransitPreferences = TransitPreferences,
+            };
+            var json = JsonSerializer.Serialize(payload, BodyOptions);
+            return new StringContent(json, Encoding.UTF8, "application/json");
+        }
+
+        private static readonly JsonSerializerOptions BodyOptions = BuildBodyOptions();
+
+        private static JsonSerializerOptions BuildBodyOptions()
+        {
+            var opts = new JsonSerializerOptions
+            {
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            };
+            opts.Converters.Add(new Engine.JsonConverters.EnumMemberJsonConverterFactory());
+            return opts;
+        }
+
+        private sealed class Payload
+        {
+            [JsonPropertyName("origin")] public Waypoint? Origin { get; set; }
+            [JsonPropertyName("destination")] public Waypoint? Destination { get; set; }
+            [JsonPropertyName("intermediates")] public List<Waypoint>? Intermediates { get; set; }
+            [JsonPropertyName("travelMode")] public RoutesTravelMode? TravelMode { get; set; }
+            [JsonPropertyName("routingPreference")] public RoutingPreference? RoutingPreference { get; set; }
+            [JsonPropertyName("polylineQuality")] public PolylineQuality? PolylineQuality { get; set; }
+            [JsonPropertyName("polylineEncoding")] public PolylineEncoding? PolylineEncoding { get; set; }
+            [JsonPropertyName("departureTime")] public string? DepartureTime { get; set; }
+            [JsonPropertyName("arrivalTime")] public string? ArrivalTime { get; set; }
+            [JsonPropertyName("computeAlternativeRoutes")] public bool? ComputeAlternativeRoutes { get; set; }
+            [JsonPropertyName("routeModifiers")] public RouteModifiers? RouteModifiers { get; set; }
+            [JsonPropertyName("languageCode")] public string? LanguageCode { get; set; }
+            [JsonPropertyName("regionCode")] public string? RegionCode { get; set; }
+            [JsonPropertyName("units")] public Units? Units { get; set; }
+            [JsonPropertyName("optimizeWaypointOrder")] public bool? OptimizeWaypointOrder { get; set; }
+            [JsonPropertyName("requestedReferenceRoutes")] public List<ReferenceRoute>? RequestedReferenceRoutes { get; set; }
+            [JsonPropertyName("extraComputations")] public List<ExtraComputation>? ExtraComputations { get; set; }
+            [JsonPropertyName("trafficModel")] public TrafficModel? TrafficModel { get; set; }
+            [JsonPropertyName("transitPreferences")] public TransitPreferences? TransitPreferences { get; set; }
+        }
+    }
+}

--- a/GoogleMapsApi/Entities/Routes/Request/RoutesTravelMode.cs
+++ b/GoogleMapsApi/Entities/Routes/Request/RoutesTravelMode.cs
@@ -1,0 +1,32 @@
+using System.Runtime.Serialization;
+
+namespace GoogleMapsApi.Entities.Routes.Request
+{
+    /// <summary>
+    /// Mode of transportation for a <see cref="RoutesRequest"/>. Note that Routes API adds
+    /// <see cref="TwoWheeler"/> over the legacy Directions API.
+    /// </summary>
+    public enum RoutesTravelMode
+    {
+        /// <summary>Travel mode unspecified. The API treats this as <see cref="Drive"/>.</summary>
+        [EnumMember(Value = "TRAVEL_MODE_UNSPECIFIED")] Unspecified,
+
+        /// <summary>Travel by passenger car.</summary>
+        [EnumMember(Value = "DRIVE")] Drive,
+
+        /// <summary>Travel by bicycle.</summary>
+        [EnumMember(Value = "BICYCLE")] Bicycle,
+
+        /// <summary>Travel by walking.</summary>
+        [EnumMember(Value = "WALK")] Walk,
+
+        /// <summary>
+        /// Two-wheeled, motorized vehicle (e.g. motorcycle). Note this differs from
+        /// <see cref="Bicycle"/> which is human-powered. Available only in a subset of regions.
+        /// </summary>
+        [EnumMember(Value = "TWO_WHEELER")] TwoWheeler,
+
+        /// <summary>Public transit travel; only available for selected regions.</summary>
+        [EnumMember(Value = "TRANSIT")] Transit,
+    }
+}

--- a/GoogleMapsApi/Entities/Routes/Request/RoutingPreference.cs
+++ b/GoogleMapsApi/Entities/Routes/Request/RoutingPreference.cs
@@ -1,0 +1,24 @@
+using System.Runtime.Serialization;
+
+namespace GoogleMapsApi.Entities.Routes.Request
+{
+    /// <summary>
+    /// How the Routes API should factor live and historical traffic into route computation.
+    /// Only applicable when <see cref="RoutesRequest.TravelMode"/> is <see cref="RoutesTravelMode.Drive"/>
+    /// or <see cref="RoutesTravelMode.TwoWheeler"/>.
+    /// </summary>
+    public enum RoutingPreference
+    {
+        /// <summary>Routing preference unspecified. Defaults to <see cref="TrafficUnaware"/>.</summary>
+        [EnumMember(Value = "ROUTING_PREFERENCE_UNSPECIFIED")] Unspecified,
+
+        /// <summary>Ignore live traffic. Cheapest and fastest, but less accurate during congestion.</summary>
+        [EnumMember(Value = "TRAFFIC_UNAWARE")] TrafficUnaware,
+
+        /// <summary>Use live traffic. Higher latency and cost than <see cref="TrafficUnaware"/>.</summary>
+        [EnumMember(Value = "TRAFFIC_AWARE")] TrafficAware,
+
+        /// <summary>Use live traffic with the highest accuracy. Highest latency and cost.</summary>
+        [EnumMember(Value = "TRAFFIC_AWARE_OPTIMAL")] TrafficAwareOptimal,
+    }
+}

--- a/GoogleMapsApi/Entities/Routes/Request/TransitPreferences.cs
+++ b/GoogleMapsApi/Entities/Routes/Request/TransitPreferences.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
+
+namespace GoogleMapsApi.Entities.Routes.Request
+{
+    /// <summary>Transit-specific preferences. Used only when <see cref="RoutesRequest.TravelMode"/> is <see cref="RoutesTravelMode.Transit"/>.</summary>
+    public sealed class TransitPreferences
+    {
+        /// <summary>Preferred transit modes (subway, bus, ...). Empty means no preference.</summary>
+        [JsonPropertyName("allowedTravelModes")]
+        public List<TransitTravelMode>? AllowedTravelModes { get; set; }
+
+        /// <summary>Optimization preference (e.g. fewer transfers).</summary>
+        [JsonPropertyName("routingPreference")]
+        public TransitRoutingPreference? RoutingPreference { get; set; }
+    }
+
+    /// <summary>Transit travel modes.</summary>
+    public enum TransitTravelMode
+    {
+        /// <summary>Unspecified.</summary>
+        [EnumMember(Value = "TRANSIT_TRAVEL_MODE_UNSPECIFIED")] Unspecified,
+
+        /// <summary>Bus.</summary>
+        [EnumMember(Value = "BUS")] Bus,
+
+        /// <summary>Subway/metro.</summary>
+        [EnumMember(Value = "SUBWAY")] Subway,
+
+        /// <summary>Train (heavy rail).</summary>
+        [EnumMember(Value = "TRAIN")] Train,
+
+        /// <summary>Light rail / tram.</summary>
+        [EnumMember(Value = "LIGHT_RAIL")] LightRail,
+
+        /// <summary>Rail (any kind).</summary>
+        [EnumMember(Value = "RAIL")] Rail,
+    }
+
+    /// <summary>Optimization preference for transit routing.</summary>
+    public enum TransitRoutingPreference
+    {
+        /// <summary>Unspecified.</summary>
+        [EnumMember(Value = "TRANSIT_ROUTING_PREFERENCE_UNSPECIFIED")] Unspecified,
+
+        /// <summary>Prefer routes with less walking.</summary>
+        [EnumMember(Value = "LESS_WALKING")] LessWalking,
+
+        /// <summary>Prefer routes with fewer transfers.</summary>
+        [EnumMember(Value = "FEWER_TRANSFERS")] FewerTransfers,
+    }
+}

--- a/GoogleMapsApi/Entities/Routes/Request/Units.cs
+++ b/GoogleMapsApi/Entities/Routes/Request/Units.cs
@@ -1,0 +1,17 @@
+using System.Runtime.Serialization;
+
+namespace GoogleMapsApi.Entities.Routes.Request
+{
+    /// <summary>Display units for distance values in the response.</summary>
+    public enum Units
+    {
+        /// <summary>Unspecified; the API picks based on the request's region.</summary>
+        [EnumMember(Value = "UNITS_UNSPECIFIED")] Unspecified,
+
+        /// <summary>Metric units (meters, kilometers).</summary>
+        [EnumMember(Value = "METRIC")] Metric,
+
+        /// <summary>Imperial units (feet, miles).</summary>
+        [EnumMember(Value = "IMPERIAL")] Imperial,
+    }
+}

--- a/GoogleMapsApi/Entities/Routes/Request/Waypoint.cs
+++ b/GoogleMapsApi/Entities/Routes/Request/Waypoint.cs
@@ -1,0 +1,90 @@
+using System.Text.Json.Serialization;
+
+namespace GoogleMapsApi.Entities.Routes.Request
+{
+    /// <summary>
+    /// Origin, destination, or intermediate stop on a route. Set exactly one of
+    /// <see cref="Location"/>, <see cref="PlaceId"/>, or <see cref="Address"/>.
+    /// </summary>
+    public sealed class Waypoint
+    {
+        /// <summary>Latitude / longitude (with optional heading) of this waypoint.</summary>
+        [JsonPropertyName("location")]
+        public WaypointLocation? Location { get; set; }
+
+        /// <summary>
+        /// Google Places place ID — the preferred way to specify a waypoint when known, since
+        /// it bypasses geocoding ambiguity.
+        /// </summary>
+        [JsonPropertyName("placeId")]
+        public string? PlaceId { get; set; }
+
+        /// <summary>Free-text address; geocoded by the API at request time.</summary>
+        [JsonPropertyName("address")]
+        public string? Address { get; set; }
+
+        /// <summary>
+        /// True if this waypoint is a pass-through point (no stop). Only meaningful for
+        /// intermediate waypoints; ignored for origin/destination.
+        /// </summary>
+        [JsonPropertyName("via")]
+        public bool? Via { get; set; }
+
+        /// <summary>
+        /// True if the waypoint is on a particular side of the road (so the route prefers
+        /// approaches from that side). Driving routes only.
+        /// </summary>
+        [JsonPropertyName("sideOfRoad")]
+        public bool? SideOfRoad { get; set; }
+
+        /// <summary>
+        /// True if the waypoint is intended as a stop where the vehicle parks. Affects
+        /// guidance for the leg and U-turn preferences.
+        /// </summary>
+        [JsonPropertyName("vehicleStopover")]
+        public bool? VehicleStopover { get; set; }
+
+        /// <summary>
+        /// Creates a waypoint from a free-text address.
+        /// </summary>
+        public static Waypoint FromAddress(string address) => new Waypoint { Address = address };
+
+        /// <summary>
+        /// Creates a waypoint from a Places place ID.
+        /// </summary>
+        public static Waypoint FromPlaceId(string placeId) => new Waypoint { PlaceId = placeId };
+
+        /// <summary>
+        /// Creates a waypoint from a latitude/longitude pair.
+        /// </summary>
+        public static Waypoint FromCoordinates(double latitude, double longitude)
+            => new Waypoint { Location = new WaypointLocation { LatLng = new LatLng { Latitude = latitude, Longitude = longitude } } };
+    }
+
+    /// <summary>Geographic location of a <see cref="Waypoint"/>.</summary>
+    public sealed class WaypointLocation
+    {
+        /// <summary>Latitude / longitude in WGS84.</summary>
+        [JsonPropertyName("latLng")]
+        public LatLng? LatLng { get; set; }
+
+        /// <summary>
+        /// Compass heading in degrees [0, 360) the vehicle is moving in. Only meaningful for
+        /// driving routes and only respected when <see cref="Waypoint.SideOfRoad"/> is true.
+        /// </summary>
+        [JsonPropertyName("heading")]
+        public int? Heading { get; set; }
+    }
+
+    /// <summary>Latitude/longitude pair in WGS84 (Google's <c>google.type.LatLng</c>).</summary>
+    public sealed class LatLng
+    {
+        /// <summary>Latitude in decimal degrees.</summary>
+        [JsonPropertyName("latitude")]
+        public double Latitude { get; set; }
+
+        /// <summary>Longitude in decimal degrees.</summary>
+        [JsonPropertyName("longitude")]
+        public double Longitude { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/Routes/Response/DurationParser.cs
+++ b/GoogleMapsApi/Entities/Routes/Response/DurationParser.cs
@@ -1,0 +1,21 @@
+using System.Globalization;
+
+namespace GoogleMapsApi.Entities.Routes.Response
+{
+    /// <summary>
+    /// Parses protobuf-duration strings ("123s", "12.5s") returned by the Routes API.
+    /// </summary>
+    internal static class DurationParser
+    {
+        public static double? ToSeconds(string? raw)
+        {
+            if (string.IsNullOrEmpty(raw))
+                return null;
+
+            var trimmed = raw!.EndsWith("s") ? raw.Substring(0, raw.Length - 1) : raw;
+            return double.TryParse(trimmed, NumberStyles.Float, CultureInfo.InvariantCulture, out var seconds)
+                ? seconds
+                : (double?)null;
+        }
+    }
+}

--- a/GoogleMapsApi/Entities/Routes/Response/FallbackInfo.cs
+++ b/GoogleMapsApi/Entities/Routes/Response/FallbackInfo.cs
@@ -1,0 +1,46 @@
+using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
+
+namespace GoogleMapsApi.Entities.Routes.Response
+{
+    /// <summary>
+    /// Populated when the Routes API had to fall back to a different routing mode than the one
+    /// requested (e.g. live traffic was unavailable).
+    /// </summary>
+    public sealed class FallbackInfo
+    {
+        /// <summary>Routing mode actually used.</summary>
+        [JsonPropertyName("routingMode")]
+        public FallbackRoutingMode? RoutingMode { get; set; }
+
+        /// <summary>Why the fallback occurred.</summary>
+        [JsonPropertyName("reason")]
+        public FallbackReason? Reason { get; set; }
+    }
+
+    /// <summary>Actual routing mode used when a fallback occurred.</summary>
+    public enum FallbackRoutingMode
+    {
+        /// <summary>Unspecified.</summary>
+        [EnumMember(Value = "FALLBACK_ROUTING_MODE_UNSPECIFIED")] Unspecified,
+
+        /// <summary>Live traffic was unavailable; a static route was returned.</summary>
+        [EnumMember(Value = "FALLBACK_TRAFFIC_UNAWARE")] TrafficUnaware,
+
+        /// <summary>Live traffic was used, but not the higher-fidelity optimal model.</summary>
+        [EnumMember(Value = "FALLBACK_TRAFFIC_AWARE")] TrafficAware,
+    }
+
+    /// <summary>Reason a fallback routing mode was used.</summary>
+    public enum FallbackReason
+    {
+        /// <summary>Unspecified.</summary>
+        [EnumMember(Value = "FALLBACK_REASON_UNSPECIFIED")] Unspecified,
+
+        /// <summary>Server error caused the fallback.</summary>
+        [EnumMember(Value = "SERVER_ERROR")] ServerError,
+
+        /// <summary>Latency exceeded the requested budget; a faster mode was used.</summary>
+        [EnumMember(Value = "LATENCY_EXCEEDED")] LatencyExceeded,
+    }
+}

--- a/GoogleMapsApi/Entities/Routes/Response/GeocodingResults.cs
+++ b/GoogleMapsApi/Entities/Routes/Response/GeocodingResults.cs
@@ -1,0 +1,67 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace GoogleMapsApi.Entities.Routes.Response
+{
+    /// <summary>
+    /// Diagnostic information about how the request's waypoints were geocoded. Returned only when
+    /// the request supplies waypoints by free-text address (waypoints supplied by place ID or
+    /// lat/lng do not require geocoding).
+    /// </summary>
+    public sealed class GeocodingResults
+    {
+        /// <summary>Geocoded origin waypoint.</summary>
+        [JsonPropertyName("origin")]
+        public GeocodedWaypoint? Origin { get; set; }
+
+        /// <summary>Geocoded destination waypoint.</summary>
+        [JsonPropertyName("destination")]
+        public GeocodedWaypoint? Destination { get; set; }
+
+        /// <summary>Geocoded intermediate waypoints, in input order.</summary>
+        [JsonPropertyName("intermediates")]
+        public List<GeocodedIntermediate>? Intermediates { get; set; }
+    }
+
+    /// <summary>Geocoded information for a single waypoint.</summary>
+    public class GeocodedWaypoint
+    {
+        /// <summary>
+        /// Status of the geocode. <c>0</c> indicates success; non-zero values indicate an error.
+        /// </summary>
+        [JsonPropertyName("geocoderStatus")]
+        public GeocoderStatus? GeocoderStatus { get; set; }
+
+        /// <summary>Resulting place ID for the geocoded location.</summary>
+        [JsonPropertyName("placeId")]
+        public string? PlaceId { get; set; }
+
+        /// <summary>Place type tags (e.g. <c>"street_address"</c>, <c>"premise"</c>).</summary>
+        [JsonPropertyName("type")]
+        public List<string>? Type { get; set; }
+
+        /// <summary>True if the geocode was a partial match (the input was not exact).</summary>
+        [JsonPropertyName("partialMatch")]
+        public bool? PartialMatch { get; set; }
+    }
+
+    /// <summary>Geocoded intermediate waypoint with its input position.</summary>
+    public sealed class GeocodedIntermediate : GeocodedWaypoint
+    {
+        /// <summary>Zero-based index of this waypoint in the request's <c>Intermediates</c> list.</summary>
+        [JsonPropertyName("intermediateWaypointRequestIndex")]
+        public int? IntermediateWaypointRequestIndex { get; set; }
+    }
+
+    /// <summary>RPC-style status returned by the geocoder.</summary>
+    public sealed class GeocoderStatus
+    {
+        /// <summary>Status code (0 means OK).</summary>
+        [JsonPropertyName("code")]
+        public int? Code { get; set; }
+
+        /// <summary>Human-readable status message.</summary>
+        [JsonPropertyName("message")]
+        public string? Message { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/Routes/Response/Polyline.cs
+++ b/GoogleMapsApi/Entities/Routes/Response/Polyline.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using GoogleMapsApi.Entities.Common;
+
+namespace GoogleMapsApi.Entities.Routes.Response
+{
+    /// <summary>
+    /// Polyline returned by the Routes API. By default the API returns the encoded-polyline
+    /// format (same as the legacy Directions API); use the <see cref="DecodedPoints"/>
+    /// helper to expand it into a list of <see cref="Location"/>s.
+    /// </summary>
+    public sealed class Polyline
+    {
+        /// <summary>Encoded polyline string. See <see cref="DecodedPoints"/>.</summary>
+        [JsonPropertyName("encodedPolyline")]
+        public string? EncodedPolyline { get; set; }
+
+        /// <summary>
+        /// Raw GeoJSON LineString returned when
+        /// <see cref="Request.RoutesRequest.PolylineEncoding"/> is set to
+        /// <see cref="Request.PolylineEncoding.GeoJsonLineString"/>. Decoding is left to the
+        /// caller (any GeoJSON library will do).
+        /// </summary>
+        [JsonPropertyName("geoJsonLinestring")]
+        public object? GeoJsonLinestring { get; set; }
+
+        private Lazy<IReadOnlyList<Location>>? _pointsLazy;
+
+        /// <summary>
+        /// Decoded points from <see cref="EncodedPolyline"/>. Empty when no encoded polyline is set.
+        /// </summary>
+        [JsonIgnore]
+        public IReadOnlyList<Location> DecodedPoints =>
+            (_pointsLazy ??= new Lazy<IReadOnlyList<Location>>(() => EncodedPolylineDecoder.Decode(EncodedPolyline))).Value;
+    }
+}

--- a/GoogleMapsApi/Entities/Routes/Response/Route.cs
+++ b/GoogleMapsApi/Entities/Routes/Response/Route.cs
@@ -1,0 +1,88 @@
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
+
+namespace GoogleMapsApi.Entities.Routes.Response
+{
+    /// <summary>A computed route — usually one per response, more when alternatives are requested.</summary>
+    public sealed class Route
+    {
+        /// <summary>Labels describing this route (e.g. <c>DEFAULT_ROUTE</c>, <c>FUEL_EFFICIENT</c>).</summary>
+        [JsonPropertyName("routeLabels")]
+        public List<RouteLabel>? RouteLabels { get; set; }
+
+        /// <summary>Legs of the route (one per origin/intermediate/destination pair).</summary>
+        [JsonPropertyName("legs")]
+        public List<RouteLeg>? Legs { get; set; }
+
+        /// <summary>Total distance covered by the route in meters.</summary>
+        [JsonPropertyName("distanceMeters")]
+        public int? DistanceMeters { get; set; }
+
+        /// <summary>
+        /// Total travel time including traffic. Returned as a protobuf-duration string
+        /// (e.g. <c>"123s"</c>); see <see cref="DurationSeconds"/> for a parsed numeric value.
+        /// </summary>
+        [JsonPropertyName("duration")]
+        public string? Duration { get; set; }
+
+        /// <summary><see cref="Duration"/> parsed to a number of seconds.</summary>
+        [JsonIgnore]
+        public double? DurationSeconds => DurationParser.ToSeconds(Duration);
+
+        /// <summary>
+        /// Travel time ignoring current traffic. Also a protobuf-duration string;
+        /// see <see cref="StaticDurationSeconds"/>.
+        /// </summary>
+        [JsonPropertyName("staticDuration")]
+        public string? StaticDuration { get; set; }
+
+        /// <summary><see cref="StaticDuration"/> parsed to a number of seconds.</summary>
+        [JsonIgnore]
+        public double? StaticDurationSeconds => DurationParser.ToSeconds(StaticDuration);
+
+        /// <summary>Encoded polyline of the route geometry.</summary>
+        [JsonPropertyName("polyline")]
+        public Polyline? Polyline { get; set; }
+
+        /// <summary>Free-text descriptions of conditions affecting the route.</summary>
+        [JsonPropertyName("warnings")]
+        public List<string>? Warnings { get; set; }
+
+        /// <summary>Bounding viewport that contains the route.</summary>
+        [JsonPropertyName("viewport")]
+        public Viewport? Viewport { get; set; }
+
+        /// <summary>Travel-advisory metadata (toll info, fuel consumption, speed-reading intervals).</summary>
+        [JsonPropertyName("travelAdvisory")]
+        public RouteTravelAdvisory? TravelAdvisory { get; set; }
+
+        /// <summary>
+        /// Optimized intermediate-waypoint order when
+        /// <see cref="Request.RoutesRequest.OptimizeWaypointOrder"/> is true. The values are
+        /// zero-based indices into the request's <c>Intermediates</c> array.
+        /// </summary>
+        [JsonPropertyName("optimizedIntermediateWaypointIndex")]
+        public List<int>? OptimizedIntermediateWaypointIndex { get; set; }
+
+        /// <summary>Token usable with the Navigation SDK to start turn-by-turn for this route.</summary>
+        [JsonPropertyName("routeToken")]
+        public string? RouteToken { get; set; }
+    }
+
+    /// <summary>Labels describing a returned route's category.</summary>
+    public enum RouteLabel
+    {
+        /// <summary>Unspecified.</summary>
+        [EnumMember(Value = "ROUTE_LABEL_UNSPECIFIED")] Unspecified,
+
+        /// <summary>The default best route.</summary>
+        [EnumMember(Value = "DEFAULT_ROUTE")] DefaultRoute,
+
+        /// <summary>An alternative to the default route.</summary>
+        [EnumMember(Value = "DEFAULT_ROUTE_ALTERNATE")] DefaultRouteAlternate,
+
+        /// <summary>The fuel-efficient route reference (when requested).</summary>
+        [EnumMember(Value = "FUEL_EFFICIENT")] FuelEfficient,
+    }
+}

--- a/GoogleMapsApi/Entities/Routes/Response/RouteLeg.cs
+++ b/GoogleMapsApi/Entities/Routes/Response/RouteLeg.cs
@@ -1,0 +1,57 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace GoogleMapsApi.Entities.Routes.Response
+{
+    /// <summary>A single leg of a <see cref="Route"/> (between two waypoints).</summary>
+    public sealed class RouteLeg
+    {
+        /// <summary>Distance covered by this leg in meters.</summary>
+        [JsonPropertyName("distanceMeters")]
+        public int? DistanceMeters { get; set; }
+
+        /// <summary>Travel time for this leg as a protobuf-duration string (e.g. <c>"123s"</c>).</summary>
+        [JsonPropertyName("duration")]
+        public string? Duration { get; set; }
+
+        /// <summary><see cref="Duration"/> parsed to seconds.</summary>
+        [JsonIgnore]
+        public double? DurationSeconds => DurationParser.ToSeconds(Duration);
+
+        /// <summary>Static (traffic-free) travel time for this leg as a protobuf-duration string.</summary>
+        [JsonPropertyName("staticDuration")]
+        public string? StaticDuration { get; set; }
+
+        /// <summary><see cref="StaticDuration"/> parsed to seconds.</summary>
+        [JsonIgnore]
+        public double? StaticDurationSeconds => DurationParser.ToSeconds(StaticDuration);
+
+        /// <summary>Polyline of this leg.</summary>
+        [JsonPropertyName("polyline")]
+        public Polyline? Polyline { get; set; }
+
+        /// <summary>Start location of the leg (waypoint snapped to road).</summary>
+        [JsonPropertyName("startLocation")]
+        public LegLocation? StartLocation { get; set; }
+
+        /// <summary>End location of the leg (waypoint snapped to road).</summary>
+        [JsonPropertyName("endLocation")]
+        public LegLocation? EndLocation { get; set; }
+
+        /// <summary>Steps that make up this leg.</summary>
+        [JsonPropertyName("steps")]
+        public List<RouteLegStep>? Steps { get; set; }
+
+        /// <summary>Travel-advisory metadata for the leg.</summary>
+        [JsonPropertyName("travelAdvisory")]
+        public RouteLegTravelAdvisory? TravelAdvisory { get; set; }
+    }
+
+    /// <summary>Geographic location of a leg endpoint.</summary>
+    public sealed class LegLocation
+    {
+        /// <summary>Latitude / longitude in WGS84.</summary>
+        [JsonPropertyName("latLng")]
+        public Request.LatLng? LatLng { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/Routes/Response/RouteLegStep.cs
+++ b/GoogleMapsApi/Entities/Routes/Response/RouteLegStep.cs
@@ -1,0 +1,120 @@
+using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
+
+namespace GoogleMapsApi.Entities.Routes.Response
+{
+    /// <summary>A single navigation step within a <see cref="RouteLeg"/>.</summary>
+    public sealed class RouteLegStep
+    {
+        /// <summary>Distance covered by this step in meters.</summary>
+        [JsonPropertyName("distanceMeters")]
+        public int? DistanceMeters { get; set; }
+
+        /// <summary>Static (traffic-free) duration of the step as a protobuf-duration string.</summary>
+        [JsonPropertyName("staticDuration")]
+        public string? StaticDuration { get; set; }
+
+        /// <summary><see cref="StaticDuration"/> parsed to seconds.</summary>
+        [JsonIgnore]
+        public double? StaticDurationSeconds => DurationParser.ToSeconds(StaticDuration);
+
+        /// <summary>Polyline of this step.</summary>
+        [JsonPropertyName("polyline")]
+        public Polyline? Polyline { get; set; }
+
+        /// <summary>Start location of the step.</summary>
+        [JsonPropertyName("startLocation")]
+        public LegLocation? StartLocation { get; set; }
+
+        /// <summary>End location of the step.</summary>
+        [JsonPropertyName("endLocation")]
+        public LegLocation? EndLocation { get; set; }
+
+        /// <summary>Navigation instruction for the step.</summary>
+        [JsonPropertyName("navigationInstruction")]
+        public NavigationInstruction? NavigationInstruction { get; set; }
+
+        /// <summary>Travel mode used for this step (relevant on transit/multi-modal routes).</summary>
+        [JsonPropertyName("travelMode")]
+        public Request.RoutesTravelMode? TravelMode { get; set; }
+    }
+
+    /// <summary>Turn-by-turn navigation instruction for a step.</summary>
+    public sealed class NavigationInstruction
+    {
+        /// <summary>High-level maneuver type (e.g. <c>TURN_LEFT</c>).</summary>
+        [JsonPropertyName("maneuver")]
+        public Maneuver? Maneuver { get; set; }
+
+        /// <summary>Human-readable instruction text.</summary>
+        [JsonPropertyName("instructions")]
+        public string? Instructions { get; set; }
+    }
+
+    /// <summary>Maneuver categories returned by the Routes API.</summary>
+    public enum Maneuver
+    {
+        /// <summary>Unspecified.</summary>
+        [EnumMember(Value = "MANEUVER_UNSPECIFIED")] Unspecified,
+
+        /// <summary>Turn slightly to the left.</summary>
+        [EnumMember(Value = "TURN_SLIGHT_LEFT")] TurnSlightLeft,
+
+        /// <summary>Turn sharply to the left.</summary>
+        [EnumMember(Value = "TURN_SHARP_LEFT")] TurnSharpLeft,
+
+        /// <summary>Make a left U-turn.</summary>
+        [EnumMember(Value = "UTURN_LEFT")] UTurnLeft,
+
+        /// <summary>Turn left.</summary>
+        [EnumMember(Value = "TURN_LEFT")] TurnLeft,
+
+        /// <summary>Turn slightly to the right.</summary>
+        [EnumMember(Value = "TURN_SLIGHT_RIGHT")] TurnSlightRight,
+
+        /// <summary>Turn sharply to the right.</summary>
+        [EnumMember(Value = "TURN_SHARP_RIGHT")] TurnSharpRight,
+
+        /// <summary>Make a right U-turn.</summary>
+        [EnumMember(Value = "UTURN_RIGHT")] UTurnRight,
+
+        /// <summary>Turn right.</summary>
+        [EnumMember(Value = "TURN_RIGHT")] TurnRight,
+
+        /// <summary>Continue straight.</summary>
+        [EnumMember(Value = "STRAIGHT")] Straight,
+
+        /// <summary>Take the ramp to the left.</summary>
+        [EnumMember(Value = "RAMP_LEFT")] RampLeft,
+
+        /// <summary>Take the ramp to the right.</summary>
+        [EnumMember(Value = "RAMP_RIGHT")] RampRight,
+
+        /// <summary>Merge.</summary>
+        [EnumMember(Value = "MERGE")] Merge,
+
+        /// <summary>Take the fork on the left.</summary>
+        [EnumMember(Value = "FORK_LEFT")] ForkLeft,
+
+        /// <summary>Take the fork on the right.</summary>
+        [EnumMember(Value = "FORK_RIGHT")] ForkRight,
+
+        /// <summary>Take the ferry.</summary>
+        [EnumMember(Value = "FERRY")] Ferry,
+
+        /// <summary>Take a train onto a ferry.</summary>
+        [EnumMember(Value = "FERRY_TRAIN")] FerryTrain,
+
+        /// <summary>Turn left at a roundabout.</summary>
+        [EnumMember(Value = "ROUNDABOUT_LEFT")] RoundaboutLeft,
+
+        /// <summary>Turn right at a roundabout.</summary>
+        [EnumMember(Value = "ROUNDABOUT_RIGHT")] RoundaboutRight,
+
+        /// <summary>Initial maneuver — depart.</summary>
+        [EnumMember(Value = "DEPART")] Depart,
+
+        /// <summary>Used to indicate a street name change.</summary>
+        [EnumMember(Value = "NAME_CHANGE")] NameChange,
+    }
+}

--- a/GoogleMapsApi/Entities/Routes/Response/RouteTravelAdvisory.cs
+++ b/GoogleMapsApi/Entities/Routes/Response/RouteTravelAdvisory.cs
@@ -1,0 +1,99 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace GoogleMapsApi.Entities.Routes.Response
+{
+    /// <summary>Route-level advisory metadata returned when the corresponding extra computations are requested.</summary>
+    public sealed class RouteTravelAdvisory
+    {
+        /// <summary>Toll information for the route. Populated when <see cref="Request.ExtraComputation.Tolls"/> is requested.</summary>
+        [JsonPropertyName("tollInfo")]
+        public TollInfo? TollInfo { get; set; }
+
+        /// <summary>
+        /// Estimated fuel consumption in microliters. Populated when
+        /// <see cref="Request.ExtraComputation.FuelConsumption"/> is requested.
+        /// </summary>
+        [JsonPropertyName("fuelConsumptionMicroliters")]
+        public string? FuelConsumptionMicroliters { get; set; }
+
+        /// <summary>
+        /// Speed-reading intervals over the route polyline. Populated when
+        /// <see cref="Request.ExtraComputation.TrafficOnPolyline"/> is requested.
+        /// </summary>
+        [JsonPropertyName("speedReadingIntervals")]
+        public List<SpeedReadingInterval>? SpeedReadingIntervals { get; set; }
+    }
+
+    /// <summary>Leg-level advisory metadata.</summary>
+    public sealed class RouteLegTravelAdvisory
+    {
+        /// <summary>Toll information for the leg.</summary>
+        [JsonPropertyName("tollInfo")]
+        public TollInfo? TollInfo { get; set; }
+
+        /// <summary>Speed-reading intervals over the leg polyline.</summary>
+        [JsonPropertyName("speedReadingIntervals")]
+        public List<SpeedReadingInterval>? SpeedReadingIntervals { get; set; }
+    }
+
+    /// <summary>Toll cost summary.</summary>
+    public sealed class TollInfo
+    {
+        /// <summary>Estimated toll prices, one per currency the route crosses.</summary>
+        [JsonPropertyName("estimatedPrice")]
+        public List<Money>? EstimatedPrice { get; set; }
+    }
+
+    /// <summary>
+    /// Monetary amount in a given currency (Google's <c>google.type.Money</c>).
+    /// </summary>
+    public sealed class Money
+    {
+        /// <summary>Three-letter ISO 4217 currency code (e.g. <c>"USD"</c>).</summary>
+        [JsonPropertyName("currencyCode")]
+        public string? CurrencyCode { get; set; }
+
+        /// <summary>Whole units of the amount (e.g. 42 USD).</summary>
+        [JsonPropertyName("units")]
+        public string? Units { get; set; }
+
+        /// <summary>
+        /// Fractional units, in nanos (10^-9). 100,000,000 nanos = $0.10. Sign matches <see cref="Units"/>.
+        /// </summary>
+        [JsonPropertyName("nanos")]
+        public int? Nanos { get; set; }
+    }
+
+    /// <summary>One segment of speed information over the polyline.</summary>
+    public sealed class SpeedReadingInterval
+    {
+        /// <summary>Starting polyline-point index (inclusive).</summary>
+        [JsonPropertyName("startPolylinePointIndex")]
+        public int? StartPolylinePointIndex { get; set; }
+
+        /// <summary>Ending polyline-point index (exclusive).</summary>
+        [JsonPropertyName("endPolylinePointIndex")]
+        public int? EndPolylinePointIndex { get; set; }
+
+        /// <summary>Traffic speed bucket for the interval.</summary>
+        [JsonPropertyName("speed")]
+        public Speed? Speed { get; set; }
+    }
+
+    /// <summary>Traffic speed bucket.</summary>
+    public enum Speed
+    {
+        /// <summary>Unspecified.</summary>
+        [System.Runtime.Serialization.EnumMember(Value = "SPEED_UNSPECIFIED")] Unspecified,
+
+        /// <summary>Normal speed; no congestion.</summary>
+        [System.Runtime.Serialization.EnumMember(Value = "NORMAL")] Normal,
+
+        /// <summary>Slow speed; light congestion.</summary>
+        [System.Runtime.Serialization.EnumMember(Value = "SLOW")] Slow,
+
+        /// <summary>Traffic jam.</summary>
+        [System.Runtime.Serialization.EnumMember(Value = "TRAFFIC_JAM")] TrafficJam,
+    }
+}

--- a/GoogleMapsApi/Entities/Routes/Response/RoutesResponse.cs
+++ b/GoogleMapsApi/Entities/Routes/Response/RoutesResponse.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using GoogleMapsApi.Entities.Common;
+using GoogleMapsApi.Entities.Routes.Request;
+
+namespace GoogleMapsApi.Entities.Routes.Response
+{
+    /// <summary>Response from the Google Routes API <c>computeRoutes</c> endpoint.</summary>
+    /// <remarks>
+    /// Which top-level fields are populated depends on what was requested via
+    /// <see cref="RoutesRequest.FieldMask"/>. Fields outside the mask are returned as null.
+    /// </remarks>
+    public sealed class RoutesResponse : IResponseFor<RoutesRequest>
+    {
+        /// <summary>
+        /// Computed routes. If <see cref="RoutesRequest.ComputeAlternativeRoutes"/> was true,
+        /// the API may return up to two additional alternatives.
+        /// </summary>
+        [JsonPropertyName("routes")]
+        public List<Route>? Routes { get; set; }
+
+        /// <summary>
+        /// Populated when the request asked for traffic-aware routing but the API fell back to
+        /// a different mode (e.g. live traffic unavailable).
+        /// </summary>
+        [JsonPropertyName("fallbackInfo")]
+        public FallbackInfo? FallbackInfo { get; set; }
+
+        /// <summary>Diagnostic information about waypoint geocoding.</summary>
+        [JsonPropertyName("geocodingResults")]
+        public GeocodingResults? GeocodingResults { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/Routes/Response/Viewport.cs
+++ b/GoogleMapsApi/Entities/Routes/Response/Viewport.cs
@@ -1,0 +1,16 @@
+using System.Text.Json.Serialization;
+
+namespace GoogleMapsApi.Entities.Routes.Response
+{
+    /// <summary>Latitude/longitude viewport that bounds a route or feature.</summary>
+    public sealed class Viewport
+    {
+        /// <summary>Low (southwest) corner.</summary>
+        [JsonPropertyName("low")]
+        public Request.LatLng? Low { get; set; }
+
+        /// <summary>High (northeast) corner.</summary>
+        [JsonPropertyName("high")]
+        public Request.LatLng? High { get; set; }
+    }
+}

--- a/GoogleMapsApi/GoogleMaps.cs
+++ b/GoogleMapsApi/GoogleMaps.cs
@@ -24,6 +24,8 @@ using GoogleMapsApi.Entities.PlacesNearBy.Request;
 using GoogleMapsApi.Entities.PlacesNearBy.Response;
 using GoogleMapsApi.Entities.PlacesFind.Response;
 using GoogleMapsApi.Entities.PlacesFind.Request;
+using GoogleMapsApi.Entities.Routes.Request;
+using GoogleMapsApi.Entities.Routes.Response;
 using System;
 
 namespace GoogleMapsApi
@@ -147,6 +149,19 @@ namespace GoogleMapsApi
             get
             {
                 return EngineFacade<AddressValidationRequest, AddressValidationResponse>.Instance;
+            }
+        }
+
+        /// <summary>
+        /// Compute routes via the Routes API — the modern replacement for the Directions API.
+        /// Supports real-time traffic, eco-routing, toll calculation, two-wheeled vehicles, and
+        /// route alternatives.
+        /// </summary>
+        public static IEngineFacade<RoutesRequest, RoutesResponse> Routes
+        {
+            get
+            {
+                return EngineFacade<RoutesRequest, RoutesResponse>.Instance;
             }
         }
 

--- a/GoogleMapsApi/GoogleMapsClient.cs
+++ b/GoogleMapsApi/GoogleMapsClient.cs
@@ -21,6 +21,8 @@ using GoogleMapsApi.Entities.PlacesNearBy.Request;
 using GoogleMapsApi.Entities.PlacesNearBy.Response;
 using GoogleMapsApi.Entities.PlacesText.Request;
 using GoogleMapsApi.Entities.PlacesText.Response;
+using GoogleMapsApi.Entities.Routes.Request;
+using GoogleMapsApi.Entities.Routes.Response;
 using GoogleMapsApi.Entities.TimeZone.Request;
 using GoogleMapsApi.Entities.TimeZone.Response;
 using System;
@@ -70,6 +72,7 @@ namespace GoogleMapsApi
             PlacesFind = new HttpClientEngineFacade<PlacesFindRequest, PlacesFindResponse>(httpClient, options);
             DistanceMatrix = new HttpClientEngineFacade<DistanceMatrixRequest, DistanceMatrixResponse>(httpClient, options);
             AddressValidation = new HttpClientEngineFacade<AddressValidationRequest, AddressValidationResponse>(httpClient, options);
+            Routes = new HttpClientEngineFacade<RoutesRequest, RoutesResponse>(httpClient, options);
         }
 
         /// <inheritdoc/>
@@ -107,5 +110,8 @@ namespace GoogleMapsApi
 
         /// <inheritdoc/>
         public IEngineFacade<AddressValidationRequest, AddressValidationResponse> AddressValidation { get; }
+
+        /// <inheritdoc/>
+        public IEngineFacade<RoutesRequest, RoutesResponse> Routes { get; }
     }
 }

--- a/GoogleMapsApi/IGoogleMapsClient.cs
+++ b/GoogleMapsApi/IGoogleMapsClient.cs
@@ -20,6 +20,8 @@ using GoogleMapsApi.Entities.PlacesNearBy.Request;
 using GoogleMapsApi.Entities.PlacesNearBy.Response;
 using GoogleMapsApi.Entities.PlacesText.Request;
 using GoogleMapsApi.Entities.PlacesText.Response;
+using GoogleMapsApi.Entities.Routes.Request;
+using GoogleMapsApi.Entities.Routes.Response;
 using GoogleMapsApi.Entities.TimeZone.Request;
 using GoogleMapsApi.Entities.TimeZone.Response;
 
@@ -67,5 +69,10 @@ namespace GoogleMapsApi
 
         /// <summary>Validate a postal address (Address Validation API). Supports USPS CASS for US/PR addresses.</summary>
         IEngineFacade<AddressValidationRequest, AddressValidationResponse> AddressValidation { get; }
+
+        /// <summary>
+        /// Compute routes via the Routes API — the modern replacement for the Directions API.
+        /// </summary>
+        IEngineFacade<RoutesRequest, RoutesResponse> Routes { get; }
     }
 }

--- a/README.md
+++ b/README.md
@@ -10,14 +10,15 @@ Release history: see [CHANGELOG.md](CHANGELOG.md).
 
 # GoogleMapsApi
 
-A friendly, strongly-typed .NET wrapper for the Google Maps Web Services APIs — Geocoding, Directions, Distance Matrix, Elevation, Time Zone, Places, and Static Maps. Multi-framework (net10.0, net8.0, netstandard2.0, net481, net462), async-first, and battle-tested with **2M+ downloads** on NuGet.
+A friendly, strongly-typed .NET wrapper for the Google Maps Web Services APIs — Geocoding, Routes, Directions, Distance Matrix, Elevation, Time Zone, Places, Address Validation, and Static Maps. Multi-framework (net10.0, net8.0, netstandard2.0, net481, net462), async-first, and battle-tested with **2M+ downloads** on NuGet.
 
 ## Supported APIs
 
 | API | Description |
 | --- | --- |
 | [Geocoding](https://developers.google.com/maps/documentation/geocoding) | Convert between addresses and geographic coordinates |
-| [Directions](https://developers.google.com/maps/documentation/directions) | Route planning between two points with multiple travel modes |
+| [Routes](https://developers.google.com/maps/documentation/routes) | Modern route planning — real-time traffic, eco-routing, toll calc, two-wheeled vehicles (replaces Directions) |
+| [Directions](https://developers.google.com/maps/documentation/directions) | Legacy route planning between two points with multiple travel modes |
 | [Distance Matrix](https://developers.google.com/maps/documentation/distance-matrix) | Travel time and distance between multiple origins/destinations |
 | [Elevation](https://developers.google.com/maps/documentation/elevation) | Elevation data for individual locations or paths |
 | [Time Zone](https://developers.google.com/maps/documentation/timezone) | Time zone information for any coordinate |
@@ -119,6 +120,29 @@ string url = staticMapGenerator.GenerateStaticMapURL(new StaticMapRequest(new Lo
     }}
 });
 Console.WriteLine("Map with path: " + url);
+```
+
+### Routes API (modern replacement for Directions)
+
+The Routes API is Google's modern replacement for the Directions API — it supports real-time traffic, eco-routing, toll calculation, two-wheeled vehicles, and route alternatives. Unlike Directions, it requires a [field mask](https://developers.google.com/maps/documentation/routes/choose_fields) to constrain the response. A sensible default is pre-populated; tighten it to reduce response size and cost.
+
+``` C#
+using GoogleMapsApi;
+using GoogleMapsApi.Entities.Routes.Request;
+
+var request = new RoutesRequest
+{
+    ApiKey = "your-google-maps-api-key",
+    Origin = Waypoint.FromAddress("San Francisco, CA"),
+    Destination = Waypoint.FromAddress("Mountain View, CA"),
+    TravelMode = RoutesTravelMode.Drive,
+    RoutingPreference = RoutingPreference.TrafficAware,
+    // FieldMask defaults to a Directions-equivalent shape; override to slim the response.
+};
+
+var response = await GoogleMaps.Routes.QueryAsync(request);
+var route = response.Routes![0];
+Console.WriteLine($"{route.DistanceMeters} m, {route.DurationSeconds} s");
 ```
 
 ### Instance-based client (`IHttpClientFactory`-friendly)


### PR DESCRIPTION
## What

Adds support for the **Google Routes API** — Google's modern replacement for the legacy Directions API. This is the P1 ★★★★★ "existential" item from the improvement plan: without it the library drifts toward "legacy projects only" as Google steers new projects to Routes.

## Highlights

- **POST-based** request to `directions/v2:computeRoutes` (not GET), with a **required field mask** that defaults to a Directions-equivalent shape and can be tightened to cut response size/cost.
- Strongly-typed request/response entities under `Entities/Routes/` — waypoints, route modifiers, transit preferences, travel modes, polyline quality/encoding, extra computations, etc.
- Wired into **both** surfaces: static `GoogleMaps.Routes` and instance `IGoogleMapsClient.Routes`.
- Shared polyline decoding extracted into `EncodedPolylineDecoder`, now reused by Directions' `OverviewPolyline` and the Routes response (removes duplication).
- **Directions API left fully intact** for back-compat.
- README usage section + unit and integration tests.

## Testing

- `dotnet build` clean, 0 warnings.
- **147 unit tests pass** (incl. existing Directions/polyline tests after the decoder refactor).
- Routes integration tests are written but require the Routes API to be enabled on the test key (currently returns 403 `PERMISSION_DENIED` in CI without it).

## Notes

- Targets the existing multi-TFM matrix; no new dependencies.
- `CHANGELOG.md` intentionally not edited — it's auto-generated by `release.sh`.