### PR TITLE
test(ci): skip billable Places API tests by default

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [ master ]
   pull_request:
+    # 'labeled' lets applying the run-billable-tests label start a run on demand.
+    types: [opened, synchronize, reopened, labeled]
   workflow_dispatch:
     inputs:
       frameworks:
@@ -15,6 +17,11 @@ on:
           - 'net10.0'
           - 'net8.0'
           - 'both'
+      run_billable:
+        description: 'Run billable API tests (Places) — counts against paid quota'
+        type: boolean
+        required: false
+        default: false
 
 permissions:
   contents: read
@@ -51,11 +58,15 @@ jobs:
       run: dotnet test --no-build --verbosity normal --framework net8.0 --logger "junit;LogFilePath=test-results/{assembly}.net8.0.xml"
       env:
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          # Enabled by the manual Run-workflow checkbox OR a run-billable-tests label on the PR.
+          RUN_BILLABLE_TESTS: ${{ inputs.run_billable || contains(github.event.pull_request.labels.*.name, 'run-billable-tests') }}
     - name: Test (net10.0)
       if: github.event_name != 'workflow_dispatch' || inputs.frameworks == 'net10.0' || inputs.frameworks == 'both'
       run: dotnet test --no-build --verbosity normal --framework net10.0 --logger "junit;LogFilePath=test-results/{assembly}.net10.0.xml"
       env:
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          # Enabled by the manual Run-workflow checkbox OR a run-billable-tests label on the PR.
+          RUN_BILLABLE_TESTS: ${{ inputs.run_billable || contains(github.event.pull_request.labels.*.name, 'run-billable-tests') }}
     - name: TestGlance
       if: always()
       uses: testglance/action@84cc24dfdf51e14f1b250bea788cdf2fc182d871  # v1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,20 @@ Integration tests require Google API key via:
 1. Environment variable: `GOOGLE_API_KEY=your_api_key`
 2. Test settings file: `GoogleMapsApi.Test/appsettings.json` (copy from `appsettings.template.json`)
 
+### Billable API Tests (skipped by default)
+Some Google APIs (currently Places) exceed the free quota and incur charges, so their integration
+fixtures (tagged `[BillableTest]`, category `Billable`) are **skipped by default** — including in
+CI. Opt in only when you specifically need them:
+```bash
+# Run the full suite including billable tests
+RUN_BILLABLE_TESTS=true dotnet test
+
+# Run only the billable tests
+RUN_BILLABLE_TESTS=true dotnet test --filter "TestCategory=Billable"
+```
+Annotate any fixture that calls a billable API with `[BillableTest]` (see `Utils/BillableTestAttribute.cs`).
+In CI, billable tests can also be triggered by adding the `run-billable-tests` label to a PR.
+
 ### Single Test Execution
 ```bash
 # Run specific test class

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,39 @@ via the `GOOGLE_API_KEY` environment variable, or copy
 `GoogleMapsApi.Test/appsettings.template.json` to `appsettings.json` and fill in the value.
 Note that running the test suite consumes your Google API quota.
 
+### Billable tests (Places API)
+
+Some Google APIs — currently **Places** — exceed the free quota and incur charges. Their
+integration fixtures are tagged `[BillableTest]` (category `Billable`, see
+`GoogleMapsApi.Test/Utils/BillableTestAttribute.cs`) and are **skipped by default** so a plain
+`dotnet test` never runs up the bill. Everything else runs as usual.
+
+Opt in only when you specifically need them, by setting the `RUN_BILLABLE_TESTS` environment
+variable to a truthy value (`1`, `true`, or `yes`):
+
+```bash
+# Run the full suite, including billable tests
+RUN_BILLABLE_TESTS=true dotnet test
+
+# Run only the billable tests
+RUN_BILLABLE_TESTS=true dotnet test --filter "TestCategory=Billable"
+```
+
+When adding a fixture that calls a billable API, annotate it with `[BillableTest]` so it stays
+off by default.
+
+#### Running billable tests in CI
+
+The same opt-in is wired into the `.NET` GitHub Actions workflow (`.github/workflows/dotnet.yml`),
+which keeps billable tests skipped on ordinary push/PR runs. Two ways to run them on demand:
+
+- **PR label** — add the `run-billable-tests` label to a pull request. Applying the label starts a
+  run, and it stays in effect while the label is present. (Labels can only be applied by
+  collaborators, and the workflow only runs for same-repo branches, so external PRs can't trigger
+  paid tests.)
+- **Manual run** — from the **Actions** tab, open the **.NET** workflow, click **Run workflow**, and
+  check **Run billable API tests (Places)**.
+
 ## Style
 
 Run `dotnet format` before pushing. It applies the repo's .editorconfig rules and keeps

--- a/GoogleMapsApi.Test/IntegrationTests/PlaceAutocompleteTests.cs
+++ b/GoogleMapsApi.Test/IntegrationTests/PlaceAutocompleteTests.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 namespace GoogleMapsApi.Test.IntegrationTests
 {
     [TestFixture]
+    [BillableTest]
     class PlaceAutocompleteTests : BaseTestIntegration
     {
         [Test]

--- a/GoogleMapsApi.Test/IntegrationTests/PlacesDetailsTests.cs
+++ b/GoogleMapsApi.Test/IntegrationTests/PlacesDetailsTests.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 namespace GoogleMapsApi.Test.IntegrationTests
 {
     [TestFixture]
+    [BillableTest]
     public class PlacesDetailsTests  : BaseTestIntegration
     {
         [Test]

--- a/GoogleMapsApi.Test/IntegrationTests/PlacesFindTests.cs
+++ b/GoogleMapsApi.Test/IntegrationTests/PlacesFindTests.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 namespace GoogleMapsApi.Test.IntegrationTests
 {
     [TestFixture]
+    [BillableTest]
     public class PlacesFindTests : BaseTestIntegration
     {
         [Test]

--- a/GoogleMapsApi.Test/IntegrationTests/PlacesNearByTests.cs
+++ b/GoogleMapsApi.Test/IntegrationTests/PlacesNearByTests.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 namespace GoogleMapsApi.Test.IntegrationTests
 {
     [TestFixture]
+    [BillableTest]
     public class PlacesNearByTests : BaseTestIntegration
     {
         [Test]

--- a/GoogleMapsApi.Test/IntegrationTests/PlacesNewTests.cs
+++ b/GoogleMapsApi.Test/IntegrationTests/PlacesNewTests.cs
@@ -2,11 +2,13 @@ using System.Linq;
 using System.Threading.Tasks;
 using GoogleMapsApi.Entities.PlacesNew.Common;
 using GoogleMapsApi.Entities.PlacesNew.Request;
+using GoogleMapsApi.Test.Utils;
 using NUnit.Framework;
 
 namespace GoogleMapsApi.Test.IntegrationTests
 {
     [TestFixture]
+    [BillableTest]
     public class PlacesNewTests : BaseTestIntegration
     {
         [Test]

--- a/GoogleMapsApi.Test/IntegrationTests/PlacesSearchTests.cs
+++ b/GoogleMapsApi.Test/IntegrationTests/PlacesSearchTests.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 namespace GoogleMapsApi.Test.IntegrationTests
 {
     [TestFixture]
+    [BillableTest]
     public class PlacesSearchTests : BaseTestIntegration
     {
         [Test]

--- a/GoogleMapsApi.Test/IntegrationTests/PlacesTextTests.cs
+++ b/GoogleMapsApi.Test/IntegrationTests/PlacesTextTests.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 namespace GoogleMapsApi.Test.IntegrationTests
 {
     [TestFixture]
+    [BillableTest]
     public class PlacesTextTests : BaseTestIntegration
     {
         [Test]

--- a/GoogleMapsApi.Test/Utils/BillableTestAttribute.cs
+++ b/GoogleMapsApi.Test/Utils/BillableTestAttribute.cs
@@ -1,0 +1,45 @@
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+
+namespace GoogleMapsApi.Test.Utils
+{
+    /// <summary>
+    /// Marks a test or fixture as exercising a billable Google API (one whose usage exceeds the
+    /// free quota and incurs charges, e.g. the Places API). These tests are skipped by default to
+    /// avoid running up the bill. Set the <c>RUN_BILLABLE_TESTS</c> environment variable to a
+    /// truthy value (<c>1</c>, <c>true</c> or <c>yes</c>) to opt in and run them.
+    /// </summary>
+    /// <remarks>
+    /// The attribute also tags the test with the <c>Billable</c> category, so runners can
+    /// additionally filter on it (e.g. <c>dotnet test --filter "TestCategory=Billable"</c>).
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
+    public sealed class BillableTestAttribute : NUnitAttribute, IApplyToTest
+    {
+        internal const string EnableEnvironmentVariable = "RUN_BILLABLE_TESTS";
+        internal const string Category = "Billable";
+
+        public void ApplyToTest(NUnit.Framework.Internal.Test test)
+        {
+            test.Properties.Add(PropertyNames.Category, Category);
+
+            if (test.RunState == RunState.NotRunnable || IsEnabled())
+                return;
+
+            test.RunState = RunState.Ignored;
+            test.Properties.Set(PropertyNames.SkipReason,
+                $"Billable API tests are skipped by default to avoid charges. Set {EnableEnvironmentVariable}=true to run them.");
+        }
+
+        private static bool IsEnabled()
+        {
+            var value = Environment.GetEnvironmentVariable(EnableEnvironmentVariable);
+
+            return !string.IsNullOrWhiteSpace(value)
+                && (value.Equals("1", StringComparison.OrdinalIgnoreCase)
+                    || value.Equals("true", StringComparison.OrdinalIgnoreCase)
+                    || value.Equals("yes", StringComparison.OrdinalIgnoreCase));
+        }
+    }
+}


### PR DESCRIPTION
## Why

Places API usage exceeds Google's free quota and incurs charges (a billing budget alert prompted this). On every push/PR, CI ran the full Places integration suite against the live, billable API — driving up cost. This makes those tests **opt-in** so the default `dotnet test` (locally and in CI) no longer hits the paid API.

## What

- **`[BillableTest]` attribute** (`GoogleMapsApi.Test/Utils/BillableTestAttribute.cs`) — an NUnit `IApplyToTest` attribute that marks a fixture `Ignored` unless `RUN_BILLABLE_TESTS` is truthy (`1`/`true`/`yes`), and tags it with category `Billable` for filtering.
- Applied `[BillableTest]` to the 7 Places fixtures (Details, Find, NearBy, New, Search, Text, Autocomplete).
- **Workflow** (`.github/workflows/dotnet.yml`) — billable tests run only when opted in, via either:
  - the **`run-billable-tests` PR label** (added a `labeled` trigger), or
  - the **`workflow_dispatch` checkbox** "Run billable API tests (Places)".
- Documented in `CONTRIBUTING.md` and `CLAUDE.md`.

Safety: labels are collaborator-only and the job already restricts to same-repo branches, so external PRs can't trigger paid tests.

## How to run billable tests

```bash
# locally
RUN_BILLABLE_TESTS=true dotnet test
RUN_BILLABLE_TESTS=true dotnet test --filter "TestCategory=Billable"
```
In CI: add the `run-billable-tests` label to the PR, or use Actions → .NET → Run workflow with the box checked.

## Verification

- Test project builds clean (net8.0).
- Default run: **26 billable tests skipped, 0 executed.**
- Opt-in (`RUN_BILLABLE_TESTS=true`) previously confirmed to execute a Places test.