### PR TITLE
docs: serve OpenSSF Scorecard badge from shields.io trusted domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![NuGet Version](https://img.shields.io/nuget/v/GoogleMapsApi.svg)](https://www.nuget.org/packages/GoogleMapsApi/)
 [![Build Status](https://github.com/maximn/google-maps/actions/workflows/dotnet.yml/badge.svg)](https://github.com/maximn/google-maps/actions/workflows/dotnet.yml)
 [![CodeQL](https://github.com/maximn/google-maps/actions/workflows/codeql.yml/badge.svg)](https://github.com/maximn/google-maps/actions/workflows/codeql.yml)
-[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/maximn/google-maps/badge)](https://scorecard.dev/viewer/?uri=github.com/maximn/google-maps)
+[![OpenSSF Scorecard](https://img.shields.io/ossf-scorecard/github.com/maximn/google-maps?label=openssf%20scorecard)](https://scorecard.dev/viewer/?uri=github.com/maximn/google-maps)
 [![License: BSD-2-Clause](https://img.shields.io/badge/License-BSD_2--Clause-blue.svg)](LICENSE.md)
 [![.NET](https://img.shields.io/badge/.NET-net10.0%20%7C%20net8.0%20%7C%20netstandard2.0%20%7C%20net481%20%7C%20net462-512BD4)](https://dotnet.microsoft.com/)
 


### PR DESCRIPTION
## Summary

NuGet only renders images from a trusted-domain allowlist. The OpenSSF Scorecard badge was served from `api.scorecard.dev`, which is not on that list, causing a yellow "Some images are not displayed" banner to appear on the NuGet package page. Routes it through `img.shields.io/ossf-scorecard` instead, which NuGet trusts. The link target (scorecard.dev viewer) is unchanged.

## Changes
- Replace `api.scorecard.dev` badge URL with `img.shields.io/ossf-scorecard` equivalent in `README.md`

## Test plan
- [ ] Confirm badge renders on GitHub README (preview in PR)
- [ ] Confirm NuGet warning disappears after next package publish
