### PR TITLE
docs(samples): add GenericHost.DistanceMatrix DI sample

### DIFF
--- a/GoogleMapsApi.sln
+++ b/GoogleMapsApi.sln
@@ -29,6 +29,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GoogleMapsApi.Extensions.De
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GoogleMapsApi.Extensions.DependencyInjection.Test", "GoogleMapsApi.Extensions.DependencyInjection.Test\GoogleMapsApi.Extensions.DependencyInjection.Test.csproj", "{3059B358-14F2-4835-9856-EBD07A578B7A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GenericHost.DistanceMatrix", "samples\GenericHost.DistanceMatrix\GenericHost.DistanceMatrix.csproj", "{41652BB3-0385-4E9E-A220-22F1D28764F3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -152,6 +154,22 @@ Global
 		{3059B358-14F2-4835-9856-EBD07A578B7A}.Release|x86.Build.0 = Release|Any CPU
 		{3059B358-14F2-4835-9856-EBD07A578B7A}.Release|x64.ActiveCfg = Release|Any CPU
 		{3059B358-14F2-4835-9856-EBD07A578B7A}.Release|x64.Build.0 = Release|Any CPU
+		{41652BB3-0385-4E9E-A220-22F1D28764F3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{41652BB3-0385-4E9E-A220-22F1D28764F3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{41652BB3-0385-4E9E-A220-22F1D28764F3}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{41652BB3-0385-4E9E-A220-22F1D28764F3}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{41652BB3-0385-4E9E-A220-22F1D28764F3}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{41652BB3-0385-4E9E-A220-22F1D28764F3}.Debug|x86.Build.0 = Debug|Any CPU
+		{41652BB3-0385-4E9E-A220-22F1D28764F3}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{41652BB3-0385-4E9E-A220-22F1D28764F3}.Debug|x64.Build.0 = Debug|Any CPU
+		{41652BB3-0385-4E9E-A220-22F1D28764F3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{41652BB3-0385-4E9E-A220-22F1D28764F3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{41652BB3-0385-4E9E-A220-22F1D28764F3}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{41652BB3-0385-4E9E-A220-22F1D28764F3}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{41652BB3-0385-4E9E-A220-22F1D28764F3}.Release|x86.ActiveCfg = Release|Any CPU
+		{41652BB3-0385-4E9E-A220-22F1D28764F3}.Release|x86.Build.0 = Release|Any CPU
+		{41652BB3-0385-4E9E-A220-22F1D28764F3}.Release|x64.ActiveCfg = Release|Any CPU
+		{41652BB3-0385-4E9E-A220-22F1D28764F3}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -164,6 +182,7 @@ Global
 		{9742F184-5CDF-49A8-B43A-1F691F077460} = {19C7D2B1-FE79-42F7-9F9E-4F403BDA6033}
 		{BF7FCFA6-53A5-4881-B79E-BDD064F3DCA0} = {950E065F-B61E-4C05-8C74-5F03946AD7E2}
 		{3059B358-14F2-4835-9856-EBD07A578B7A} = {9D09CCCC-6AFA-41EA-BFB3-4698FC5830E6}
+		{41652BB3-0385-4E9E-A220-22F1D28764F3} = {19C7D2B1-FE79-42F7-9F9E-4F403BDA6033}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {061AA237-7231-49DE-835A-296ED94715C4}

--- a/samples/GenericHost.DistanceMatrix/GenericHost.DistanceMatrix.csproj
+++ b/samples/GenericHost.DistanceMatrix/GenericHost.DistanceMatrix.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>Samples.GenericHost.DistanceMatrix</RootNamespace>
+    <AssemblyName>Samples.GenericHost.DistanceMatrix</AssemblyName>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\GoogleMapsApi.Extensions.DependencyInjection\GoogleMapsApi.Extensions.DependencyInjection.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+</Project>

--- a/samples/GenericHost.DistanceMatrix/Program.cs
+++ b/samples/GenericHost.DistanceMatrix/Program.cs
@@ -1,0 +1,34 @@
+using GoogleMapsApi;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Samples.GenericHost.DistanceMatrix;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+// Keep the repo-wide GOOGLE_API_KEY convention working by surfacing it into the
+// "GoogleMaps" section that AddGoogleMaps(IConfiguration) binds below.
+var envApiKey = Environment.GetEnvironmentVariable("GOOGLE_API_KEY");
+if (!string.IsNullOrWhiteSpace(envApiKey))
+{
+    builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+    {
+        ["GoogleMaps:ApiKey"] = envApiKey,
+    });
+}
+
+// Register IGoogleMapsClient (IHttpClientFactory-backed) and bind GoogleMapsClientOptions
+// from the "GoogleMaps" config section — appsettings.json, environment variables and
+// user secrets all flow through here, so the ambient API key lives in configuration.
+builder.Services.AddGoogleMaps(builder.Configuration.GetSection("GoogleMaps"));
+
+// A typical application service that depends on IGoogleMapsClient by constructor injection.
+builder.Services.AddSingleton<TravelTimeService>();
+
+using var host = builder.Build();
+
+var origin = args.ElementAtOrDefault(0) ?? "New York, NY";
+var destination = args.ElementAtOrDefault(1) ?? "Boston, MA";
+
+var travelTime = host.Services.GetRequiredService<TravelTimeService>();
+return await travelTime.RunAsync(origin, destination);

--- a/samples/GenericHost.DistanceMatrix/README.md
+++ b/samples/GenericHost.DistanceMatrix/README.md
@@ -1,0 +1,36 @@
+# GenericHost.DistanceMatrix
+
+Console app built on the .NET **Generic Host** that resolves an application service from the
+container and uses it to compute travel distance and duration between two places via the
+Distance Matrix API.
+
+This is the dedicated showcase for the
+[`GoogleMapsApi.Extensions.DependencyInjection`](../../GoogleMapsApi.Extensions.DependencyInjection/)
+package: `IGoogleMapsClient` is registered once with `AddGoogleMaps(...)` and the ambient API key
+is bound from **configuration**, so `TravelTimeService` depends only on `IGoogleMapsClient` and
+never sees the key or an `HttpClient`.
+
+## Run
+
+```bash
+GOOGLE_API_KEY=your_api_key dotnet run --project samples/GenericHost.DistanceMatrix -- "New York, NY" "Boston, MA"
+```
+
+Omit the origin/destination args and it defaults to New York → Boston.
+
+The API key resolves from (in order):
+
+1. The `GOOGLE_API_KEY` environment variable (mapped into `GoogleMaps:ApiKey` in `Program.cs`).
+2. The `GoogleMaps:ApiKey` configuration value — `appsettings.json`, user secrets, or a
+   `GoogleMaps__ApiKey` environment variable.
+
+## What this demonstrates
+
+- [`AddGoogleMaps(IConfiguration)`](../../GoogleMapsApi.Extensions.DependencyInjection/GoogleMapsServiceCollectionExtensions.cs) —
+  binds [`GoogleMapsClientOptions`](../../GoogleMapsApi/GoogleMapsClientOptions.cs) (the ambient API key) from a config section
+- Constructor injection of [`IGoogleMapsClient`](../../GoogleMapsApi/IGoogleMapsClient.cs) into a regular application service
+- `Host.CreateApplicationBuilder` generic-host wiring with `IServiceCollection` and `ILogger<T>`
+- [`DistanceMatrixRequest`](../../GoogleMapsApi/Entities/DistanceMatrix/Request/DistanceMatrixRequest.cs) /
+  [`DistanceMatrixResponse`](../../GoogleMapsApi/Entities/DistanceMatrix/Response/DistanceMatrixResponse.cs) with requests that carry **no** API key — it comes from DI
+
+> The Minimal API sample uses the `AddGoogleMaps(Action<GoogleMapsClientOptions>)` overload instead; this sample uses the configuration-binding overload.

--- a/samples/GenericHost.DistanceMatrix/TravelTimeService.cs
+++ b/samples/GenericHost.DistanceMatrix/TravelTimeService.cs
@@ -1,0 +1,57 @@
+using GoogleMapsApi;
+using GoogleMapsApi.Entities.DistanceMatrix.Request;
+using GoogleMapsApi.Entities.DistanceMatrix.Response;
+using Microsoft.Extensions.Logging;
+
+namespace Samples.GenericHost.DistanceMatrix;
+
+/// <summary>
+/// Computes travel distance and duration between two places. The Google Maps client is
+/// supplied by dependency injection — this class never touches the API key or HttpClient.
+/// </summary>
+public sealed class TravelTimeService
+{
+    private readonly IGoogleMapsClient _maps;
+    private readonly ILogger<TravelTimeService> _logger;
+
+    public TravelTimeService(IGoogleMapsClient maps, ILogger<TravelTimeService> logger)
+    {
+        _maps = maps;
+        _logger = logger;
+    }
+
+    public async Task<int> RunAsync(string origin, string destination, CancellationToken ct = default)
+    {
+        // No ApiKey on the request — it's filled from the ambient options bound in DI.
+        var request = new DistanceMatrixRequest
+        {
+            Origins = [origin],
+            Destinations = [destination],
+            Units = DistanceMatrixUnitSystems.metric,
+        };
+
+        DistanceMatrixResponse response = await _maps.DistanceMatrix.QueryAsync(request, ct);
+
+        if (response.Status != DistanceMatrixStatusCodes.OK)
+        {
+            _logger.LogError("Distance Matrix request failed: {Status} {Error}", response.Status, response.ErrorMessage);
+            return 1;
+        }
+
+        var element = response.Rows.First().Elements.First();
+        if (element.Status != DistanceMatrixElementStatusCodes.OK)
+        {
+            _logger.LogError("No route from {Origin} to {Destination}: {Status}", origin, destination, element.Status);
+            return 1;
+        }
+
+        _logger.LogInformation(
+            "{Origin} -> {Destination}: {Distance}, about {Duration}",
+            response.OriginAddresses.First(),
+            response.DestinationAddresses.First(),
+            element.Distance.Text,
+            element.Duration.Text);
+
+        return 0;
+    }
+}

--- a/samples/README.md
+++ b/samples/README.md
@@ -4,10 +4,13 @@ Minimal, copy-pasteable demos of [GoogleMapsApi](../GoogleMapsApi/GoogleMapsApi.
 
 All samples read the Google Maps API key from the `GOOGLE_API_KEY` environment variable. The Minimal API and Blazor samples also accept `GoogleApiKey` from configuration (e.g. `appsettings.json` or user secrets) as a fallback. Samples target `net10.0` with a `net8.0` fallback for older SDKs.
 
-| Sample | What it demonstrates | Run |
-| --- | --- | --- |
-| [Console.Geocoding](Console.Geocoding/) | Geocoding an address from a console app | `GOOGLE_API_KEY=... dotnet run --project samples/Console.Geocoding -- "1600 Amphitheatre Parkway"` |
-| [MinimalApi.Directions](MinimalApi.Directions/) | ASP.NET Core minimal API returning a directions route summary as JSON | `GOOGLE_API_KEY=... dotnet run --project samples/MinimalApi.Directions` |
-| [Blazor.Geocoding](Blazor.Geocoding/) | Blazor Server page that geocodes an address typed in the browser | `GOOGLE_API_KEY=... dotnet run --project samples/Blazor.Geocoding` |
+| Sample | What it demonstrates | Package | Run |
+| --- | --- | --- | --- |
+| [Console.Geocoding](Console.Geocoding/) | Geocoding an address from a console app | Core `IGoogleMapsClient` | `GOOGLE_API_KEY=... dotnet run --project samples/Console.Geocoding -- "1600 Amphitheatre Parkway"` |
+| [MinimalApi.Directions](MinimalApi.Directions/) | ASP.NET Core minimal API returning a directions route summary as JSON, wired up with a single `AddGoogleMaps(options => ...)` call and an ambient API key | [`GoogleMapsApi.Extensions.DependencyInjection`](../GoogleMapsApi.Extensions.DependencyInjection/) | `GOOGLE_API_KEY=... dotnet run --project samples/MinimalApi.Directions` |
+| [GenericHost.DistanceMatrix](GenericHost.DistanceMatrix/) | Generic-host console that injects `IGoogleMapsClient` into an application service, with the ambient API key bound from configuration via `AddGoogleMaps(IConfiguration)` | [`GoogleMapsApi.Extensions.DependencyInjection`](../GoogleMapsApi.Extensions.DependencyInjection/) | `GOOGLE_API_KEY=... dotnet run --project samples/GenericHost.DistanceMatrix -- "New York, NY" "Boston, MA"` |
+| [Blazor.Geocoding](Blazor.Geocoding/) | Blazor Server page that geocodes an address typed in the browser | Core `IGoogleMapsClient` (manual `AddHttpClient` registration) | `GOOGLE_API_KEY=... dotnet run --project samples/Blazor.Geocoding` |
+
+The **Minimal API** and **Generic Host** samples are the showcases for the [`GoogleMapsApi.Extensions.DependencyInjection`](../GoogleMapsApi.Extensions.DependencyInjection/) package — both register `IGoogleMapsClient` (backed by `IHttpClientFactory`) plus an ambient API key in one `AddGoogleMaps(...)` call, so individual requests don't repeat the key. They demonstrate the two ways to supply the key: Minimal API uses the `Action<GoogleMapsClientOptions>` overload, Generic Host binds it from configuration with the `IConfiguration` overload. The Console and Blazor samples use the core library directly — Blazor shows the manual `AddHttpClient<IGoogleMapsClient, GoogleMapsClient>()` registration when you'd rather not take the extra package.
 
 > Get an API key in the [Google Cloud Console](https://console.cloud.google.com/) and enable the Geocoding and/or Directions API for your project.


### PR DESCRIPTION
## Summary

Adds a dedicated `GenericHost.DistanceMatrix` sample that showcases the
`AddGoogleMaps(IConfiguration)` overload from `GoogleMapsApi.Extensions.DependencyInjection`.
It wires up a `TravelTimeService` via the .NET generic host, with `IGoogleMapsClient` resolved
by constructor injection and the ambient API key bound from configuration — no key on individual
requests. Also updates `samples/README.md` to make it clear which samples use the DI package.

## Changes

- `samples/GenericHost.DistanceMatrix/` — new generic-host console sample (Program.cs,
  TravelTimeService.cs, appsettings.json, README.md, .csproj)
- `samples/README.md` — adds Package column to the table; prose explaining both DI overloads
- `GoogleMapsApi.sln` — project added under the `samples` solution folder

## Test plan

- [ ] `dotnet build samples/GenericHost.DistanceMatrix` — builds clean on net10.0 + net8.0
- [ ] `GOOGLE_API_KEY=<key> dotnet run --project samples/GenericHost.DistanceMatrix -- "New York, NY" "Boston, MA"` — prints distance/duration
- [ ] Without a key: exits with code 1 and logs a clear `REQUEST_DENIED` message (no crash)
