### PR TITLE
build: derive package version from git tags via MinVer

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -28,6 +28,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          fetch-depth: 0   # MinVer needs full history + tags to derive the version
 
       - name: Setup .NET
         uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2  # v5.3.0
@@ -41,10 +43,14 @@ jobs:
         env:
           INPUT_VERSION: ${{ inputs.version }}
         run: |
+          # On a tag push MinVer derives the version from the checked-out v* tag.
+          # On a manual run there is no tag, so override MinVer with the requested version.
           if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
             VERSION="$INPUT_VERSION"
+            echo "MINVER_OVERRIDE=-p:MinVerVersionOverride=$VERSION" >> "$GITHUB_OUTPUT"
           else
             VERSION="${GITHUB_REF#refs/tags/v}"
+            echo "MINVER_OVERRIDE=" >> "$GITHUB_OUTPUT"
           fi
           echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Resolved version: $VERSION"
@@ -53,10 +59,10 @@ jobs:
         run: dotnet restore
 
       - name: Build
-        run: dotnet build --configuration Release --no-restore -p:Version=${{ steps.get_version.outputs.VERSION }}
+        run: dotnet build --configuration Release --no-restore ${{ steps.get_version.outputs.MINVER_OVERRIDE }}
 
       - name: Pack
-        run: dotnet pack --configuration Release --no-build --output . -p:Version=${{ steps.get_version.outputs.VERSION }}
+        run: dotnet pack --configuration Release --no-build --output . ${{ steps.get_version.outputs.MINVER_OVERRIDE }}
 
       - name: Attest build provenance
         if: github.event_name == 'push' || inputs.dry_run == false

--- a/GoogleMapsApi.Extensions.DependencyInjection/GoogleMapsApi.Extensions.DependencyInjection.csproj
+++ b/GoogleMapsApi.Extensions.DependencyInjection/GoogleMapsApi.Extensions.DependencyInjection.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
 	<TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
 	<LangVersion>latest</LangVersion>
-	<Version>0.0.0</Version>
+	<MinVerTagPrefix>v</MinVerTagPrefix>
 	<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 	<AssemblyName>GoogleMapsApi.Extensions.DependencyInjection</AssemblyName>
 	<RootNamespace>GoogleMapsApi.Extensions.DependencyInjection</RootNamespace>
@@ -41,6 +41,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="4.14.0" PrivateAssets="all" />
+    <PackageReference Include="MinVer" Version="6.0.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.8" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.8" />
   </ItemGroup>

--- a/GoogleMapsApi/GoogleMapsApi.csproj
+++ b/GoogleMapsApi/GoogleMapsApi.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
 	<TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
 	<LangVersion>latest</LangVersion>
-	<Version>0.0.0</Version>
+	<MinVerTagPrefix>v</MinVerTagPrefix>
 	<AppxAutoIncrementPackageRevision>True</AppxAutoIncrementPackageRevision>
 	<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 	<AssemblyName>GoogleMapsApi</AssemblyName>
@@ -41,6 +41,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="All"/>
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="4.14.0" PrivateAssets="all" />
+    <PackageReference Include="MinVer" Version="6.0.0" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -69,12 +69,10 @@ Both options end at the same place — a `v*` tag in `origin` — and trigger th
 
 [`.github/workflows/nuget.yml`](.github/workflows/nuget.yml) runs on `push` of any `v*` tag:
 
-1. Checks out the repo at the tagged commit
+1. Checks out the repo with full history and tags (`fetch-depth: 0`) at the tagged commit
 2. Installs the .NET SDKs needed to build all target frameworks
-3. Extracts the version from the tag (`v1.4.6` → `1.4.6`)
-4. Injects the version into `GoogleMapsApi/GoogleMapsApi.csproj` (the csproj's `<Version>0.0.0</Version>` placeholder stays unchanged in the repo — only the runner copy is patched)
-5. `dotnet restore` → `dotnet build -c Release` → `dotnet pack -c Release`
-6. `dotnet nuget push *.nupkg --api-key $NUGET_API_KEY --skip-duplicate`
+3. `dotnet restore` → `dotnet build -c Release` → `dotnet pack -c Release` — [MinVer](https://github.com/adamralph/minver) derives the package version from the `v*` tag at build time (`v1.4.6` → `1.4.6`); no csproj is patched. Commits without a tag get a unique prerelease version (e.g. `1.4.7-alpha.0.3`), so only tagged builds publish a stable release.
+4. `dotnet nuget push *.nupkg --api-key $NUGET_API_KEY --skip-duplicate`
 
 `--skip-duplicate` means re-running the workflow with the same version is a no-op rather than an error.
 


### PR DESCRIPTION
## What

Replaces the hardcoded `<Version>0.0.0</Version>` placeholder + the CI-side `-p:Version=` override with [MinVer](https://github.com/adamralph/minver), which derives the package SemVer directly from the existing `v*` release tags.

## Why

Today the real version lives only in the git tag plus a string-munging step in `nuget.yml`; local/dev builds always produce `0.0.0`, and there's no unique version per commit. This makes the version the property of the tag itself — the single source of truth — and gives every commit a unique, deterministic version (e.g. `2.1.1-alpha.0.17`).

## Changes

- **Both packable projects** (`GoogleMapsApi`, `GoogleMapsApi.Extensions.DependencyInjection`): drop `<Version>0.0.0</Version>`, add `<MinVerTagPrefix>v</MinVerTagPrefix>` + `MinVer` PackageReference (`PrivateAssets="all"`). They stay lockstep-versioned off the same tags.
- **`.github/workflows/nuget.yml`**: checkout with `fetch-depth: 0` so MinVer can see tags/history; remove `-p:Version=` from build/pack. Manual `workflow_dispatch` runs (no tag present) pass `MinVerVersionOverride` to honour the requested version.
- **`RELEASING.md`**: document tag-derived versioning.

## Release process — unchanged

`release.sh` is untouched. `./release.sh [patch|minor|major]` still computes the next version, updates the changelog, and pushes the annotated `v*` tag that triggers publishing. The tag is now what MinVer reads.

## Verification

- Branch is 17 commits past `v2.1.0` → both packages build `…2.1.1-alpha.0.17.nupkg` (unique, lockstep prerelease).
- `-p:MinVerVersionOverride=9.9.9` → `GoogleMapsApi.9.9.9.nupkg`, confirming the manual-dispatch path.
- A `v*` tag push checks out at the tag → MinVer yields exactly that version. Only tagged builds publish a stable release.