### PR TITLE
feat: emit OpenTelemetry tracing spans via ActivitySource

### DIFF
--- a/GoogleMapsApi.Test/DiagnosticsTracingTests.cs
+++ b/GoogleMapsApi.Test/DiagnosticsTracingTests.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using GoogleMapsApi.Diagnostics;
+using GoogleMapsApi.Entities.Geocoding.Request;
+using NUnit.Framework;
+
+namespace GoogleMapsApi.Test
+{
+    /// <summary>
+    /// Hermetic tests asserting that each API call emits a correctly tagged OpenTelemetry span from the
+    /// <see cref="GoogleMapsActivity.SourceName"/> source. No live network calls — every HTTP exchange is
+    /// intercepted by <see cref="StubHandler"/>.
+    /// </summary>
+    [TestFixture]
+    public class DiagnosticsTracingTests
+    {
+        private const string OkGeocodingJson = "{\"status\":\"OK\",\"results\":[]}";
+
+        private static ActivityListener CreateListener(List<Activity> captured)
+        {
+            var listener = new ActivityListener
+            {
+                ShouldListenTo = source => source.Name == GoogleMapsActivity.SourceName,
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+                ActivityStopped = activity => captured.Add(activity)
+            };
+            ActivitySource.AddActivityListener(listener);
+            return listener;
+        }
+
+        [Test]
+        public async Task QueryAsync_EmitsClientSpan_WithSemanticConventionTags()
+        {
+            var captured = new List<Activity>();
+            using var listener = CreateListener(captured);
+
+            using var handler = new StubHandler(HttpStatusCode.OK, OkGeocodingJson);
+            using var http = new HttpClient(handler);
+            var client = new GoogleMapsClient(http, new GoogleMapsClientOptions { ApiKey = "secret-key" });
+
+            await client.Geocode.QueryAsync(new GeocodingRequest { Address = "1600 Amphitheatre Pkwy" });
+
+            Assert.That(captured, Has.Count.EqualTo(1));
+            var activity = captured[0];
+            Assert.That(activity.OperationName, Is.EqualTo("GoogleMapsApi Geocoding"));
+            Assert.That(activity.Kind, Is.EqualTo(ActivityKind.Client));
+            Assert.That(activity.GetTagItem("gmaps.api"), Is.EqualTo("Geocoding"));
+            Assert.That(activity.GetTagItem("http.request.method"), Is.EqualTo("GET"));
+            Assert.That(activity.GetTagItem("server.address"), Is.EqualTo("maps.googleapis.com"));
+            Assert.That(activity.GetTagItem("http.response.status_code"), Is.EqualTo(200));
+            Assert.That(activity.GetTagItem("gmaps.response_status"), Is.EqualTo("OK"));
+            Assert.That(activity.Status, Is.EqualTo(ActivityStatusCode.Unset));
+        }
+
+        [Test]
+        public async Task QueryAsync_RedactsApiKey_FromUrlFullTag()
+        {
+            var captured = new List<Activity>();
+            using var listener = CreateListener(captured);
+
+            using var handler = new StubHandler(HttpStatusCode.OK, OkGeocodingJson);
+            using var http = new HttpClient(handler);
+            var client = new GoogleMapsClient(http, new GoogleMapsClientOptions { ApiKey = "super-secret-key" });
+
+            await client.Geocode.QueryAsync(new GeocodingRequest { Address = "Pier 39" });
+
+            var urlFull = (string)captured.Single().GetTagItem("url.full")!;
+            Assert.That(urlFull, Does.Contain("key=REDACTED"));
+            Assert.That(urlFull, Does.Not.Contain("super-secret-key"));
+        }
+
+        [Test]
+        public void QueryAsync_HttpError_MarksSpanAsError()
+        {
+            var captured = new List<Activity>();
+            using var listener = CreateListener(captured);
+
+            using var handler = new StubHandler(HttpStatusCode.Forbidden, "denied");
+            using var http = new HttpClient(handler);
+            var client = new GoogleMapsClient(http, new GoogleMapsClientOptions { ApiKey = "k" });
+
+            Assert.ThrowsAsync<System.Security.Authentication.AuthenticationException>(
+                (Func<Task>)(() => client.Geocode.QueryAsync(new GeocodingRequest { Address = "a" })));
+
+            var activity = captured.Single();
+            Assert.That(activity.Status, Is.EqualTo(ActivityStatusCode.Error));
+            Assert.That(activity.GetTagItem("http.response.status_code"), Is.EqualTo(403));
+            Assert.That(activity.GetTagItem("error.type"), Is.Not.Null);
+        }
+
+        [Test]
+        public async Task QueryAsync_WithoutListener_DoesNotThrow()
+        {
+            using var handler = new StubHandler(HttpStatusCode.OK, OkGeocodingJson);
+            using var http = new HttpClient(handler);
+            var client = new GoogleMapsClient(http, new GoogleMapsClientOptions { ApiKey = "k" });
+
+            var response = await client.Geocode.QueryAsync(new GeocodingRequest { Address = "a" });
+
+            Assert.That(response, Is.Not.Null);
+        }
+
+        private sealed class StubHandler : HttpMessageHandler
+        {
+            private readonly HttpStatusCode _statusCode;
+            private readonly string _responseBody;
+
+            public StubHandler(HttpStatusCode statusCode, string responseBody)
+            {
+                _statusCode = statusCode;
+                _responseBody = responseBody;
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                return Task.FromResult(new HttpResponseMessage(_statusCode)
+                {
+                    Content = new StringContent(_responseBody)
+                });
+            }
+        }
+    }
+}

--- a/GoogleMapsApi/Diagnostics/GoogleMapsActivity.cs
+++ b/GoogleMapsApi/Diagnostics/GoogleMapsActivity.cs
@@ -1,0 +1,24 @@
+using System.Diagnostics;
+using System.Reflection;
+
+namespace GoogleMapsApi.Diagnostics
+{
+    /// <summary>
+    /// Distributed-tracing entry point for the library. Every Google Maps API call emits one
+    /// <see cref="System.Diagnostics.Activity"/> (an OpenTelemetry span) from the source named
+    /// <see cref="SourceName"/>. Subscribe to it from your tracing pipeline — for OpenTelemetry,
+    /// call <c>AddSource(GoogleMapsActivity.SourceName)</c> on your <c>TracerProviderBuilder</c>.
+    /// Instrumentation is inert (zero allocations) until a listener is registered, so it is always on.
+    /// </summary>
+    public static class GoogleMapsActivity
+    {
+        /// <summary>
+        /// The <see cref="System.Diagnostics.ActivitySource"/> name spans are emitted from: <c>"GoogleMapsApi"</c>.
+        /// Pass this to <c>AddSource(...)</c> to collect the library's traces.
+        /// </summary>
+        public const string SourceName = "GoogleMapsApi";
+
+        internal static readonly ActivitySource Source =
+            new ActivitySource(SourceName, typeof(GoogleMapsActivity).Assembly.GetName().Version?.ToString());
+    }
+}

--- a/GoogleMapsApi/Engine/MapsAPIGenericEngine.cs
+++ b/GoogleMapsApi/Engine/MapsAPIGenericEngine.cs
@@ -1,10 +1,15 @@
 using GoogleMapsApi.Entities.Common;
 using GoogleMapsApi.Engine.JsonConverters;
+using GoogleMapsApi.Diagnostics;
 using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.IO;
 using System.Net;
 using System.Net.Http;
+using System.Reflection;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Text;
@@ -19,6 +24,11 @@ namespace GoogleMapsApi.Engine
 		where TResponse : IResponseFor<TRequest>
 	{
 		private static readonly JsonSerializerOptions jsonOptions = JsonSerializerConfiguration.CreateOptions();
+
+		private static readonly ConcurrentDictionary<Type, PropertyInfo?> statusProperties = new();
+
+		private static readonly Regex secretQueryParameter =
+			new Regex(@"([?&](?:key|signature)=)[^&]*", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
 		internal static async Task<TResponse> QueryGoogleAPIAsync(
 			HttpClient httpClient,
@@ -37,19 +47,65 @@ namespace GoogleMapsApi.Engine
 			var uri = onUriCreated?.Invoke(requestUri) ?? requestUri;
 
 			var body = request.GetRequestBody();
-			string responseContent;
+
+			var apiName = GetApiName();
+			using var activity = GoogleMapsActivity.Source.StartActivity($"GoogleMapsApi {apiName}", ActivityKind.Client);
+			if (activity is not null)
+			{
+				activity.SetTag("gmaps.api", apiName);
+				activity.SetTag("http.request.method", body is null ? "GET" : "POST");
+				activity.SetTag("server.address", uri.Host);
+				activity.SetTag("url.full", RedactUrl(uri));
+			}
+
 			try
 			{
-				responseContent = await GetHttpResponseAsync(httpClient, uri, body, timeout, token).ConfigureAwait(false);
+				string responseContent;
+				try
+				{
+					responseContent = await GetHttpResponseAsync(httpClient, uri, body, timeout, token).ConfigureAwait(false);
+				}
+				finally
+				{
+					body?.Dispose();
+				}
+
+				onRawResponseReceived?.Invoke(Encoding.UTF8.GetBytes(responseContent));
+
+				var response = JsonSerializer.Deserialize<TResponse>(responseContent, jsonOptions)!;
+
+				if (activity is not null)
+				{
+					var responseStatus = GetResponseStatus(response);
+					if (responseStatus is not null)
+						activity.SetTag("gmaps.response_status", responseStatus);
+				}
+
+				return response;
 			}
-			finally
+			catch (Exception ex)
 			{
-				body?.Dispose();
+				activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+				activity?.SetTag("error.type", ex.GetType().FullName);
+				throw;
 			}
+		}
 
-			onRawResponseReceived?.Invoke(Encoding.UTF8.GetBytes(responseContent));
+		private static string GetApiName()
+		{
+			var name = typeof(TRequest).Name;
+			return name.EndsWith("Request", StringComparison.Ordinal)
+				? name.Substring(0, name.Length - "Request".Length)
+				: name;
+		}
 
-			return JsonSerializer.Deserialize<TResponse>(responseContent, jsonOptions)!;
+		private static string RedactUrl(Uri uri)
+			=> secretQueryParameter.Replace(uri.AbsoluteUri, "$1REDACTED");
+
+		private static string? GetResponseStatus(TResponse response)
+		{
+			var property = statusProperties.GetOrAdd(typeof(TResponse), static t => t.GetProperty("Status"));
+			return property?.GetValue(response)?.ToString();
 		}
 
 		private static async Task<string> GetHttpResponseAsync(HttpClient httpClient, Uri uri, HttpContent? body, TimeSpan timeout, CancellationToken cancellationToken)
@@ -63,6 +119,7 @@ namespace GoogleMapsApi.Engine
 				using var response = body == null
 					? await httpClient.GetAsync(uri, cts.Token).ConfigureAwait(false)
 					: await httpClient.PostAsync(uri, body, cts.Token).ConfigureAwait(false);
+				Activity.Current?.SetTag("http.response.status_code", (int)response.StatusCode);
 				await HandleHttpResponse(response, timeout).ConfigureAwait(false);
 				return await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 			}

--- a/GoogleMapsApi/GoogleMapsApi.csproj
+++ b/GoogleMapsApi/GoogleMapsApi.csproj
@@ -55,5 +55,7 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Text.Encodings.Web" Version="10.0.8" />
     <PackageReference Include="System.Text.Json" Version="10.0.8" />
+    <!-- ActivitySource is in-box for net8.0+; netstandard2.0 needs the DiagnosticSource package. -->
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="10.0.8" />
   </ItemGroup>
 </Project>

--- a/GoogleMapsApi/PublicAPI.Unshipped.txt
+++ b/GoogleMapsApi/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+GoogleMapsApi.Diagnostics.GoogleMapsActivity
+const GoogleMapsApi.Diagnostics.GoogleMapsActivity.SourceName = "GoogleMapsApi" -> string!

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ A friendly, strongly-typed .NET wrapper for the Google Maps Web Services APIs �
 
 ## Why this vs Google's official SDKs
 
-Google's official .NET packages (e.g. `Google.Maps.Routing.V2`, `Google.Maps.Places.V1`) are auto-generated from gRPC service definitions — they're verbose, split across many packages, and feel like protobuf instead of .NET. **GoogleMapsApi** is a single, idiomatic NuGet package: one install, async-first, multi-target (modern .NET through legacy .NET Framework), with hand-crafted request/response types that read like normal C#.
+Google's official .NET packages (e.g. `Google.Maps.Routing.V2`, `Google.Maps.Places.V1`) are auto-generated from gRPC service definitions — they're verbose, split across many packages, and feel like protobuf instead of .NET. **GoogleMapsApi** is a single, idiomatic NuGet package: one install, async-first, multi-target (modern .NET through legacy .NET Framework), with hand-crafted request/response types that read like normal C#. It also emits [OpenTelemetry traces](#observability-opentelemetry-tracing) out of the box — something the official SDKs don't.
 
 # Installation
 
@@ -213,6 +213,38 @@ The API is async-first. When you must call from a synchronous context, block on 
 DirectionsResponse directions = maps.Directions.QueryAsync(directionsRequest).GetAwaiter().GetResult();
 Console.WriteLine(directions);
 ```
+
+## Observability (OpenTelemetry tracing)
+
+Every API call emits a [distributed-tracing](https://opentelemetry.io/docs/concepts/signals/traces/) span from an
+[`ActivitySource`](https://learn.microsoft.com/dotnet/core/diagnostics/distributed-tracing) named **`GoogleMapsApi`**.
+There is nothing to enable on the library side — the instrumentation is inert (zero allocations) until a listener is
+registered, and lights up automatically once your tracing pipeline subscribes to the source.
+
+With OpenTelemetry, add the source by name (the constant `GoogleMapsApi.Diagnostics.GoogleMapsActivity.SourceName`):
+
+``` C#
+using OpenTelemetry.Trace;
+using GoogleMapsApi.Diagnostics;
+
+builder.Services.AddOpenTelemetry().WithTracing(tracing => tracing
+    .AddSource(GoogleMapsActivity.SourceName) // "GoogleMapsApi"
+    .AddOtlpExporter());
+```
+
+Each span is `Client`-kind, named `GoogleMapsApi <Api>` (e.g. `GoogleMapsApi Geocoding`), with its **duration**
+representing call latency. Tags follow OpenTelemetry HTTP semantic conventions plus a small `gmaps.*` set:
+
+| Tag | Example | Notes |
+| --- | --- | --- |
+| `gmaps.api` | `Geocoding` | The Maps API invoked |
+| `http.request.method` | `GET` / `POST` | |
+| `server.address` | `maps.googleapis.com` | |
+| `url.full` | `…/geocode/json?...&key=REDACTED` | **API key and signature are always redacted** |
+| `http.response.status_code` | `200` | |
+| `gmaps.response_status` | `OK` / `ZERO_RESULTS` | Google body status, where the API exposes one |
+
+Failures set the span status to `Error` and add an `error.type` tag.
 
 ---
 


### PR DESCRIPTION
## Summary
Adds OpenTelemetry distributed tracing to the library. Every Google Maps API call now emits one span from an `ActivitySource` named `GoogleMapsApi`, making the library a first-class citizen in observability dashboards with zero wiring beyond `AddSource("GoogleMapsApi")` — a differentiator versus the official Google SDKs, which emit nothing. Instrumentation is inert until a listener subscribes, so it ships on by default with no opt-in.

## Changes
- New public `GoogleMapsApi.Diagnostics.GoogleMapsActivity` exposing `const SourceName = "GoogleMapsApi"`; the `ActivitySource` instance itself stays internal.
- Instrument the single engine choke point (`MapsAPIGenericEngine.QueryGoogleAPIAsync`) with a `Client`-kind span. Tags follow OTel HTTP semantic conventions plus a `gmaps.*` set: `gmaps.api`, `http.request.method`, `server.address`, `url.full` (**API key + signature redacted**), `http.response.status_code`, and `gmaps.response_status` (Google body status via cached reflection). Failures set span status `Error` + `error.type`. Latency is the span duration.
- Add `System.Diagnostics.DiagnosticSource` conditionally for `netstandard2.0` (in-box on net8/net10).
- Register the new public surface in `PublicAPI.Unshipped.txt` (analyzer-enforced).
- Document an "Observability (OpenTelemetry tracing)" section in the README.

## Test plan
- [x] `dotnet build` (full solution) — succeeds on all TFMs, 0 warnings / 0 errors
- [x] New `DiagnosticsTracingTests` — 4/4 pass (tags, key redaction, error-path status, no-listener safety)
- [x] Full hermetic unit suite — 152/152 pass
- [ ] Reviewer: confirm a span appears in your tracing backend after `AddSource("GoogleMapsApi")`
