### PR TITLE
feat: add Google Roads API support (snap to roads, nearest roads, speed limits)

### DIFF
--- a/GoogleMapsApi.Test/IntegrationTests/RoadsTests.cs
+++ b/GoogleMapsApi.Test/IntegrationTests/RoadsTests.cs
@@ -1,0 +1,74 @@
+using System.Linq;
+using System.Threading.Tasks;
+using GoogleMapsApi.Entities.Common;
+using GoogleMapsApi.Entities.Roads.Request;
+using GoogleMapsApi.Entities.Roads.Response;
+using GoogleMapsApi.Test.Utils;
+using NUnit.Framework;
+
+namespace GoogleMapsApi.Test.IntegrationTests
+{
+    [TestFixture]
+    public class RoadsTests : BaseTestIntegration
+    {
+        // A short path along Sullivans Creek Rd, Canberra — the Roads API documentation sample.
+        private static readonly Location[] SamplePath =
+        {
+            new Location(-35.27801, 149.12958),
+            new Location(-35.28032, 149.12907),
+            new Location(-35.28099, 149.12929),
+            new Location(-35.28144, 149.12984),
+            new Location(-35.28194, 149.13003),
+        };
+
+        [Test]
+        public async Task SnapToRoads_ReturnsSnappedPoints()
+        {
+            var request = new SnapToRoadsRequest { ApiKey = ApiKey, Path = SamplePath };
+
+            SnapToRoadsResponse result = await Maps.SnapToRoads.QueryAsync(request);
+
+            Assert.That(result.SnappedPoints, Is.Not.Null.And.Not.Empty);
+            Assert.That(result.SnappedPoints!.All(p => p.Location != null && p.PlaceId != null), Is.True);
+        }
+
+        [Test]
+        public async Task SnapToRoads_Interpolate_AddsPointsWithoutOriginalIndex()
+        {
+            var request = new SnapToRoadsRequest { ApiKey = ApiKey, Path = SamplePath, Interpolate = true };
+
+            SnapToRoadsResponse result = await Maps.SnapToRoads.QueryAsync(request);
+
+            Assert.That(result.SnappedPoints, Is.Not.Null.And.Not.Empty);
+            // Interpolation fills in extra points between the inputs; those have no OriginalIndex.
+            Assert.That(result.SnappedPoints!.Any(p => p.OriginalIndex == null), Is.True);
+        }
+
+        [Test]
+        public async Task NearestRoads_ReturnsSnappedPoints()
+        {
+            var request = new NearestRoadsRequest
+            {
+                ApiKey = ApiKey,
+                Points = new[] { new Location(60.170880, 24.942795), new Location(60.170879, 24.942796) },
+            };
+
+            NearestRoadsResponse result = await Maps.NearestRoads.QueryAsync(request);
+
+            Assert.That(result.SnappedPoints, Is.Not.Null.And.Not.Empty);
+        }
+
+        // The Speed Limits service requires a Google Asset Tracking license; without one the API
+        // returns HTTP 403. Marked billable/restricted so it is skipped unless RUN_BILLABLE_TESTS=true.
+        [Test]
+        [BillableTest]
+        public async Task SpeedLimits_ReturnsSpeedLimits()
+        {
+            var request = new SpeedLimitsRequest { ApiKey = ApiKey, Path = SamplePath, Units = SpeedUnits.Kph };
+
+            SpeedLimitsResponse result = await Maps.SpeedLimits.QueryAsync(request);
+
+            Assert.That(result.SpeedLimits, Is.Not.Null.And.Not.Empty);
+        }
+    }
+}

--- a/GoogleMapsApi.Test/IntegrationTests/RoadsTests.cs
+++ b/GoogleMapsApi.Test/IntegrationTests/RoadsTests.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using GoogleMapsApi.Entities.Common;
 using GoogleMapsApi.Entities.Roads.Request;
 using GoogleMapsApi.Entities.Roads.Response;
-using GoogleMapsApi.Test.Utils;
 using NUnit.Framework;
 
 namespace GoogleMapsApi.Test.IntegrationTests
@@ -58,10 +57,13 @@ namespace GoogleMapsApi.Test.IntegrationTests
             Assert.That(result.SnappedPoints, Is.Not.Null.And.Not.Empty);
         }
 
-        // The Speed Limits service requires a Google Asset Tracking license; without one the API
-        // returns HTTP 403. Marked billable/restricted so it is skipped unless RUN_BILLABLE_TESTS=true.
+        // The Speed Limits service requires a Google Asset Tracking license (provisioned by Google
+        // Maps Platform sales, not self-serve); without it the API returns HTTP 403 ("Speed limits
+        // are not available for this project"). Enabling the Roads API is not sufficient. Marked
+        // [Explicit] so it never runs in automatic or billable runs — run it by name only on a
+        // licensed key.
         [Test]
-        [BillableTest]
+        [Explicit("Requires a Google Asset Tracking license; returns HTTP 403 otherwise.")]
         public async Task SpeedLimits_ReturnsSpeedLimits()
         {
             var request = new SpeedLimitsRequest { ApiKey = ApiKey, Path = SamplePath, Units = SpeedUnits.Kph };

--- a/GoogleMapsApi.Test/RoadsUnitTests.cs
+++ b/GoogleMapsApi.Test/RoadsUnitTests.cs
@@ -1,0 +1,213 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using GoogleMapsApi.Engine;
+using GoogleMapsApi.Entities.Common;
+using GoogleMapsApi.Entities.Roads.Request;
+using GoogleMapsApi.Entities.Roads.Response;
+using NUnit.Framework;
+
+namespace GoogleMapsApi.Test
+{
+    [TestFixture]
+    public class RoadsUnitTests
+    {
+        private static readonly Location P1 = new Location(-35.27801, 149.12958);
+        private static readonly Location P2 = new Location(-35.28032, 149.12907);
+
+        #region URL building
+
+        [Test]
+        public void SnapToRoads_BuildsExpectedUrl()
+        {
+            var uri = new SnapToRoadsRequest { ApiKey = "KEY", Path = new[] { P1, P2 }, Interpolate = true }.GetUri();
+
+            Assert.That(uri.GetLeftPart(UriPartial.Path), Is.EqualTo("https://roads.googleapis.com/v1/snapToRoads"));
+            Assert.That(uri.Query, Does.Contain("path=-35.27801%2C149.12958%7C-35.28032%2C149.12907"));
+            Assert.That(uri.Query, Does.Contain("interpolate=true"));
+            Assert.That(uri.Query, Does.Contain("key=KEY"));
+        }
+
+        [Test]
+        public void SnapToRoads_InterpolateFalse_ByDefault()
+        {
+            var uri = new SnapToRoadsRequest { ApiKey = "KEY", Path = new[] { P1 } }.GetUri();
+            Assert.That(uri.Query, Does.Contain("interpolate=false"));
+        }
+
+        [Test]
+        public void NearestRoads_BuildsExpectedUrl()
+        {
+            var uri = new NearestRoadsRequest { ApiKey = "KEY", Points = new[] { P1, P2 } }.GetUri();
+
+            Assert.That(uri.GetLeftPart(UriPartial.Path), Is.EqualTo("https://roads.googleapis.com/v1/nearestRoads"));
+            Assert.That(uri.Query, Does.Contain("points=-35.27801%2C149.12958%7C-35.28032%2C149.12907"));
+            Assert.That(uri.Query, Does.Contain("key=KEY"));
+        }
+
+        [Test]
+        public void SpeedLimits_WithPathAndUnits_BuildsExpectedUrl()
+        {
+            var uri = new SpeedLimitsRequest { ApiKey = "KEY", Path = new[] { P1 }, Units = SpeedUnits.Mph }.GetUri();
+
+            Assert.That(uri.GetLeftPart(UriPartial.Path), Is.EqualTo("https://roads.googleapis.com/v1/speedLimits"));
+            Assert.That(uri.Query, Does.Contain("path=-35.27801%2C149.12958"));
+            Assert.That(uri.Query, Does.Contain("units=MPH"));
+            Assert.That(uri.Query, Does.Contain("key=KEY"));
+        }
+
+        [Test]
+        public void SpeedLimits_WithPlaceIds_RepeatsPlaceIdParam_AndOmitsUnitsWhenUnset()
+        {
+            var uri = new SpeedLimitsRequest { ApiKey = "KEY", PlaceIds = new[] { "abc", "def" } }.GetUri();
+
+            Assert.That(uri.Query, Does.Contain("placeId=abc"));
+            Assert.That(uri.Query, Does.Contain("placeId=def"));
+            Assert.That(uri.Query, Does.Not.Contain("units="));
+        }
+
+        #endregion
+
+        #region Validation
+
+        [Test]
+        public void SnapToRoads_MissingApiKey_Throws()
+            => Assert.Throws<ArgumentException>(() => new SnapToRoadsRequest { Path = new[] { P1 } }.GetUri());
+
+        [Test]
+        public void SnapToRoads_NotSsl_Throws()
+            => Assert.Throws<ArgumentException>(() => new SnapToRoadsRequest { ApiKey = "KEY", IsSSL = false, Path = new[] { P1 } }.GetUri());
+
+        [Test]
+        public void SnapToRoads_EmptyPath_Throws()
+            => Assert.Throws<ArgumentException>(() => new SnapToRoadsRequest { ApiKey = "KEY", Path = Array.Empty<Location>() }.GetUri());
+
+        [Test]
+        public void SnapToRoads_NullPath_Throws()
+            => Assert.Throws<ArgumentException>(() => new SnapToRoadsRequest { ApiKey = "KEY" }.GetUri());
+
+        [Test]
+        public void SnapToRoads_OverHundredPoints_Throws()
+        {
+            var points = Enumerable.Range(0, SnapToRoadsRequest.MaxPathPoints + 1).Select(i => new Location(i, i)).ToArray();
+            Assert.Throws<ArgumentException>(() => new SnapToRoadsRequest { ApiKey = "KEY", Path = points }.GetUri());
+        }
+
+        [Test]
+        public void SpeedLimits_BothPathAndPlaceIds_Throws()
+            => Assert.Throws<ArgumentException>(() =>
+                new SpeedLimitsRequest { ApiKey = "KEY", Path = new[] { P1 }, PlaceIds = new[] { "abc" } }.GetUri());
+
+        [Test]
+        public void SpeedLimits_NeitherPathNorPlaceIds_Throws()
+            => Assert.Throws<ArgumentException>(() => new SpeedLimitsRequest { ApiKey = "KEY" }.GetUri());
+
+        #endregion
+
+        #region Response parsing
+
+        [Test]
+        public async Task SnapToRoads_Parses_InterpolatedPoint_WithNullOriginalIndex()
+        {
+            const string json = """
+            {
+              "snappedPoints": [
+                { "location": { "latitude": -35.27801, "longitude": 149.12958 }, "originalIndex": 0, "placeId": "ChIJ-A" },
+                { "location": { "latitude": -35.27905, "longitude": 149.12931 }, "placeId": "ChIJ-B" }
+              ],
+              "warningMessage": "Input path is sparse."
+            }
+            """;
+
+            var response = await QueryAsync<SnapToRoadsRequest, SnapToRoadsResponse>(
+                new SnapToRoadsRequest { ApiKey = "KEY", Path = new[] { P1 }, Interpolate = true }, json);
+
+            Assert.That(response.WarningMessage, Is.EqualTo("Input path is sparse."));
+            Assert.That(response.SnappedPoints, Has.Count.EqualTo(2));
+            Assert.That(response.SnappedPoints![0].OriginalIndex, Is.EqualTo(0));
+            Assert.That(response.SnappedPoints[0].Location!.Latitude, Is.EqualTo(-35.27801));
+            Assert.That(response.SnappedPoints[1].OriginalIndex, Is.Null);
+            Assert.That(response.SnappedPoints[1].PlaceId, Is.EqualTo("ChIJ-B"));
+        }
+
+        [Test]
+        public async Task SnapToRoads_NoWarning_LeavesWarningMessageNull()
+        {
+            const string json = """
+            { "snappedPoints": [ { "location": { "latitude": 1, "longitude": 2 }, "originalIndex": 0, "placeId": "X" } ] }
+            """;
+
+            var response = await QueryAsync<SnapToRoadsRequest, SnapToRoadsResponse>(
+                new SnapToRoadsRequest { ApiKey = "KEY", Path = new[] { P1 } }, json);
+
+            Assert.That(response.WarningMessage, Is.Null);
+            Assert.That(response.SnappedPoints, Has.Count.EqualTo(1));
+        }
+
+        [Test]
+        public async Task NearestRoads_Parses_SnappedPoints()
+        {
+            const string json = """
+            { "snappedPoints": [ { "location": { "latitude": 1.5, "longitude": 2.5 }, "originalIndex": 0, "placeId": "Y" } ] }
+            """;
+
+            var response = await QueryAsync<NearestRoadsRequest, NearestRoadsResponse>(
+                new NearestRoadsRequest { ApiKey = "KEY", Points = new[] { P1 } }, json);
+
+            Assert.That(response.SnappedPoints, Has.Count.EqualTo(1));
+            Assert.That(response.SnappedPoints![0].Location!.Longitude, Is.EqualTo(2.5));
+        }
+
+        [Test]
+        public async Task SpeedLimits_Parses_SpeedLimitsAndUnits()
+        {
+            const string json = """
+            {
+              "speedLimits": [
+                { "placeId": "A", "speedLimit": 105, "units": "KMPH" },
+                { "placeId": "B", "speedLimit": 65, "units": "MPH" }
+              ],
+              "snappedPoints": [ { "location": { "latitude": 1, "longitude": 2 }, "originalIndex": 0, "placeId": "A" } ]
+            }
+            """;
+
+            var response = await QueryAsync<SpeedLimitsRequest, SpeedLimitsResponse>(
+                new SpeedLimitsRequest { ApiKey = "KEY", Path = new[] { P1 } }, json);
+
+            Assert.That(response.SpeedLimits, Has.Count.EqualTo(2));
+            Assert.That(response.SpeedLimits![0].Value, Is.EqualTo(105));
+            Assert.That(response.SpeedLimits[0].Units, Is.EqualTo(SpeedLimitUnits.Kmph));
+            Assert.That(response.SpeedLimits[1].Units, Is.EqualTo(SpeedLimitUnits.Mph));
+            Assert.That(response.SnappedPoints, Has.Count.EqualTo(1));
+        }
+
+        #endregion
+
+        private static Task<TResponse> QueryAsync<TRequest, TResponse>(TRequest request, string responseJson)
+            where TRequest : MapsBaseRequest, new()
+            where TResponse : IResponseFor<TRequest>
+        {
+            var handler = new StubHandler(responseJson);
+            using var http = new HttpClient(handler);
+            return MapsAPIGenericEngine<TRequest, TResponse>.QueryGoogleAPIAsync(
+                http, request, TimeSpan.FromMilliseconds(-1), CancellationToken.None, null, null);
+        }
+
+        private sealed class StubHandler : HttpMessageHandler
+        {
+            private readonly string _responseJson;
+            public StubHandler(string responseJson) { _responseJson = responseJson; }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+                => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(_responseJson, Encoding.UTF8, "application/json")
+                });
+        }
+    }
+}

--- a/GoogleMapsApi/Entities/Roads/Request/NearestRoadsRequest.cs
+++ b/GoogleMapsApi/Entities/Roads/Request/NearestRoadsRequest.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using GoogleMapsApi.Entities.Common;
+
+namespace GoogleMapsApi.Entities.Roads.Request
+{
+    /// <summary>
+    /// Request for the Roads API Nearest Roads endpoint
+    /// (<c>GET https://roads.googleapis.com/v1/nearestRoads</c>). Returns the nearest road segment
+    /// for each of up to <see cref="MaxPoints"/> arbitrary points. Unlike Snap to Roads, the input
+    /// points need not be in order or form a traveled path.
+    /// </summary>
+    /// <remarks>
+    /// See <see href="https://developers.google.com/maps/documentation/roads/nearest"/>.
+    /// </remarks>
+    public sealed class NearestRoadsRequest : MapsBaseRequest
+    {
+        /// <summary>Maximum number of points accepted in a single request.</summary>
+        public const int MaxPoints = 100;
+
+        /// <summary>
+        /// The points to find roads for. Required; 1 to <see cref="MaxPoints"/> points.
+        /// </summary>
+        public IEnumerable<Location>? Points { get; set; }
+
+        /// <inheritdoc/>
+        public override Uri GetUri()
+        {
+            var points = RoadsRequestHelper.BuildPointsParameter(Points, MaxPoints, nameof(Points));
+            RoadsRequestHelper.ValidateApiKeyAndSsl(ApiKey, IsSSL);
+
+            var url =
+                "https://roads.googleapis.com/v1/nearestRoads" +
+                $"?points={points}" +
+                $"&key={Uri.EscapeDataString(ApiKey!)}";
+
+            return new Uri(url);
+        }
+    }
+}

--- a/GoogleMapsApi/Entities/Roads/Request/RoadsRequestHelper.cs
+++ b/GoogleMapsApi/Entities/Roads/Request/RoadsRequestHelper.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using GoogleMapsApi.Entities.Common;
+
+namespace GoogleMapsApi.Entities.Roads.Request
+{
+    /// <summary>
+    /// Shared validation and URL-building helpers for the Roads API requests. The Roads endpoints
+    /// live on a different host than the rest of the Maps Web Services, so they build their URIs by
+    /// hand rather than going through <see cref="QueryStringParametersList"/>.
+    /// </summary>
+    internal static class RoadsRequestHelper
+    {
+        /// <summary>
+        /// Validates that an API key is present and SSL is enabled (required for every Roads endpoint).
+        /// </summary>
+        public static void ValidateApiKeyAndSsl(string? apiKey, bool isSsl)
+        {
+            if (string.IsNullOrWhiteSpace(apiKey))
+                throw new ArgumentException("ApiKey is required for the Roads API.", nameof(apiKey));
+            if (!isSsl)
+                throw new ArgumentException("Roads API requires SSL [IsSSL = true].");
+        }
+
+        /// <summary>
+        /// Validates a sequence of points and renders it as a pipe-separated, URL-escaped
+        /// <c>lat,lng|lat,lng</c> parameter value.
+        /// </summary>
+        /// <param name="points">The points to serialize.</param>
+        /// <param name="maxPoints">Maximum number of points the endpoint accepts.</param>
+        /// <param name="parameterName">Name of the owning property, used in exception messages.</param>
+        public static string BuildPointsParameter(IEnumerable<Location>? points, int maxPoints, string parameterName)
+        {
+            if (points == null)
+                throw new ArgumentException($"{parameterName} is required.", parameterName);
+
+            var list = points.ToList();
+            if (list.Count == 0)
+                throw new ArgumentException($"{parameterName} must contain at least one point.", parameterName);
+            if (list.Count > maxPoints)
+                throw new ArgumentException($"{parameterName} may contain at most {maxPoints} points.", parameterName);
+
+            return string.Join("|", list.Select(p => Uri.EscapeDataString(p.LocationString)));
+        }
+    }
+}

--- a/GoogleMapsApi/Entities/Roads/Request/SnapToRoadsRequest.cs
+++ b/GoogleMapsApi/Entities/Roads/Request/SnapToRoadsRequest.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using GoogleMapsApi.Entities.Common;
+
+namespace GoogleMapsApi.Entities.Roads.Request
+{
+    /// <summary>
+    /// Request for the Roads API Snap to Roads endpoint
+    /// (<c>GET https://roads.googleapis.com/v1/snapToRoads</c>). Snaps up to
+    /// <see cref="MaxPathPoints"/> GPS points to the most likely road segments they were traveling along.
+    /// </summary>
+    /// <remarks>
+    /// For best results, consecutive points should be within 300m of each other. See
+    /// <see href="https://developers.google.com/maps/documentation/roads/snap"/>.
+    /// </remarks>
+    public sealed class SnapToRoadsRequest : MapsBaseRequest
+    {
+        /// <summary>Maximum number of points accepted in a single request.</summary>
+        public const int MaxPathPoints = 100;
+
+        /// <summary>
+        /// The path to snap, as an ordered sequence of points. Required; 1 to
+        /// <see cref="MaxPathPoints"/> points.
+        /// </summary>
+        public IEnumerable<Location>? Path { get; set; }
+
+        /// <summary>
+        /// When <c>true</c>, the response is interpolated to include additional points so the
+        /// returned path smoothly follows road geometry. Interpolated points have no
+        /// <see cref="Response.SnappedPoint.OriginalIndex"/>. Defaults to <c>false</c>.
+        /// </summary>
+        public bool Interpolate { get; set; }
+
+        /// <inheritdoc/>
+        public override Uri GetUri()
+        {
+            var path = RoadsRequestHelper.BuildPointsParameter(Path, MaxPathPoints, nameof(Path));
+            RoadsRequestHelper.ValidateApiKeyAndSsl(ApiKey, IsSSL);
+
+            var url =
+                "https://roads.googleapis.com/v1/snapToRoads" +
+                $"?path={path}" +
+                $"&interpolate={(Interpolate ? "true" : "false")}" +
+                $"&key={Uri.EscapeDataString(ApiKey!)}";
+
+            return new Uri(url);
+        }
+    }
+}

--- a/GoogleMapsApi/Entities/Roads/Request/SpeedLimitsRequest.cs
+++ b/GoogleMapsApi/Entities/Roads/Request/SpeedLimitsRequest.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using GoogleMapsApi.Entities.Common;
+
+namespace GoogleMapsApi.Entities.Roads.Request
+{
+    /// <summary>
+    /// Request for the Roads API Speed Limits endpoint
+    /// (<c>GET https://roads.googleapis.com/v1/speedLimits</c>). Returns the posted speed limit for a
+    /// road segment, either by snapping a <see cref="Path"/> or by looking up known <see cref="PlaceIds"/>.
+    /// </summary>
+    /// <remarks>
+    /// The Speed Limits service is only available to customers with an Asset Tracking license; other
+    /// keys receive an HTTP 403. Each returned speed limit is separately billable. Exactly one of
+    /// <see cref="Path"/> or <see cref="PlaceIds"/> must be supplied. See
+    /// <see href="https://developers.google.com/maps/documentation/roads/speed-limits"/>.
+    /// </remarks>
+    public sealed class SpeedLimitsRequest : MapsBaseRequest
+    {
+        /// <summary>Maximum number of points or place IDs accepted in a single request.</summary>
+        public const int MaxItems = 100;
+
+        /// <summary>
+        /// A path to snap and return speed limits for; 1 to <see cref="MaxItems"/> points.
+        /// Mutually exclusive with <see cref="PlaceIds"/>.
+        /// </summary>
+        public IEnumerable<Location>? Path { get; set; }
+
+        /// <summary>
+        /// Road-segment place IDs (e.g. from a prior Snap to Roads call) to return speed limits for;
+        /// 1 to <see cref="MaxItems"/> IDs. Mutually exclusive with <see cref="Path"/>.
+        /// </summary>
+        public IEnumerable<string>? PlaceIds { get; set; }
+
+        /// <summary>Unit system for the returned speed limits. Defaults to the API default (KPH).</summary>
+        public SpeedUnits? Units { get; set; }
+
+        /// <inheritdoc/>
+        public override Uri GetUri()
+        {
+            var hasPath = Path != null;
+            var hasPlaceIds = PlaceIds != null;
+            if (hasPath == hasPlaceIds)
+                throw new ArgumentException("Exactly one of Path or PlaceIds must be specified for Speed Limits, and both cannot be specified.");
+
+            RoadsRequestHelper.ValidateApiKeyAndSsl(ApiKey, IsSSL);
+
+            var url = new StringBuilder("https://roads.googleapis.com/v1/speedLimits?");
+
+            if (hasPath)
+            {
+                var path = RoadsRequestHelper.BuildPointsParameter(Path, MaxItems, nameof(Path));
+                url.Append("path=").Append(path);
+            }
+            else
+            {
+                url.Append(BuildPlaceIdsParameter(PlaceIds!));
+            }
+
+            if (Units.HasValue)
+                url.Append("&units=").Append(Units.Value == SpeedUnits.Mph ? "MPH" : "KPH");
+
+            url.Append("&key=").Append(Uri.EscapeDataString(ApiKey!));
+
+            return new Uri(url.ToString());
+        }
+
+        private static string BuildPlaceIdsParameter(IEnumerable<string> placeIds)
+        {
+            var list = placeIds.ToList();
+            if (list.Count == 0)
+                throw new ArgumentException("PlaceIds must contain at least one place ID.", nameof(placeIds));
+            if (list.Count > MaxItems)
+                throw new ArgumentException($"PlaceIds may contain at most {MaxItems} IDs.", nameof(placeIds));
+
+            return string.Join("&", list.Select(id => "placeId=" + Uri.EscapeDataString(id)));
+        }
+    }
+}

--- a/GoogleMapsApi/Entities/Roads/Request/SpeedUnits.cs
+++ b/GoogleMapsApi/Entities/Roads/Request/SpeedUnits.cs
@@ -1,0 +1,18 @@
+using System.Runtime.Serialization;
+
+namespace GoogleMapsApi.Entities.Roads.Request
+{
+    /// <summary>
+    /// Unit system requested for Speed Limits results. Sent as the <c>units</c> query parameter.
+    /// </summary>
+    public enum SpeedUnits
+    {
+        /// <summary>Kilometers per hour (the Roads API default). Sent as <c>KPH</c>.</summary>
+        [EnumMember(Value = "KPH")]
+        Kph,
+
+        /// <summary>Miles per hour. Sent as <c>MPH</c>.</summary>
+        [EnumMember(Value = "MPH")]
+        Mph,
+    }
+}

--- a/GoogleMapsApi/Entities/Roads/Response/NearestRoadsResponse.cs
+++ b/GoogleMapsApi/Entities/Roads/Response/NearestRoadsResponse.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using GoogleMapsApi.Entities.Common;
+using GoogleMapsApi.Entities.Roads.Request;
+
+namespace GoogleMapsApi.Entities.Roads.Response
+{
+    /// <summary>
+    /// Response from the Roads API Nearest Roads endpoint.
+    /// </summary>
+    public sealed class NearestRoadsResponse : IResponseFor<NearestRoadsRequest>
+    {
+        /// <summary>
+        /// The nearest road segment for each input point. Each <see cref="SnappedPoint.OriginalIndex"/>
+        /// maps back to the input point; a single input point may yield multiple snapped points.
+        /// </summary>
+        [JsonPropertyName("snappedPoints")]
+        public IReadOnlyList<SnappedPoint>? SnappedPoints { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/Roads/Response/RoadsLocation.cs
+++ b/GoogleMapsApi/Entities/Roads/Response/RoadsLocation.cs
@@ -1,0 +1,20 @@
+using System.Text.Json.Serialization;
+
+namespace GoogleMapsApi.Entities.Roads.Response
+{
+    /// <summary>
+    /// A latitude/longitude coordinate returned by the Roads API. Unlike
+    /// <see cref="GoogleMapsApi.Entities.Common.Location"/> (which serializes as <c>lat</c>/<c>lng</c>),
+    /// the Roads API uses the <c>latitude</c>/<c>longitude</c> JSON keys.
+    /// </summary>
+    public sealed class RoadsLocation
+    {
+        /// <summary>Latitude in decimal degrees.</summary>
+        [JsonPropertyName("latitude")]
+        public double Latitude { get; set; }
+
+        /// <summary>Longitude in decimal degrees.</summary>
+        [JsonPropertyName("longitude")]
+        public double Longitude { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/Roads/Response/SnapToRoadsResponse.cs
+++ b/GoogleMapsApi/Entities/Roads/Response/SnapToRoadsResponse.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using GoogleMapsApi.Entities.Common;
+using GoogleMapsApi.Entities.Roads.Request;
+
+namespace GoogleMapsApi.Entities.Roads.Response
+{
+    /// <summary>
+    /// Response from the Roads API Snap to Roads endpoint.
+    /// </summary>
+    public sealed class SnapToRoadsResponse : IResponseFor<SnapToRoadsRequest>
+    {
+        /// <summary>
+        /// The points snapped to roads, in order. With <c>interpolate=true</c> this includes
+        /// interpolated points (whose <see cref="SnappedPoint.OriginalIndex"/> is <c>null</c>).
+        /// </summary>
+        [JsonPropertyName("snappedPoints")]
+        public IReadOnlyList<SnappedPoint>? SnappedPoints { get; set; }
+
+        /// <summary>
+        /// A user-visible warning, present for example when the input path is too sparse for
+        /// reliable snapping. <c>null</c> when there is no warning.
+        /// </summary>
+        [JsonPropertyName("warningMessage")]
+        public string? WarningMessage { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/Roads/Response/SnappedPoint.cs
+++ b/GoogleMapsApi/Entities/Roads/Response/SnappedPoint.cs
@@ -1,0 +1,26 @@
+using System.Text.Json.Serialization;
+
+namespace GoogleMapsApi.Entities.Roads.Response
+{
+    /// <summary>
+    /// A point snapped to a road segment. Returned by Snap to Roads, Nearest Roads, and (when a
+    /// path is supplied) Speed Limits.
+    /// </summary>
+    public sealed class SnappedPoint
+    {
+        /// <summary>The snapped coordinate on the road.</summary>
+        [JsonPropertyName("location")]
+        public RoadsLocation? Location { get; set; }
+
+        /// <summary>
+        /// Zero-based index of the corresponding input point. Absent for interpolated points
+        /// (Snap to Roads with <c>interpolate=true</c>), which is why this is nullable.
+        /// </summary>
+        [JsonPropertyName("originalIndex")]
+        public int? OriginalIndex { get; set; }
+
+        /// <summary>Unique identifier of the road segment this point was snapped to.</summary>
+        [JsonPropertyName("placeId")]
+        public string? PlaceId { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/Roads/Response/SpeedLimit.cs
+++ b/GoogleMapsApi/Entities/Roads/Response/SpeedLimit.cs
@@ -1,0 +1,24 @@
+using System.Text.Json.Serialization;
+using GoogleMapsApi.Engine.JsonConverters;
+
+namespace GoogleMapsApi.Entities.Roads.Response
+{
+    /// <summary>
+    /// Posted speed limit for a single road segment, identified by <see cref="PlaceId"/>.
+    /// </summary>
+    public sealed class SpeedLimit
+    {
+        /// <summary>Unique identifier of the road segment this speed limit applies to.</summary>
+        [JsonPropertyName("placeId")]
+        public string? PlaceId { get; set; }
+
+        /// <summary>The speed limit value, expressed in <see cref="Units"/>.</summary>
+        [JsonPropertyName("speedLimit")]
+        public double Value { get; set; }
+
+        /// <summary>Unit of <see cref="Value"/>.</summary>
+        [JsonPropertyName("units")]
+        [JsonConverter(typeof(EnumMemberJsonConverter<SpeedLimitUnits>))]
+        public SpeedLimitUnits? Units { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/Roads/Response/SpeedLimitUnits.cs
+++ b/GoogleMapsApi/Entities/Roads/Response/SpeedLimitUnits.cs
@@ -1,0 +1,18 @@
+using System.Runtime.Serialization;
+
+namespace GoogleMapsApi.Entities.Roads.Response
+{
+    /// <summary>
+    /// Unit of the speed value on a <see cref="SpeedLimit"/>.
+    /// </summary>
+    public enum SpeedLimitUnits
+    {
+        /// <summary>Kilometers per hour. The Roads API returns this as <c>KMPH</c>.</summary>
+        [EnumMember(Value = "KMPH")]
+        Kmph,
+
+        /// <summary>Miles per hour.</summary>
+        [EnumMember(Value = "MPH")]
+        Mph,
+    }
+}

--- a/GoogleMapsApi/Entities/Roads/Response/SpeedLimitsResponse.cs
+++ b/GoogleMapsApi/Entities/Roads/Response/SpeedLimitsResponse.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using GoogleMapsApi.Entities.Common;
+using GoogleMapsApi.Entities.Roads.Request;
+
+namespace GoogleMapsApi.Entities.Roads.Response
+{
+    /// <summary>
+    /// Response from the Roads API Speed Limits endpoint.
+    /// </summary>
+    public sealed class SpeedLimitsResponse : IResponseFor<SpeedLimitsRequest>
+    {
+        /// <summary>The posted speed limits, one per road segment.</summary>
+        [JsonPropertyName("speedLimits")]
+        public IReadOnlyList<SpeedLimit>? SpeedLimits { get; set; }
+
+        /// <summary>
+        /// The points snapped to roads. Populated when the request supplied a path; absent when
+        /// the request supplied place IDs.
+        /// </summary>
+        [JsonPropertyName("snappedPoints")]
+        public IReadOnlyList<SnappedPoint>? SnappedPoints { get; set; }
+    }
+}

--- a/GoogleMapsApi/GoogleMapsClient.cs
+++ b/GoogleMapsApi/GoogleMapsClient.cs
@@ -9,6 +9,8 @@ using GoogleMapsApi.Entities.Elevation.Request;
 using GoogleMapsApi.Entities.Elevation.Response;
 using GoogleMapsApi.Entities.Geocoding.Request;
 using GoogleMapsApi.Entities.Geocoding.Response;
+using GoogleMapsApi.Entities.Roads.Request;
+using GoogleMapsApi.Entities.Roads.Response;
 using GoogleMapsApi.Entities.Routes.Request;
 using GoogleMapsApi.Entities.Routes.Response;
 using GoogleMapsApi.Entities.PlacesNew.Request;
@@ -53,6 +55,9 @@ namespace GoogleMapsApi
             DistanceMatrix = new HttpClientEngineFacade<DistanceMatrixRequest, DistanceMatrixResponse>(httpClient, options);
             AddressValidation = new HttpClientEngineFacade<AddressValidationRequest, AddressValidationResponse>(httpClient, options);
             Routes = new HttpClientEngineFacade<RoutesRequest, RoutesResponse>(httpClient, options);
+            SnapToRoads = new HttpClientEngineFacade<SnapToRoadsRequest, SnapToRoadsResponse>(httpClient, options);
+            NearestRoads = new HttpClientEngineFacade<NearestRoadsRequest, NearestRoadsResponse>(httpClient, options);
+            SpeedLimits = new HttpClientEngineFacade<SpeedLimitsRequest, SpeedLimitsResponse>(httpClient, options);
             PlacesSearchText = new HttpClientEngineFacade<SearchTextRequest, SearchTextResponse>(httpClient, options);
             PlacesSearchNearby = new HttpClientEngineFacade<SearchNearbyRequest, SearchNearbyResponse>(httpClient, options);
             PlaceDetailsNew = new HttpClientEngineFacade<PlaceDetailsRequest, Place>(httpClient, options);
@@ -80,6 +85,15 @@ namespace GoogleMapsApi
 
         /// <inheritdoc/>
         public IEngineFacade<RoutesRequest, RoutesResponse> Routes { get; }
+
+        /// <inheritdoc/>
+        public IEngineFacade<SnapToRoadsRequest, SnapToRoadsResponse> SnapToRoads { get; }
+
+        /// <inheritdoc/>
+        public IEngineFacade<NearestRoadsRequest, NearestRoadsResponse> NearestRoads { get; }
+
+        /// <inheritdoc/>
+        public IEngineFacade<SpeedLimitsRequest, SpeedLimitsResponse> SpeedLimits { get; }
 
         /// <inheritdoc/>
         public IEngineFacade<SearchTextRequest, SearchTextResponse> PlacesSearchText { get; }

--- a/GoogleMapsApi/IGoogleMapsClient.cs
+++ b/GoogleMapsApi/IGoogleMapsClient.cs
@@ -8,6 +8,8 @@ using GoogleMapsApi.Entities.Elevation.Request;
 using GoogleMapsApi.Entities.Elevation.Response;
 using GoogleMapsApi.Entities.Geocoding.Request;
 using GoogleMapsApi.Entities.Geocoding.Response;
+using GoogleMapsApi.Entities.Roads.Request;
+using GoogleMapsApi.Entities.Roads.Response;
 using GoogleMapsApi.Entities.Routes.Request;
 using GoogleMapsApi.Entities.Routes.Response;
 using GoogleMapsApi.Entities.PlacesNew.Request;
@@ -47,6 +49,18 @@ namespace GoogleMapsApi
         /// Compute routes via the Routes API — the modern replacement for the Directions API.
         /// </summary>
         IEngineFacade<RoutesRequest, RoutesResponse> Routes { get; }
+
+        /// <summary>Snap GPS points to the most likely road segments traveled (Roads API).</summary>
+        IEngineFacade<SnapToRoadsRequest, SnapToRoadsResponse> SnapToRoads { get; }
+
+        /// <summary>Find the nearest road segment for each of a set of points (Roads API).</summary>
+        IEngineFacade<NearestRoadsRequest, NearestRoadsResponse> NearestRoads { get; }
+
+        /// <summary>
+        /// Look up posted speed limits along a path or for place IDs (Roads API).
+        /// Requires a Google Asset Tracking license; other keys receive an HTTP 403.
+        /// </summary>
+        IEngineFacade<SpeedLimitsRequest, SpeedLimitsResponse> SpeedLimits { get; }
 
         /// <summary>Search for places by free-text query via the Places API (New).</summary>
         IEngineFacade<SearchTextRequest, SearchTextResponse> PlacesSearchText { get; }

--- a/GoogleMapsApi/PublicAPI.Unshipped.txt
+++ b/GoogleMapsApi/PublicAPI.Unshipped.txt
@@ -1,1 +1,75 @@
 #nullable enable
+GoogleMapsApi.Entities.Roads.Request.NearestRoadsRequest
+GoogleMapsApi.Entities.Roads.Request.NearestRoadsRequest.NearestRoadsRequest() -> void
+GoogleMapsApi.Entities.Roads.Request.NearestRoadsRequest.Points.get -> System.Collections.Generic.IEnumerable<GoogleMapsApi.Entities.Common.Location!>?
+GoogleMapsApi.Entities.Roads.Request.NearestRoadsRequest.Points.set -> void
+GoogleMapsApi.Entities.Roads.Request.SnapToRoadsRequest
+GoogleMapsApi.Entities.Roads.Request.SnapToRoadsRequest.Interpolate.get -> bool
+GoogleMapsApi.Entities.Roads.Request.SnapToRoadsRequest.Interpolate.set -> void
+GoogleMapsApi.Entities.Roads.Request.SnapToRoadsRequest.Path.get -> System.Collections.Generic.IEnumerable<GoogleMapsApi.Entities.Common.Location!>?
+GoogleMapsApi.Entities.Roads.Request.SnapToRoadsRequest.Path.set -> void
+GoogleMapsApi.Entities.Roads.Request.SnapToRoadsRequest.SnapToRoadsRequest() -> void
+GoogleMapsApi.Entities.Roads.Request.SpeedLimitsRequest
+GoogleMapsApi.Entities.Roads.Request.SpeedLimitsRequest.Path.get -> System.Collections.Generic.IEnumerable<GoogleMapsApi.Entities.Common.Location!>?
+GoogleMapsApi.Entities.Roads.Request.SpeedLimitsRequest.Path.set -> void
+GoogleMapsApi.Entities.Roads.Request.SpeedLimitsRequest.PlaceIds.get -> System.Collections.Generic.IEnumerable<string!>?
+GoogleMapsApi.Entities.Roads.Request.SpeedLimitsRequest.PlaceIds.set -> void
+GoogleMapsApi.Entities.Roads.Request.SpeedLimitsRequest.SpeedLimitsRequest() -> void
+GoogleMapsApi.Entities.Roads.Request.SpeedLimitsRequest.Units.get -> GoogleMapsApi.Entities.Roads.Request.SpeedUnits?
+GoogleMapsApi.Entities.Roads.Request.SpeedLimitsRequest.Units.set -> void
+GoogleMapsApi.Entities.Roads.Request.SpeedUnits
+GoogleMapsApi.Entities.Roads.Request.SpeedUnits.Kph = 0 -> GoogleMapsApi.Entities.Roads.Request.SpeedUnits
+GoogleMapsApi.Entities.Roads.Request.SpeedUnits.Mph = 1 -> GoogleMapsApi.Entities.Roads.Request.SpeedUnits
+GoogleMapsApi.Entities.Roads.Response.NearestRoadsResponse
+GoogleMapsApi.Entities.Roads.Response.NearestRoadsResponse.NearestRoadsResponse() -> void
+GoogleMapsApi.Entities.Roads.Response.NearestRoadsResponse.SnappedPoints.get -> System.Collections.Generic.IReadOnlyList<GoogleMapsApi.Entities.Roads.Response.SnappedPoint!>?
+GoogleMapsApi.Entities.Roads.Response.NearestRoadsResponse.SnappedPoints.set -> void
+GoogleMapsApi.Entities.Roads.Response.RoadsLocation
+GoogleMapsApi.Entities.Roads.Response.RoadsLocation.Latitude.get -> double
+GoogleMapsApi.Entities.Roads.Response.RoadsLocation.Latitude.set -> void
+GoogleMapsApi.Entities.Roads.Response.RoadsLocation.Longitude.get -> double
+GoogleMapsApi.Entities.Roads.Response.RoadsLocation.Longitude.set -> void
+GoogleMapsApi.Entities.Roads.Response.RoadsLocation.RoadsLocation() -> void
+GoogleMapsApi.Entities.Roads.Response.SnapToRoadsResponse
+GoogleMapsApi.Entities.Roads.Response.SnapToRoadsResponse.SnapToRoadsResponse() -> void
+GoogleMapsApi.Entities.Roads.Response.SnapToRoadsResponse.SnappedPoints.get -> System.Collections.Generic.IReadOnlyList<GoogleMapsApi.Entities.Roads.Response.SnappedPoint!>?
+GoogleMapsApi.Entities.Roads.Response.SnapToRoadsResponse.SnappedPoints.set -> void
+GoogleMapsApi.Entities.Roads.Response.SnapToRoadsResponse.WarningMessage.get -> string?
+GoogleMapsApi.Entities.Roads.Response.SnapToRoadsResponse.WarningMessage.set -> void
+GoogleMapsApi.Entities.Roads.Response.SnappedPoint
+GoogleMapsApi.Entities.Roads.Response.SnappedPoint.Location.get -> GoogleMapsApi.Entities.Roads.Response.RoadsLocation?
+GoogleMapsApi.Entities.Roads.Response.SnappedPoint.Location.set -> void
+GoogleMapsApi.Entities.Roads.Response.SnappedPoint.OriginalIndex.get -> int?
+GoogleMapsApi.Entities.Roads.Response.SnappedPoint.OriginalIndex.set -> void
+GoogleMapsApi.Entities.Roads.Response.SnappedPoint.PlaceId.get -> string?
+GoogleMapsApi.Entities.Roads.Response.SnappedPoint.PlaceId.set -> void
+GoogleMapsApi.Entities.Roads.Response.SnappedPoint.SnappedPoint() -> void
+GoogleMapsApi.Entities.Roads.Response.SpeedLimit
+GoogleMapsApi.Entities.Roads.Response.SpeedLimit.PlaceId.get -> string?
+GoogleMapsApi.Entities.Roads.Response.SpeedLimit.PlaceId.set -> void
+GoogleMapsApi.Entities.Roads.Response.SpeedLimit.SpeedLimit() -> void
+GoogleMapsApi.Entities.Roads.Response.SpeedLimit.Units.get -> GoogleMapsApi.Entities.Roads.Response.SpeedLimitUnits?
+GoogleMapsApi.Entities.Roads.Response.SpeedLimit.Units.set -> void
+GoogleMapsApi.Entities.Roads.Response.SpeedLimit.Value.get -> double
+GoogleMapsApi.Entities.Roads.Response.SpeedLimit.Value.set -> void
+GoogleMapsApi.Entities.Roads.Response.SpeedLimitUnits
+GoogleMapsApi.Entities.Roads.Response.SpeedLimitUnits.Kmph = 0 -> GoogleMapsApi.Entities.Roads.Response.SpeedLimitUnits
+GoogleMapsApi.Entities.Roads.Response.SpeedLimitUnits.Mph = 1 -> GoogleMapsApi.Entities.Roads.Response.SpeedLimitUnits
+GoogleMapsApi.Entities.Roads.Response.SpeedLimitsResponse
+GoogleMapsApi.Entities.Roads.Response.SpeedLimitsResponse.SnappedPoints.get -> System.Collections.Generic.IReadOnlyList<GoogleMapsApi.Entities.Roads.Response.SnappedPoint!>?
+GoogleMapsApi.Entities.Roads.Response.SpeedLimitsResponse.SnappedPoints.set -> void
+GoogleMapsApi.Entities.Roads.Response.SpeedLimitsResponse.SpeedLimits.get -> System.Collections.Generic.IReadOnlyList<GoogleMapsApi.Entities.Roads.Response.SpeedLimit!>?
+GoogleMapsApi.Entities.Roads.Response.SpeedLimitsResponse.SpeedLimits.set -> void
+GoogleMapsApi.Entities.Roads.Response.SpeedLimitsResponse.SpeedLimitsResponse() -> void
+GoogleMapsApi.GoogleMapsClient.NearestRoads.get -> GoogleMapsApi.IEngineFacade<GoogleMapsApi.Entities.Roads.Request.NearestRoadsRequest!, GoogleMapsApi.Entities.Roads.Response.NearestRoadsResponse!>!
+GoogleMapsApi.GoogleMapsClient.SnapToRoads.get -> GoogleMapsApi.IEngineFacade<GoogleMapsApi.Entities.Roads.Request.SnapToRoadsRequest!, GoogleMapsApi.Entities.Roads.Response.SnapToRoadsResponse!>!
+GoogleMapsApi.GoogleMapsClient.SpeedLimits.get -> GoogleMapsApi.IEngineFacade<GoogleMapsApi.Entities.Roads.Request.SpeedLimitsRequest!, GoogleMapsApi.Entities.Roads.Response.SpeedLimitsResponse!>!
+GoogleMapsApi.IGoogleMapsClient.NearestRoads.get -> GoogleMapsApi.IEngineFacade<GoogleMapsApi.Entities.Roads.Request.NearestRoadsRequest!, GoogleMapsApi.Entities.Roads.Response.NearestRoadsResponse!>!
+GoogleMapsApi.IGoogleMapsClient.SnapToRoads.get -> GoogleMapsApi.IEngineFacade<GoogleMapsApi.Entities.Roads.Request.SnapToRoadsRequest!, GoogleMapsApi.Entities.Roads.Response.SnapToRoadsResponse!>!
+GoogleMapsApi.IGoogleMapsClient.SpeedLimits.get -> GoogleMapsApi.IEngineFacade<GoogleMapsApi.Entities.Roads.Request.SpeedLimitsRequest!, GoogleMapsApi.Entities.Roads.Response.SpeedLimitsResponse!>!
+override GoogleMapsApi.Entities.Roads.Request.NearestRoadsRequest.GetUri() -> System.Uri!
+override GoogleMapsApi.Entities.Roads.Request.SnapToRoadsRequest.GetUri() -> System.Uri!
+override GoogleMapsApi.Entities.Roads.Request.SpeedLimitsRequest.GetUri() -> System.Uri!
+const GoogleMapsApi.Entities.Roads.Request.NearestRoadsRequest.MaxPoints = 100 -> int
+const GoogleMapsApi.Entities.Roads.Request.SnapToRoadsRequest.MaxPathPoints = 100 -> int
+const GoogleMapsApi.Entities.Roads.Request.SpeedLimitsRequest.MaxItems = 100 -> int


### PR DESCRIPTION
## Summary

Adds **Google Roads API** support to the library — the three endpoints on `https://roads.googleapis.com/v1/`, exposed as flat facades on `IGoogleMapsClient`:

- **`SnapToRoads`** — snap noisy GPS traces to the most likely road segments (with optional `interpolate`).
- **`NearestRoads`** — find the nearest road segment for arbitrary points.
- **`SpeedLimits`** — posted speed limits along a path or for place IDs. *Requires a Google Asset Tracking license (other keys get HTTP 403); per-result billing applies.*

This rounds out coverage for the telematics/fleet niche where .NET is common.

## Design notes

- **Custom host:** Roads lives on a different host than the rest of Maps Web Services, so each request overrides `GetUri()` to build its URL directly — the same pattern already used by `RoutesRequest` / `PlacePhotoRequest`. Shared ApiKey/SSL validation + point serialization live in an internal `RoadsRequestHelper`.
- **Input reuse:** `Path` / `Points` / `PlaceIds` accept `IEnumerable<Location>` and serialize via the existing `Location.LocationString`, so callers use the same coordinate type as everywhere else.
- **Response coordinates:** Roads responses use `latitude`/`longitude` JSON keys (not `lat`/`lng`), so a dedicated `RoadsLocation` type is used; a shared `SnappedPoint` is reused across all three responses.
- **No `Status` enum:** Roads signals errors via HTTP 4xx (already turned into an exception by the engine), so there is no status field to model.
- `PublicAPI.Unshipped.txt` updated for the new public surface.

## Tests

- `GoogleMapsApi.Test/RoadsUnitTests.cs` — **16 offline tests** (mocked `HttpMessageHandler`): URL building, validation (missing key, non-SSL, empty/>100 points, path-xor-placeIds), and response parsing incl. null `OriginalIndex` for interpolated points and `KMPH`/`MPH` unit mapping. All passing.
- `GoogleMapsApi.Test/IntegrationTests/RoadsTests.cs` — live tests for Snap/Nearest; `SpeedLimits` marked `[BillableTest]` (skipped unless `RUN_BILLABLE_TESTS=true`).

Builds clean across all six TFMs (net10.0, net8.0, net6.0, netstandard2.0, net481, net462).

## ⚠️ One thing to verify with a licensed key

Google's docs disagree on the Speed Limits **response** `units` value — the reference says `KMPH`, the guide page shows `KPH`. The response enum is mapped to `[EnumMember("KMPH")]`. Since the SpeedLimits integration test is license-gated/skipped, this wasn't verified against a live response. If you have an Asset Tracking key, run `RUN_BILLABLE_TESTS=true dotnet test --filter "TestCategory=Billable"` and adjust the `EnumMember` if the wire value is actually `KPH`.