### PR TITLE
feat: add Aerial View API support

### DIFF
--- a/GoogleMapsApi.Test/AerialViewUnitTests.cs
+++ b/GoogleMapsApi.Test/AerialViewUnitTests.cs
@@ -1,0 +1,195 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using GoogleMapsApi.Engine;
+using GoogleMapsApi.Entities.AerialView.Request;
+using GoogleMapsApi.Entities.AerialView.Response;
+using NUnit.Framework;
+
+namespace GoogleMapsApi.Test
+{
+    [TestFixture]
+    public class AerialViewUnitTests
+    {
+        private const string ActiveJson =
+            "{\"uris\":{" +
+            "\"IMAGE\":{\"landscapeUri\":\"https://img/l.jpg\",\"portraitUri\":\"https://img/p.jpg\"}," +
+            "\"MP4_HIGH\":{\"landscapeUri\":\"https://v/l.mp4\",\"portraitUri\":\"https://v/p.mp4\"}}," +
+            "\"state\":\"ACTIVE\"," +
+            "\"metadata\":{\"videoId\":\"vid-123\",\"captureDate\":{\"year\":2022,\"month\":10,\"day\":24},\"duration\":\"40s\"}}";
+
+        private const string ProcessingJson =
+            "{\"state\":\"PROCESSING\",\"metadata\":{\"videoId\":\"proc-1\"}}";
+
+        [Test]
+        public void RenderVideo_GetUri_TargetsAerialViewHost_WithKeyInQueryString()
+        {
+            var request = new RenderVideoRequest { ApiKey = "abc 123", Address = "x" };
+
+            var uri = request.GetUri();
+
+            Assert.That(uri.Host, Is.EqualTo("aerialview.googleapis.com"));
+            Assert.That(uri.AbsolutePath, Is.EqualTo("/v1/videos:renderVideo"));
+            Assert.That(uri.Query, Is.EqualTo("?key=abc%20123"));
+        }
+
+        [Test]
+        public void RenderVideo_GetUri_MissingApiKey_Throws()
+        {
+            var request = new RenderVideoRequest { Address = "x" };
+            Assert.Throws<InvalidOperationException>(() => request.GetUri());
+        }
+
+        [Test]
+        public async Task RenderVideo_IssuesPost_WithJsonAddressBody()
+        {
+            var handler = new RecordingHandler(ProcessingJson);
+            using var http = new HttpClient(handler);
+
+            var request = new RenderVideoRequest { ApiKey = "k", Address = "500 W 2nd St, Austin, TX 78701" };
+
+            var response = await MapsAPIGenericEngine<RenderVideoRequest, AerialViewVideoResponse>
+                .QueryGoogleAPIAsync(http, request, TimeSpan.FromMilliseconds(-1), CancellationToken.None, null, null);
+
+            Assert.That(handler.LastMethod, Is.EqualTo(HttpMethod.Post));
+            Assert.That(handler.LastContentType, Is.EqualTo("application/json"));
+            Assert.That(handler.LastUri!.Host, Is.EqualTo("aerialview.googleapis.com"));
+            Assert.That(handler.LastUri!.AbsolutePath, Is.EqualTo("/v1/videos:renderVideo"));
+
+            using var body = JsonDocument.Parse(handler.LastRequestBody!);
+            Assert.That(body.RootElement.GetProperty("address").GetString(), Is.EqualTo("500 W 2nd St, Austin, TX 78701"));
+
+            Assert.That(response.State, Is.EqualTo(VideoState.Processing));
+            Assert.That(response.Metadata!.VideoId, Is.EqualTo("proc-1"));
+        }
+
+        [Test]
+        public void RenderVideo_GetRequestBody_MissingAddress_Throws()
+        {
+            var request = new RenderVideoRequest { ApiKey = "k" };
+            using var http = new HttpClient(new RecordingHandler(ProcessingJson));
+
+            var ex = Assert.ThrowsAsync<ArgumentException>(async () =>
+                await MapsAPIGenericEngine<RenderVideoRequest, AerialViewVideoResponse>
+                    .QueryGoogleAPIAsync(http, request, TimeSpan.FromMilliseconds(-1), CancellationToken.None, null, null));
+            Assert.That(ex!.ParamName, Is.EqualTo("Address"));
+        }
+
+        [Test]
+        public void LookupVideo_GetUri_ByVideoId()
+        {
+            var request = new LookupVideoRequest { ApiKey = "k", VideoId = "vid 1" };
+
+            var uri = request.GetUri();
+
+            Assert.That(uri.Host, Is.EqualTo("aerialview.googleapis.com"));
+            Assert.That(uri.AbsolutePath, Is.EqualTo("/v1/videos:lookupVideo"));
+            Assert.That(uri.Query, Is.EqualTo("?key=k&videoId=vid%201"));
+        }
+
+        [Test]
+        public void LookupVideo_GetUri_ByAddress()
+        {
+            var request = new LookupVideoRequest { ApiKey = "k", Address = "Austin, TX" };
+
+            var uri = request.GetUri();
+
+            Assert.That(uri.Query, Is.EqualTo("?key=k&address=Austin%2C%20TX"));
+        }
+
+        [Test]
+        public void LookupVideo_GetUri_NeitherSelector_Throws()
+        {
+            var request = new LookupVideoRequest { ApiKey = "k" };
+            Assert.Throws<InvalidOperationException>(() => request.GetUri());
+        }
+
+        [Test]
+        public void LookupVideo_GetUri_BothSelectors_Throws()
+        {
+            var request = new LookupVideoRequest { ApiKey = "k", VideoId = "v", Address = "a" };
+            Assert.Throws<InvalidOperationException>(() => request.GetUri());
+        }
+
+        [Test]
+        public async Task LookupVideo_IssuesGet_WithNoBody()
+        {
+            var handler = new RecordingHandler(ActiveJson);
+            using var http = new HttpClient(handler);
+
+            var request = new LookupVideoRequest { ApiKey = "k", VideoId = "vid-123" };
+
+            await MapsAPIGenericEngine<LookupVideoRequest, AerialViewVideoResponse>
+                .QueryGoogleAPIAsync(http, request, TimeSpan.FromMilliseconds(-1), CancellationToken.None, null, null);
+
+            Assert.That(handler.LastMethod, Is.EqualTo(HttpMethod.Get));
+            Assert.That(handler.LastRequestBody, Is.Null);
+        }
+
+        [Test]
+        public void Response_Deserializes_ActiveVideo_WithUrisAndMetadata()
+        {
+            var options = JsonSerializerConfiguration.CreateOptions();
+            var response = JsonSerializer.Deserialize<AerialViewVideoResponse>(ActiveJson, options);
+
+            Assert.That(response, Is.Not.Null);
+            Assert.That(response!.State, Is.EqualTo(VideoState.Active));
+            Assert.That(response.Metadata!.VideoId, Is.EqualTo("vid-123"));
+            Assert.That(response.Metadata.Duration, Is.EqualTo("40s"));
+            Assert.That(response.Metadata.DurationValue, Is.EqualTo(TimeSpan.FromSeconds(40)));
+            Assert.That(response.Metadata.CaptureDate!.Year, Is.EqualTo(2022));
+            Assert.That(response.Metadata.CaptureDate.Month, Is.EqualTo(10));
+            Assert.That(response.Metadata.CaptureDate.Day, Is.EqualTo(24));
+
+            Assert.That(response.Uris!["MP4_HIGH"].LandscapeUri, Is.EqualTo("https://v/l.mp4"));
+            Assert.That(response.TryGetUris(MediaFormat.Mp4High, out var mp4), Is.True);
+            Assert.That(mp4!.PortraitUri, Is.EqualTo("https://v/p.mp4"));
+            Assert.That(response.TryGetUris(MediaFormat.Dash, out var dash), Is.False);
+            Assert.That(dash, Is.Null);
+        }
+
+        [Test]
+        public void Response_Deserializes_ProcessingVideo_WithoutUris()
+        {
+            var options = JsonSerializerConfiguration.CreateOptions();
+            var response = JsonSerializer.Deserialize<AerialViewVideoResponse>(ProcessingJson, options);
+
+            Assert.That(response, Is.Not.Null);
+            Assert.That(response!.State, Is.EqualTo(VideoState.Processing));
+            Assert.That(response.Uris, Is.Null);
+            Assert.That(response.Metadata!.VideoId, Is.EqualTo("proc-1"));
+            Assert.That(response.Metadata.DurationValue, Is.Null);
+        }
+
+        private sealed class RecordingHandler : HttpMessageHandler
+        {
+            private readonly string _responseJson;
+
+            public RecordingHandler(string responseJson) { _responseJson = responseJson; }
+
+            public HttpMethod? LastMethod { get; private set; }
+            public Uri? LastUri { get; private set; }
+            public string? LastRequestBody { get; private set; }
+            public string? LastContentType { get; private set; }
+
+            protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                LastMethod = request.Method;
+                LastUri = request.RequestUri;
+                if (request.Content != null)
+                {
+                    LastRequestBody = await request.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    LastContentType = request.Content.Headers.ContentType?.MediaType;
+                }
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(_responseJson, Encoding.UTF8, "application/json")
+                };
+            }
+        }
+    }
+}

--- a/GoogleMapsApi.Test/IntegrationTests/AerialViewTests.cs
+++ b/GoogleMapsApi.Test/IntegrationTests/AerialViewTests.cs
@@ -1,0 +1,40 @@
+using System.Threading.Tasks;
+using GoogleMapsApi.Entities.AerialView.Request;
+using GoogleMapsApi.Entities.AerialView.Response;
+using GoogleMapsApi.Test.Utils;
+using NUnit.Framework;
+
+namespace GoogleMapsApi.Test.IntegrationTests
+{
+    [TestFixture]
+    [BillableTest]
+    public class AerialViewTests : BaseTestIntegration
+    {
+        // A stable US address that has 3D imagery available.
+        private const string Address = "500 W 2nd St, Austin, TX 78701";
+
+        [Test]
+        public async Task RenderVideo_ReturnsProcessingOrActive_WithVideoId()
+        {
+            var response = await Maps.AerialView.RenderVideo.QueryAsync(
+                new RenderVideoRequest { ApiKey = ApiKey, Address = Address });
+
+            Assert.That(response.State, Is.AnyOf(VideoState.Processing, VideoState.Active));
+            Assert.That(response.Metadata!.VideoId, Is.Not.Null.And.Not.Empty);
+        }
+
+        [Test]
+        public async Task LookupVideo_ByVideoId_ReturnsNonFailedVideo()
+        {
+            var render = await Maps.AerialView.RenderVideo.QueryAsync(
+                new RenderVideoRequest { ApiKey = ApiKey, Address = Address });
+            var videoId = render.Metadata!.VideoId!;
+
+            var lookup = await Maps.AerialView.LookupVideo.QueryAsync(
+                new LookupVideoRequest { ApiKey = ApiKey, VideoId = videoId });
+
+            Assert.That(lookup.State, Is.Not.EqualTo(VideoState.Failed));
+            Assert.That(lookup.Metadata!.VideoId, Is.EqualTo(videoId));
+        }
+    }
+}

--- a/GoogleMapsApi/AerialViewApi.cs
+++ b/GoogleMapsApi/AerialViewApi.cs
@@ -1,0 +1,26 @@
+using System.Net.Http;
+using GoogleMapsApi.Engine;
+using GoogleMapsApi.Entities.AerialView.Request;
+using GoogleMapsApi.Entities.AerialView.Response;
+
+namespace GoogleMapsApi
+{
+    /// <summary>
+    /// Default <see cref="IAerialViewApi"/> implementation grouping the two Aerial View endpoints over a
+    /// shared <see cref="HttpClient"/> and <see cref="GoogleMapsClientOptions"/>.
+    /// </summary>
+    internal sealed class AerialViewApi : IAerialViewApi
+    {
+        public AerialViewApi(HttpClient httpClient, GoogleMapsClientOptions options)
+        {
+            RenderVideo = new HttpClientEngineFacade<RenderVideoRequest, AerialViewVideoResponse>(httpClient, options);
+            LookupVideo = new HttpClientEngineFacade<LookupVideoRequest, AerialViewVideoResponse>(httpClient, options);
+        }
+
+        /// <inheritdoc/>
+        public IEngineFacade<RenderVideoRequest, AerialViewVideoResponse> RenderVideo { get; }
+
+        /// <inheritdoc/>
+        public IEngineFacade<LookupVideoRequest, AerialViewVideoResponse> LookupVideo { get; }
+    }
+}

--- a/GoogleMapsApi/Entities/AerialView/Request/LookupVideoRequest.cs
+++ b/GoogleMapsApi/Entities/AerialView/Request/LookupVideoRequest.cs
@@ -1,0 +1,48 @@
+using System;
+using GoogleMapsApi.Entities.Common;
+
+namespace GoogleMapsApi.Entities.AerialView.Request
+{
+    /// <summary>
+    /// Request for the Aerial View API <c>lookupVideo</c> endpoint
+    /// (<c>GET https://aerialview.googleapis.com/v1/videos:lookupVideo</c>).
+    /// Retrieves a video and its current state by <see cref="VideoId"/> (recommended) or
+    /// <see cref="Address"/> — supply exactly one.
+    /// </summary>
+    /// <remarks>
+    /// A still-rendering video returns HTTP 200 with state <see cref="Response.VideoState.Processing"/>.
+    /// A video that does not exist (or has no 3D imagery) returns HTTP 404, which the engine surfaces as
+    /// an <see cref="System.Net.Http.HttpRequestException"/>. This endpoint is billable.
+    /// </remarks>
+    public sealed class LookupVideoRequest : MapsBaseRequest
+    {
+        /// <summary>The video id returned by a prior <c>RenderVideo</c> call. Mutually exclusive with <see cref="Address"/>.</summary>
+        public string? VideoId { get; set; }
+
+        /// <summary>The US postal address to look up. Mutually exclusive with <see cref="VideoId"/>.</summary>
+        public string? Address { get; set; }
+
+        /// <inheritdoc/>
+        public override Uri GetUri()
+        {
+            if (string.IsNullOrWhiteSpace(ApiKey))
+                throw new InvalidOperationException("ApiKey is required for the Aerial View API.");
+            if (!IsSSL)
+                throw new ArgumentException("Aerial View API requires SSL [IsSSL = true].");
+
+            var hasVideoId = !string.IsNullOrWhiteSpace(VideoId);
+            var hasAddress = !string.IsNullOrWhiteSpace(Address);
+            if (hasVideoId == hasAddress)
+                throw new InvalidOperationException("Specify exactly one of VideoId or Address for the Aerial View lookupVideo endpoint.");
+
+            var selector = hasVideoId
+                ? $"videoId={Uri.EscapeDataString(VideoId!)}"
+                : $"address={Uri.EscapeDataString(Address!)}";
+
+            return new Uri(
+                "https://aerialview.googleapis.com/v1/videos:lookupVideo" +
+                $"?key={Uri.EscapeDataString(ApiKey!)}" +
+                $"&{selector}");
+        }
+    }
+}

--- a/GoogleMapsApi/Entities/AerialView/Request/RenderVideoRequest.cs
+++ b/GoogleMapsApi/Entities/AerialView/Request/RenderVideoRequest.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using GoogleMapsApi.Entities.Common;
+
+namespace GoogleMapsApi.Entities.AerialView.Request
+{
+    /// <summary>
+    /// Request for the Aerial View API <c>renderVideo</c> endpoint
+    /// (<c>POST https://aerialview.googleapis.com/v1/videos:renderVideo</c>).
+    /// Enqueues rendering of a cinematic flyover video for a US postal address.
+    /// </summary>
+    /// <remarks>
+    /// Rendering is asynchronous and can take a long time (up to a few hours). The response carries a
+    /// <see cref="Response.VideoState.Processing"/> state plus a video id; poll
+    /// <see cref="LookupVideoRequest"/> by that id until the state becomes
+    /// <see cref="Response.VideoState.Active"/> (use exponential backoff). If a video already exists for
+    /// the address, this returns immediately. The render endpoint itself is not billed.
+    /// </remarks>
+    public sealed class RenderVideoRequest : MapsBaseRequest
+    {
+        /// <summary>The US postal address to render a flyover for. Required.</summary>
+        public string Address { get; set; } = null!;
+
+        /// <inheritdoc/>
+        public override Uri GetUri()
+        {
+            if (string.IsNullOrWhiteSpace(ApiKey))
+                throw new InvalidOperationException("ApiKey is required for the Aerial View API.");
+            if (!IsSSL)
+                throw new ArgumentException("Aerial View API requires SSL [IsSSL = true].");
+
+            return new Uri($"https://aerialview.googleapis.com/v1/videos:renderVideo?key={Uri.EscapeDataString(ApiKey!)}");
+        }
+
+        /// <inheritdoc/>
+        protected internal override HttpContent? GetRequestBody()
+        {
+            if (string.IsNullOrWhiteSpace(Address))
+                throw new ArgumentException("Address is required for the Aerial View renderVideo endpoint.", nameof(Address));
+
+            var payload = new Payload { Address = Address };
+            var json = JsonSerializer.Serialize(payload, BodyOptions);
+            return new StringContent(json, Encoding.UTF8, "application/json");
+        }
+
+        private static readonly JsonSerializerOptions BodyOptions = new JsonSerializerOptions
+        {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        };
+
+        private sealed class Payload
+        {
+            [JsonPropertyName("address")] public string? Address { get; set; }
+        }
+    }
+}

--- a/GoogleMapsApi/Entities/AerialView/Response/AerialViewUris.cs
+++ b/GoogleMapsApi/Entities/AerialView/Response/AerialViewUris.cs
@@ -1,0 +1,18 @@
+using System.Text.Json.Serialization;
+
+namespace GoogleMapsApi.Entities.AerialView.Response
+{
+    /// <summary>
+    /// A pair of signed, short-lived URIs for a single <see cref="MediaFormat"/> of an Aerial View
+    /// video — one for each aspect ratio. The URIs expire, so fetch them fresh via <c>LookupVideo</c>
+    /// rather than caching them.
+    /// </summary>
+    public sealed class AerialViewUris
+    {
+        /// <summary>Signed URI for the landscape (16:9) rendition.</summary>
+        [JsonPropertyName("landscapeUri")] public string? LandscapeUri { get; set; }
+
+        /// <summary>Signed URI for the portrait (9:16) rendition.</summary>
+        [JsonPropertyName("portraitUri")] public string? PortraitUri { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/AerialView/Response/AerialViewVideoResponse.cs
+++ b/GoogleMapsApi/Entities/AerialView/Response/AerialViewVideoResponse.cs
@@ -1,0 +1,63 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using GoogleMapsApi.Entities.AerialView.Request;
+using GoogleMapsApi.Entities.Common;
+
+namespace GoogleMapsApi.Entities.AerialView.Response
+{
+    /// <summary>
+    /// An Aerial View video (<c>Video</c>). Returned by both <c>RenderVideo</c> and <c>LookupVideo</c>.
+    /// </summary>
+    /// <remarks>
+    /// While <see cref="State"/> is <see cref="VideoState.Processing"/>, <see cref="Uris"/> is absent and
+    /// <see cref="Metadata"/> typically carries only the video id. Once <see cref="VideoState.Active"/>,
+    /// <see cref="Uris"/> is populated with signed, short-lived links for each available
+    /// <see cref="MediaFormat"/>.
+    /// </remarks>
+    public sealed class AerialViewVideoResponse
+        : IResponseFor<RenderVideoRequest>, IResponseFor<LookupVideoRequest>
+    {
+        /// <summary>Current rendering state of the video.</summary>
+        [JsonPropertyName("state")] public VideoState State { get; set; }
+
+        /// <summary>Metadata about the video (id, capture date, duration).</summary>
+        [JsonPropertyName("metadata")] public VideoMetadata? Metadata { get; set; }
+
+        /// <summary>
+        /// Signed, short-lived URIs keyed by media format (e.g. <c>"MP4_HIGH"</c>, <c>"HLS"</c>). Only
+        /// present when <see cref="State"/> is <see cref="VideoState.Active"/>. The keys are
+        /// <see cref="MediaFormat"/> wire values; this is left string-keyed so unknown future formats
+        /// deserialize without throwing. Prefer <see cref="TryGetUris"/> for typed access.
+        /// </summary>
+        [JsonPropertyName("uris")] public Dictionary<string, AerialViewUris>? Uris { get; set; }
+
+        /// <summary>
+        /// Looks up the <see cref="AerialViewUris"/> for a known <see cref="MediaFormat"/>.
+        /// </summary>
+        /// <param name="format">The media format to retrieve.</param>
+        /// <param name="uris">The matching URIs, or <c>null</c> if the format is not present.</param>
+        /// <returns><c>true</c> if the format was present; otherwise <c>false</c>.</returns>
+        public bool TryGetUris(MediaFormat format, out AerialViewUris? uris)
+        {
+            if (Uris != null && Uris.TryGetValue(ToWireValue(format), out var found))
+            {
+                uris = found;
+                return true;
+            }
+
+            uris = null;
+            return false;
+        }
+
+        private static string ToWireValue(MediaFormat format) => format switch
+        {
+            MediaFormat.Image => "IMAGE",
+            MediaFormat.Mp4High => "MP4_HIGH",
+            MediaFormat.Mp4Medium => "MP4_MEDIUM",
+            MediaFormat.Mp4Low => "MP4_LOW",
+            MediaFormat.Dash => "DASH",
+            MediaFormat.Hls => "HLS",
+            _ => "MEDIA_FORMAT_UNSPECIFIED",
+        };
+    }
+}

--- a/GoogleMapsApi/Entities/AerialView/Response/CaptureDate.cs
+++ b/GoogleMapsApi/Entities/AerialView/Response/CaptureDate.cs
@@ -1,0 +1,20 @@
+using System.Text.Json.Serialization;
+
+namespace GoogleMapsApi.Entities.AerialView.Response
+{
+    /// <summary>
+    /// The date the underlying imagery was captured (a <c>google.type.Date</c>). Any field may be
+    /// <c>0</c> when that component is not significant.
+    /// </summary>
+    public sealed class CaptureDate
+    {
+        /// <summary>Year of the date (e.g. 2022), or 0 if not significant.</summary>
+        [JsonPropertyName("year")] public int Year { get; set; }
+
+        /// <summary>Month of the date (1-12), or 0 if not significant.</summary>
+        [JsonPropertyName("month")] public int Month { get; set; }
+
+        /// <summary>Day of the month (1-31), or 0 if not significant.</summary>
+        [JsonPropertyName("day")] public int Day { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/AerialView/Response/MediaFormat.cs
+++ b/GoogleMapsApi/Entities/AerialView/Response/MediaFormat.cs
@@ -1,0 +1,32 @@
+using System.Runtime.Serialization;
+
+namespace GoogleMapsApi.Entities.AerialView.Response
+{
+    /// <summary>
+    /// Media format of an Aerial View video rendition. Used as the keys of
+    /// <see cref="AerialViewVideoResponse.Uris"/>.
+    /// </summary>
+    public enum MediaFormat
+    {
+        /// <summary>The media format is unknown. Default value.</summary>
+        [EnumMember(Value = "MEDIA_FORMAT_UNSPECIFIED")] Unspecified,
+
+        /// <summary>A thumbnail image of the video.</summary>
+        [EnumMember(Value = "IMAGE")] Image,
+
+        /// <summary>High-quality MP4 rendition.</summary>
+        [EnumMember(Value = "MP4_HIGH")] Mp4High,
+
+        /// <summary>Medium-quality MP4 rendition.</summary>
+        [EnumMember(Value = "MP4_MEDIUM")] Mp4Medium,
+
+        /// <summary>Low-quality MP4 rendition.</summary>
+        [EnumMember(Value = "MP4_LOW")] Mp4Low,
+
+        /// <summary>MPEG-DASH adaptive-bitrate manifest.</summary>
+        [EnumMember(Value = "DASH")] Dash,
+
+        /// <summary>HLS adaptive-bitrate manifest (Apple).</summary>
+        [EnumMember(Value = "HLS")] Hls,
+    }
+}

--- a/GoogleMapsApi/Entities/AerialView/Response/VideoMetadata.cs
+++ b/GoogleMapsApi/Entities/AerialView/Response/VideoMetadata.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Globalization;
+using System.Text.Json.Serialization;
+
+namespace GoogleMapsApi.Entities.AerialView.Response
+{
+    /// <summary>
+    /// Metadata describing a rendered Aerial View video. While processing, only <see cref="VideoId"/>
+    /// is typically populated; the remaining fields become available once the video is
+    /// <see cref="VideoState.Active"/>.
+    /// </summary>
+    public sealed class VideoMetadata
+    {
+        /// <summary>Identifier of the video. Use it for subsequent <c>LookupVideo</c> calls.</summary>
+        [JsonPropertyName("videoId")] public string? VideoId { get; set; }
+
+        /// <summary>Date the underlying imagery was captured.</summary>
+        [JsonPropertyName("captureDate")] public CaptureDate? CaptureDate { get; set; }
+
+        /// <summary>
+        /// Video duration as a <c>google.protobuf.Duration</c> string (seconds with an <c>s</c> suffix,
+        /// e.g. <c>"40s"</c>). Use <see cref="DurationValue"/> for a parsed <see cref="TimeSpan"/>.
+        /// </summary>
+        [JsonPropertyName("duration")] public string? Duration { get; set; }
+
+        /// <summary>
+        /// <see cref="Duration"/> parsed into a <see cref="TimeSpan"/>, or <c>null</c> when it is
+        /// absent or not in the expected <c>"&lt;seconds&gt;s"</c> form.
+        /// </summary>
+        [JsonIgnore]
+        public TimeSpan? DurationValue
+        {
+            get
+            {
+                var raw = Duration;
+                if (string.IsNullOrWhiteSpace(raw) || !raw!.EndsWith("s", StringComparison.Ordinal))
+                    return null;
+
+                var seconds = raw.Substring(0, raw.Length - 1);
+                return double.TryParse(seconds, NumberStyles.Float, CultureInfo.InvariantCulture, out var value)
+                    ? TimeSpan.FromSeconds(value)
+                    : (TimeSpan?)null;
+            }
+        }
+    }
+}

--- a/GoogleMapsApi/Entities/AerialView/Response/VideoState.cs
+++ b/GoogleMapsApi/Entities/AerialView/Response/VideoState.cs
@@ -1,0 +1,22 @@
+using System.Runtime.Serialization;
+
+namespace GoogleMapsApi.Entities.AerialView.Response
+{
+    /// <summary>
+    /// Rendering state of an Aerial View video.
+    /// </summary>
+    public enum VideoState
+    {
+        /// <summary>The state is unknown. Default value.</summary>
+        [EnumMember(Value = "STATE_UNSPECIFIED")] Unspecified,
+
+        /// <summary>The video is currently being rendered. Poll <c>LookupVideo</c> until the state changes.</summary>
+        [EnumMember(Value = "PROCESSING")] Processing,
+
+        /// <summary>Rendering finished; the video is viewable and <c>Uris</c> are populated.</summary>
+        [EnumMember(Value = "ACTIVE")] Active,
+
+        /// <summary>Rendering failed for this video.</summary>
+        [EnumMember(Value = "FAILED")] Failed,
+    }
+}

--- a/GoogleMapsApi/GoogleMapsClient.cs
+++ b/GoogleMapsApi/GoogleMapsClient.cs
@@ -1,6 +1,8 @@
 using GoogleMapsApi.Engine;
 using GoogleMapsApi.Entities.AddressValidation.Request;
 using GoogleMapsApi.Entities.AddressValidation.Response;
+using GoogleMapsApi.Entities.AerialView.Request;
+using GoogleMapsApi.Entities.AerialView.Response;
 using GoogleMapsApi.Entities.Directions.Request;
 using GoogleMapsApi.Entities.Directions.Response;
 using GoogleMapsApi.Entities.DistanceMatrix.Request;
@@ -58,6 +60,7 @@ namespace GoogleMapsApi
             PlaceDetailsNew = new HttpClientEngineFacade<PlaceDetailsRequest, Place>(httpClient, options);
             PlacesAutocompleteNew = new HttpClientEngineFacade<AutocompleteRequest, AutocompleteResponse>(httpClient, options);
             PlacePhoto = new HttpClientEngineFacade<PlacePhotoRequest, PlacePhotoResponse>(httpClient, options);
+            AerialView = new AerialViewApi(httpClient, options);
         }
 
         /// <inheritdoc/>
@@ -95,5 +98,8 @@ namespace GoogleMapsApi
 
         /// <inheritdoc/>
         public IEngineFacade<PlacePhotoRequest, PlacePhotoResponse> PlacePhoto { get; }
+
+        /// <inheritdoc/>
+        public IAerialViewApi AerialView { get; }
     }
 }

--- a/GoogleMapsApi/IAerialViewApi.cs
+++ b/GoogleMapsApi/IAerialViewApi.cs
@@ -1,0 +1,25 @@
+using GoogleMapsApi.Entities.AerialView.Request;
+using GoogleMapsApi.Entities.AerialView.Response;
+
+namespace GoogleMapsApi
+{
+    /// <summary>
+    /// Aerial View API operations: render a cinematic flyover video for an address and look up a video's
+    /// state and media URIs. Both operations return the same <see cref="AerialViewVideoResponse"/>.
+    /// </summary>
+    public interface IAerialViewApi
+    {
+        /// <summary>
+        /// Enqueue rendering of a flyover video for a US postal address (free). Returns a
+        /// <see cref="VideoState.Processing"/> video to poll via <see cref="LookupVideo"/>, or an
+        /// existing video if one is already available.
+        /// </summary>
+        IEngineFacade<RenderVideoRequest, AerialViewVideoResponse> RenderVideo { get; }
+
+        /// <summary>
+        /// Look up a video by id or address (billable). Returns the current state and, once active, the
+        /// signed media URIs.
+        /// </summary>
+        IEngineFacade<LookupVideoRequest, AerialViewVideoResponse> LookupVideo { get; }
+    }
+}

--- a/GoogleMapsApi/IGoogleMapsClient.cs
+++ b/GoogleMapsApi/IGoogleMapsClient.cs
@@ -62,5 +62,8 @@ namespace GoogleMapsApi
 
         /// <summary>Resolve a place photo reference to an image URI via the Places API (New).</summary>
         IEngineFacade<PlacePhotoRequest, PlacePhotoResponse> PlacePhoto { get; }
+
+        /// <summary>Render and look up cinematic flyover videos via the Aerial View API.</summary>
+        IAerialViewApi AerialView { get; }
     }
 }

--- a/GoogleMapsApi/PublicAPI.Unshipped.txt
+++ b/GoogleMapsApi/PublicAPI.Unshipped.txt
@@ -1,1 +1,63 @@
 #nullable enable
+GoogleMapsApi.Entities.AerialView.Request.LookupVideoRequest
+GoogleMapsApi.Entities.AerialView.Request.LookupVideoRequest.Address.get -> string?
+GoogleMapsApi.Entities.AerialView.Request.LookupVideoRequest.Address.set -> void
+GoogleMapsApi.Entities.AerialView.Request.LookupVideoRequest.LookupVideoRequest() -> void
+GoogleMapsApi.Entities.AerialView.Request.LookupVideoRequest.VideoId.get -> string?
+GoogleMapsApi.Entities.AerialView.Request.LookupVideoRequest.VideoId.set -> void
+GoogleMapsApi.Entities.AerialView.Request.RenderVideoRequest
+GoogleMapsApi.Entities.AerialView.Request.RenderVideoRequest.Address.get -> string!
+GoogleMapsApi.Entities.AerialView.Request.RenderVideoRequest.Address.set -> void
+GoogleMapsApi.Entities.AerialView.Request.RenderVideoRequest.RenderVideoRequest() -> void
+GoogleMapsApi.Entities.AerialView.Response.AerialViewUris
+GoogleMapsApi.Entities.AerialView.Response.AerialViewUris.AerialViewUris() -> void
+GoogleMapsApi.Entities.AerialView.Response.AerialViewUris.LandscapeUri.get -> string?
+GoogleMapsApi.Entities.AerialView.Response.AerialViewUris.LandscapeUri.set -> void
+GoogleMapsApi.Entities.AerialView.Response.AerialViewUris.PortraitUri.get -> string?
+GoogleMapsApi.Entities.AerialView.Response.AerialViewUris.PortraitUri.set -> void
+GoogleMapsApi.Entities.AerialView.Response.AerialViewVideoResponse
+GoogleMapsApi.Entities.AerialView.Response.AerialViewVideoResponse.AerialViewVideoResponse() -> void
+GoogleMapsApi.Entities.AerialView.Response.AerialViewVideoResponse.Metadata.get -> GoogleMapsApi.Entities.AerialView.Response.VideoMetadata?
+GoogleMapsApi.Entities.AerialView.Response.AerialViewVideoResponse.Metadata.set -> void
+GoogleMapsApi.Entities.AerialView.Response.AerialViewVideoResponse.State.get -> GoogleMapsApi.Entities.AerialView.Response.VideoState
+GoogleMapsApi.Entities.AerialView.Response.AerialViewVideoResponse.State.set -> void
+GoogleMapsApi.Entities.AerialView.Response.AerialViewVideoResponse.TryGetUris(GoogleMapsApi.Entities.AerialView.Response.MediaFormat format, out GoogleMapsApi.Entities.AerialView.Response.AerialViewUris? uris) -> bool
+GoogleMapsApi.Entities.AerialView.Response.AerialViewVideoResponse.Uris.get -> System.Collections.Generic.Dictionary<string!, GoogleMapsApi.Entities.AerialView.Response.AerialViewUris!>?
+GoogleMapsApi.Entities.AerialView.Response.AerialViewVideoResponse.Uris.set -> void
+GoogleMapsApi.Entities.AerialView.Response.CaptureDate
+GoogleMapsApi.Entities.AerialView.Response.CaptureDate.CaptureDate() -> void
+GoogleMapsApi.Entities.AerialView.Response.CaptureDate.Day.get -> int
+GoogleMapsApi.Entities.AerialView.Response.CaptureDate.Day.set -> void
+GoogleMapsApi.Entities.AerialView.Response.CaptureDate.Month.get -> int
+GoogleMapsApi.Entities.AerialView.Response.CaptureDate.Month.set -> void
+GoogleMapsApi.Entities.AerialView.Response.CaptureDate.Year.get -> int
+GoogleMapsApi.Entities.AerialView.Response.CaptureDate.Year.set -> void
+GoogleMapsApi.Entities.AerialView.Response.MediaFormat
+GoogleMapsApi.Entities.AerialView.Response.MediaFormat.Dash = 5 -> GoogleMapsApi.Entities.AerialView.Response.MediaFormat
+GoogleMapsApi.Entities.AerialView.Response.MediaFormat.Hls = 6 -> GoogleMapsApi.Entities.AerialView.Response.MediaFormat
+GoogleMapsApi.Entities.AerialView.Response.MediaFormat.Image = 1 -> GoogleMapsApi.Entities.AerialView.Response.MediaFormat
+GoogleMapsApi.Entities.AerialView.Response.MediaFormat.Mp4High = 2 -> GoogleMapsApi.Entities.AerialView.Response.MediaFormat
+GoogleMapsApi.Entities.AerialView.Response.MediaFormat.Mp4Low = 4 -> GoogleMapsApi.Entities.AerialView.Response.MediaFormat
+GoogleMapsApi.Entities.AerialView.Response.MediaFormat.Mp4Medium = 3 -> GoogleMapsApi.Entities.AerialView.Response.MediaFormat
+GoogleMapsApi.Entities.AerialView.Response.MediaFormat.Unspecified = 0 -> GoogleMapsApi.Entities.AerialView.Response.MediaFormat
+GoogleMapsApi.Entities.AerialView.Response.VideoMetadata
+GoogleMapsApi.Entities.AerialView.Response.VideoMetadata.CaptureDate.get -> GoogleMapsApi.Entities.AerialView.Response.CaptureDate?
+GoogleMapsApi.Entities.AerialView.Response.VideoMetadata.CaptureDate.set -> void
+GoogleMapsApi.Entities.AerialView.Response.VideoMetadata.Duration.get -> string?
+GoogleMapsApi.Entities.AerialView.Response.VideoMetadata.Duration.set -> void
+GoogleMapsApi.Entities.AerialView.Response.VideoMetadata.DurationValue.get -> System.TimeSpan?
+GoogleMapsApi.Entities.AerialView.Response.VideoMetadata.VideoId.get -> string?
+GoogleMapsApi.Entities.AerialView.Response.VideoMetadata.VideoId.set -> void
+GoogleMapsApi.Entities.AerialView.Response.VideoMetadata.VideoMetadata() -> void
+GoogleMapsApi.Entities.AerialView.Response.VideoState
+GoogleMapsApi.Entities.AerialView.Response.VideoState.Active = 2 -> GoogleMapsApi.Entities.AerialView.Response.VideoState
+GoogleMapsApi.Entities.AerialView.Response.VideoState.Failed = 3 -> GoogleMapsApi.Entities.AerialView.Response.VideoState
+GoogleMapsApi.Entities.AerialView.Response.VideoState.Processing = 1 -> GoogleMapsApi.Entities.AerialView.Response.VideoState
+GoogleMapsApi.Entities.AerialView.Response.VideoState.Unspecified = 0 -> GoogleMapsApi.Entities.AerialView.Response.VideoState
+GoogleMapsApi.GoogleMapsClient.AerialView.get -> GoogleMapsApi.IAerialViewApi!
+GoogleMapsApi.IAerialViewApi
+GoogleMapsApi.IAerialViewApi.LookupVideo.get -> GoogleMapsApi.IEngineFacade<GoogleMapsApi.Entities.AerialView.Request.LookupVideoRequest!, GoogleMapsApi.Entities.AerialView.Response.AerialViewVideoResponse!>!
+GoogleMapsApi.IAerialViewApi.RenderVideo.get -> GoogleMapsApi.IEngineFacade<GoogleMapsApi.Entities.AerialView.Request.RenderVideoRequest!, GoogleMapsApi.Entities.AerialView.Response.AerialViewVideoResponse!>!
+GoogleMapsApi.IGoogleMapsClient.AerialView.get -> GoogleMapsApi.IAerialViewApi!
+override GoogleMapsApi.Entities.AerialView.Request.LookupVideoRequest.GetUri() -> System.Uri!
+override GoogleMapsApi.Entities.AerialView.Request.RenderVideoRequest.GetUri() -> System.Uri!

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Release history: see [CHANGELOG.md](CHANGELOG.md).
 
 # GoogleMapsApi
 
-A friendly, strongly-typed .NET wrapper for the Google Maps Web Services APIs — Geocoding, Routes, Directions, Distance Matrix, Elevation, Time Zone, Places, Address Validation, and Static Maps. Multi-framework (net10.0, net8.0, netstandard2.0 — the latter still covers .NET Framework 4.6.1+), async-first, and battle-tested with **2M+ downloads** on NuGet.
+A friendly, strongly-typed .NET wrapper for the Google Maps Web Services APIs — Geocoding, Routes, Directions, Distance Matrix, Elevation, Time Zone, Places, Address Validation, Aerial View, and Static Maps. Multi-framework (net10.0, net8.0, netstandard2.0 — the latter still covers .NET Framework 4.6.1+), async-first, and battle-tested with **2M+ downloads** on NuGet.
 
 ## Supported APIs
 
@@ -24,6 +24,7 @@ A friendly, strongly-typed .NET wrapper for the Google Maps Web Services APIs �
 | [Time Zone](https://developers.google.com/maps/documentation/timezone) | Time zone information for any coordinate |
 | [Places (New)](https://developers.google.com/maps/documentation/places/web-service/op-overview) | Modern Places API — Text Search, Nearby Search, Place Details, Autocomplete, Place Photos |
 | [Address Validation](https://developers.google.com/maps/documentation/address-validation) | Validate a postal address with component-level confirmation; USPS CASS for US/PR |
+| [Aerial View](https://developers.google.com/maps/documentation/aerial-view) | Render and look up cinematic flyover videos for US addresses |
 | [Static Maps](https://developers.google.com/maps/documentation/maps-static) | Generate URLs for static map images with markers, paths, and styles |
 
 ## Why this vs Google's official SDKs
@@ -152,6 +153,32 @@ var response = await maps.Routes.QueryAsync(request);
 var route = response.Routes![0];
 Console.WriteLine($"{route.DistanceMeters} m, {route.DurationSeconds} s");
 ```
+
+### Aerial View API (cinematic flyover videos)
+
+The [Aerial View API](https://developers.google.com/maps/documentation/aerial-view) renders cinematic 3D flyover videos of US addresses. It has two operations, grouped under `maps.AerialView`: `RenderVideo` enqueues rendering (free), and `LookupVideo` fetches a video's state and signed media URIs (billable). Rendering is asynchronous and can take up to a few hours, so the typical flow is *render once, then poll lookup by `videoId` with exponential backoff until the state is `Active`*.
+
+``` C#
+using GoogleMapsApi;
+using GoogleMapsApi.Entities.AerialView.Request;
+using GoogleMapsApi.Entities.AerialView.Response;
+
+using var http = new HttpClient();
+var maps = new GoogleMapsClient(http, new GoogleMapsClientOptions { ApiKey = "your-google-maps-api-key" });
+
+// 1. Request a render (returns immediately; usually Processing on first call).
+var render = await maps.AerialView.RenderVideo.QueryAsync(
+    new RenderVideoRequest { Address = "500 W 2nd St, Austin, TX 78701" });
+var videoId = render.Metadata!.VideoId!;
+
+// 2. Poll until the video is ready (use a real backoff; rendering can take hours).
+var video = await maps.AerialView.LookupVideo.QueryAsync(new LookupVideoRequest { VideoId = videoId });
+
+if (video.State == VideoState.Active && video.TryGetUris(MediaFormat.Mp4High, out var uris))
+    Console.WriteLine(uris!.LandscapeUri);
+```
+
+> A looked-up video that does not exist (or has no 3D imagery available) returns HTTP 404, surfaced as an `HttpRequestException`. A still-rendering video is **not** an error — it returns `State == VideoState.Processing`.
 
 ### Instance-based client (`IHttpClientFactory`-friendly)
 


### PR DESCRIPTION
## Summary
Adds support for the Google Maps **Aerial View API** — render and look up cinematic 3D flyover videos for US addresses. This extends the library's modern-v1 API coverage alongside Routes, Places (New), and Address Validation.

## Changes
- New `Entities/AerialView/` request + response types: `RenderVideoRequest` (POST `videos:renderVideo`), `LookupVideoRequest` (GET `videos:lookupVideo`, `videoId`/`address` oneof), and the shared `AerialViewVideoResponse` (`State`, `Metadata`, signed `Uris`) with `VideoState` / `MediaFormat` enums.
- Convenience helpers: `AerialViewVideoResponse.TryGetUris(MediaFormat, ...)` over a string-keyed `Uris` map (defensive against unknown formats) and `VideoMetadata.DurationValue` (parses the `"40s"` protobuf duration to `TimeSpan`).
- Nested facade group: `client.AerialView.RenderVideo` / `client.AerialView.LookupVideo` via the new public `IAerialViewApi` (internal `AerialViewApi` impl); wired into `GoogleMapsClient` + `IGoogleMapsClient`.
- `PublicAPI.Unshipped.txt` updated for the new public surface; README gets a Supported-APIs row and a render→poll→`Active` usage section.
- Tests: 11 unit tests (URI host/path/key, POST body, GET no-body, oneof validation, ACTIVE/PROCESSING deserialization) plus 2 `[BillableTest]` live integration tests (skipped by default — `lookupVideo` is billable).

## Test plan
- [x] `dotnet build GoogleMapsApi.sln` — 0 errors (PublicAPI analyzer satisfied)
- [x] `dotnet test --filter "FullyQualifiedName~AerialView"` — 11 passed, 2 billable skipped
- [x] DI extension tests — 7 passed (group resolves with no extra wiring)
- [ ] Optional live check: `RUN_BILLABLE_TESTS=true GOOGLE_API_KEY=<key with Aerial View enabled> dotnet test --filter "FullyQualifiedName~AerialView"`
