### PR TITLE
feat(solar): add Solar API support (buildingInsights, dataLayers, geoTiff)

### DIFF
--- a/GoogleMapsApi.Test/IntegrationTests/SolarTests.cs
+++ b/GoogleMapsApi.Test/IntegrationTests/SolarTests.cs
@@ -1,0 +1,75 @@
+using System.Threading.Tasks;
+using GoogleMapsApi.Entities.Solar.Request;
+using GoogleMapsApi.Test.Utils;
+using NUnit.Framework;
+
+namespace GoogleMapsApi.Test.IntegrationTests
+{
+    /// <summary>
+    /// Live Solar API tests. The Solar API is billable, so these are skipped by default; set
+    /// <c>RUN_BILLABLE_TESTS=true</c> (and use a key with the Solar API enabled) to run them.
+    /// </summary>
+    [TestFixture]
+    [BillableTest]
+    public class SolarTests : BaseTestIntegration
+    {
+        // Mountain View, CA — well covered by Solar API imagery.
+        private const double Latitude = 37.4450;
+        private const double Longitude = -122.1390;
+
+        [Test]
+        public async Task BuildingInsights_ValidLocation_ReturnsSolarData()
+        {
+            var request = new BuildingInsightsRequest
+            {
+                ApiKey = ApiKey,
+                Latitude = Latitude,
+                Longitude = Longitude,
+            };
+
+            var response = await Maps.SolarBuildingInsights.QueryAsync(request);
+
+            Assert.That(response.Name, Is.Not.Null.And.Not.Empty);
+            Assert.That(response.Center, Is.Not.Null);
+            Assert.That(response.SolarPotential, Is.Not.Null);
+            Assert.That(response.SolarPotential!.MaxArrayPanelsCount, Is.GreaterThan(0));
+        }
+
+        [Test]
+        public async Task DataLayers_ValidLocation_ReturnsLayerUrls()
+        {
+            var request = new DataLayersRequest
+            {
+                ApiKey = ApiKey,
+                Latitude = Latitude,
+                Longitude = Longitude,
+                RadiusMeters = 50,
+            };
+
+            var response = await Maps.SolarDataLayers.QueryAsync(request);
+
+            Assert.That(response.DsmUrl, Is.Not.Null.And.Not.Empty);
+            Assert.That(response.AnnualFluxUrl, Is.Not.Null.And.Not.Empty);
+        }
+
+        [Test]
+        public async Task GeoTiff_FromDataLayerUrl_DownloadsBytes()
+        {
+            var layers = await Maps.SolarDataLayers.QueryAsync(new DataLayersRequest
+            {
+                ApiKey = ApiKey,
+                Latitude = Latitude,
+                Longitude = Longitude,
+                RadiusMeters = 50,
+            });
+
+            var response = await Maps.SolarGeoTiff.QueryAsync(new GeoTiffRequest
+            {
+                ApiKey = ApiKey,
+                Url = layers.DsmUrl!,
+            });
+
+            Assert.That(response.Content, Is.Not.Null.And.Not.Empty);
+        }
+    }
+}

--- a/GoogleMapsApi.Test/SolarUnitTests.cs
+++ b/GoogleMapsApi.Test/SolarUnitTests.cs
@@ -1,0 +1,214 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using GoogleMapsApi.Entities.Solar.Request;
+using GoogleMapsApi.Entities.Solar.Response;
+using NUnit.Framework;
+
+namespace GoogleMapsApi.Test
+{
+    /// <summary>
+    /// Hermetic tests for the Solar API request/response plumbing. No live network calls — URLs are
+    /// asserted directly off <c>GetUri()</c> and HTTP exchanges are intercepted by a stub handler.
+    /// </summary>
+    [TestFixture]
+    public class SolarUnitTests
+    {
+        // --- URL generation ---------------------------------------------------------------
+
+        [Test]
+        public void BuildingInsights_GetUri_BuildsExpectedUrl()
+        {
+            var uri = new BuildingInsightsRequest
+            {
+                ApiKey = "k",
+                Latitude = 37.4,
+                Longitude = -122.1,
+                RequiredQuality = ImageryQuality.High,
+            }.GetUri();
+
+            Assert.That(uri.Scheme, Is.EqualTo("https"));
+            Assert.That(uri.Host, Is.EqualTo("solar.googleapis.com"));
+            Assert.That(uri.AbsolutePath, Is.EqualTo("/v1/buildingInsights:findClosest"));
+            Assert.That(uri.Query, Does.Contain("location.latitude=37.4"));
+            Assert.That(uri.Query, Does.Contain("location.longitude=-122.1"));
+            Assert.That(uri.Query, Does.Contain("requiredQuality=HIGH"));
+            Assert.That(uri.Query, Does.Contain("key=k"));
+        }
+
+        [Test]
+        public void BuildingInsights_GetUri_OmitsRequiredQuality_WhenUnset()
+        {
+            var uri = new BuildingInsightsRequest { ApiKey = "k", Latitude = 1, Longitude = 2 }.GetUri();
+            Assert.That(uri.Query, Does.Not.Contain("requiredQuality"));
+        }
+
+        [Test]
+        public void DataLayers_GetUri_BuildsExpectedUrl()
+        {
+            var uri = new DataLayersRequest
+            {
+                ApiKey = "k",
+                Latitude = 37.4,
+                Longitude = -122.1,
+                RadiusMeters = 50,
+                View = DataLayerView.FullLayers,
+                RequiredQuality = ImageryQuality.Medium,
+                PixelSizeMeters = 0.5,
+                ExactQualityRequired = true,
+            }.GetUri();
+
+            Assert.That(uri.Host, Is.EqualTo("solar.googleapis.com"));
+            Assert.That(uri.AbsolutePath, Is.EqualTo("/v1/dataLayers:get"));
+            Assert.That(uri.Query, Does.Contain("radiusMeters=50"));
+            Assert.That(uri.Query, Does.Contain("view=FULL_LAYERS"));
+            Assert.That(uri.Query, Does.Contain("requiredQuality=MEDIUM"));
+            Assert.That(uri.Query, Does.Contain("pixelSizeMeters=0.5"));
+            Assert.That(uri.Query, Does.Contain("exactQualityRequired=true"));
+            Assert.That(uri.Query, Does.Contain("key=k"));
+        }
+
+        [Test]
+        public void GeoTiff_GetUri_AppendsKeyToLayerUrl()
+        {
+            var uri = new GeoTiffRequest
+            {
+                ApiKey = "k",
+                Url = "https://solar.googleapis.com/v1/geoTiff:get?id=abc123",
+            }.GetUri();
+
+            Assert.That(uri.Host, Is.EqualTo("solar.googleapis.com"));
+            Assert.That(uri.AbsolutePath, Is.EqualTo("/v1/geoTiff:get"));
+            Assert.That(uri.Query, Does.Contain("id=abc123"));
+            Assert.That(uri.Query, Does.Contain("key=k"));
+        }
+
+        // --- Guard clauses ----------------------------------------------------------------
+
+        [Test]
+        public void BuildingInsights_GetUri_MissingApiKey_Throws()
+        {
+            Assert.Throws<InvalidOperationException>(
+                () => new BuildingInsightsRequest { Latitude = 1, Longitude = 2 }.GetUri());
+        }
+
+        [Test]
+        public void BuildingInsights_GetUri_NonSsl_Throws()
+        {
+            Assert.Throws<ArgumentException>(
+                () => new BuildingInsightsRequest { ApiKey = "k", IsSSL = false, Latitude = 1, Longitude = 2 }.GetUri());
+        }
+
+        [Test]
+        public void DataLayers_GetUri_NonPositiveRadius_Throws()
+        {
+            Assert.Throws<ArgumentException>(
+                () => new DataLayersRequest { ApiKey = "k", Latitude = 1, Longitude = 2, RadiusMeters = 0 }.GetUri());
+        }
+
+        [Test]
+        public void GeoTiff_GetUri_EmptyUrl_Throws()
+        {
+            Assert.Throws<ArgumentException>(
+                () => new GeoTiffRequest { ApiKey = "k", Url = "" }.GetUri());
+        }
+
+        [Test]
+        public void GeoTiff_GetUri_ForeignHost_Throws()
+        {
+            Assert.Throws<ArgumentException>(
+                () => new GeoTiffRequest { ApiKey = "k", Url = "https://evil.example.com/geoTiff:get?id=x" }.GetUri());
+        }
+
+        // --- Binary engine path -----------------------------------------------------------
+
+        [Test]
+        public async Task GeoTiff_QueryAsync_ReturnsRawBytesAndContentType()
+        {
+            var payload = new byte[] { 0x49, 0x49, 0x2A, 0x00, 0x10, 0x20, 0x30 };
+            using var handler = new StubHandler(payload, "image/tiff");
+            using var http = new HttpClient(handler);
+            var client = new GoogleMapsClient(http, new GoogleMapsClientOptions { ApiKey = "k" });
+
+            var response = await client.SolarGeoTiff.QueryAsync(new GeoTiffRequest
+            {
+                Url = "https://solar.googleapis.com/v1/geoTiff:get?id=abc",
+            });
+
+            Assert.That(response.Content, Is.EqualTo(payload));
+            Assert.That(response.ContentType, Is.EqualTo("image/tiff"));
+        }
+
+        // --- JSON deserialization ---------------------------------------------------------
+
+        [Test]
+        public async Task BuildingInsights_QueryAsync_DeserializesNestedFields()
+        {
+            const string json = """
+            {
+              "name": "buildings/abc",
+              "center": { "latitude": 37.4, "longitude": -122.1 },
+              "imageryQuality": "HIGH",
+              "solarPotential": {
+                "maxArrayPanelsCount": 42,
+                "panelCapacityWatts": 250,
+                "solarPanels": [
+                  { "center": { "latitude": 37.4, "longitude": -122.1 }, "orientation": "LANDSCAPE", "yearlyEnergyDcKwh": 410.5, "segmentIndex": 0 }
+                ],
+                "financialAnalyses": [
+                  {
+                    "monthlyBill": { "currencyCode": "USD", "units": "35" },
+                    "panelConfigIndex": 3,
+                    "cashPurchaseSavings": {
+                      "paybackYears": 8.5,
+                      "savings": { "savingsLifetime": { "currencyCode": "USD", "units": "42000", "nanos": 500000000 } }
+                    }
+                  }
+                ]
+              }
+            }
+            """;
+            using var handler = new StubHandler(Encoding.UTF8.GetBytes(json), "application/json");
+            using var http = new HttpClient(handler);
+            var client = new GoogleMapsClient(http, new GoogleMapsClientOptions { ApiKey = "k" });
+
+            var response = await client.SolarBuildingInsights.QueryAsync(new BuildingInsightsRequest { Latitude = 37.4, Longitude = -122.1 });
+
+            Assert.That(response.Name, Is.EqualTo("buildings/abc"));
+            Assert.That(response.ImageryQuality, Is.EqualTo(ImageryQuality.High));
+            Assert.That(response.SolarPotential, Is.Not.Null);
+            Assert.That(response.SolarPotential!.MaxArrayPanelsCount, Is.EqualTo(42));
+            Assert.That(response.SolarPotential.SolarPanels![0].Orientation, Is.EqualTo(SolarPanelOrientation.Landscape));
+
+            var analysis = response.SolarPotential.FinancialAnalyses![0];
+            Assert.That(analysis.MonthlyBill!.Units, Is.EqualTo(35L), "int64 encoded as JSON string should parse");
+            var lifetime = analysis.CashPurchaseSavings!.Savings!.SavingsLifetime!;
+            Assert.That(lifetime.Units, Is.EqualTo(42000L));
+            Assert.That(lifetime.Nanos, Is.EqualTo(500000000));
+        }
+
+        private sealed class StubHandler : HttpMessageHandler
+        {
+            private readonly byte[] _body;
+            private readonly string _mediaType;
+
+            public StubHandler(byte[] body, string mediaType)
+            {
+                _body = body;
+                _mediaType = mediaType;
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var content = new ByteArrayContent(_body);
+                content.Headers.ContentType = new MediaTypeHeaderValue(_mediaType);
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = content });
+            }
+        }
+    }
+}

--- a/GoogleMapsApi/Engine/CoordinateFormatter.cs
+++ b/GoogleMapsApi/Engine/CoordinateFormatter.cs
@@ -1,0 +1,21 @@
+using System.Globalization;
+
+namespace GoogleMapsApi.Engine
+{
+    /// <summary>
+    /// Formats <see cref="double"/> values for Google Maps URLs: full precision, no scientific
+    /// notation, trailing zeros trimmed (e.g. <c>37.4</c> rather than <c>37.39999999999999</c>).
+    /// </summary>
+    internal static class CoordinateFormatter
+    {
+        private static readonly string DoubleFormat = "0." + new string('#', 339);
+
+        public static string Format(double value)
+        {
+            var formatted = value.ToString(DoubleFormat, CultureInfo.InvariantCulture);
+            if (formatted.Contains("."))
+                formatted = formatted.TrimEnd('0').TrimEnd('.');
+            return formatted.Length == 0 ? "0" : formatted;
+        }
+    }
+}

--- a/GoogleMapsApi/Engine/EnumMemberHelper.cs
+++ b/GoogleMapsApi/Engine/EnumMemberHelper.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Serialization;
+
+namespace GoogleMapsApi.Engine
+{
+    /// <summary>
+    /// Resolves the <see cref="EnumMemberAttribute"/> wire value of an enum member, for requests
+    /// that build query strings by hand (where the JSON converters don't apply).
+    /// </summary>
+    internal static class EnumMemberHelper
+    {
+        public static string GetValue<TEnum>(TEnum value) where TEnum : struct, Enum
+        {
+            var member = typeof(TEnum).GetMember(value.ToString()).FirstOrDefault();
+            var attribute = member?.GetCustomAttribute<EnumMemberAttribute>();
+            return attribute?.Value ?? value.ToString();
+        }
+    }
+}

--- a/GoogleMapsApi/Engine/MapsAPIGenericEngine.cs
+++ b/GoogleMapsApi/Engine/MapsAPIGenericEngine.cs
@@ -37,22 +37,38 @@ namespace GoogleMapsApi.Engine
 			var uri = onUriCreated?.Invoke(requestUri) ?? requestUri;
 
 			var body = request.GetRequestBody();
-			string responseContent;
 			try
 			{
-				responseContent = await GetHttpResponseAsync(httpClient, uri, body, timeout, token).ConfigureAwait(false);
+				// Binary endpoints (e.g. Solar GeoTIFF) carry raw bytes, not JSON.
+				if (typeof(IBinaryResponse).IsAssignableFrom(typeof(TResponse)))
+				{
+					var (bytes, contentType) = await SendAsync(httpClient, uri, body, timeout, token, async response =>
+						(await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false),
+						 response.Content.Headers.ContentType?.MediaType)).ConfigureAwait(false);
+
+					onRawResponseReceived?.Invoke(bytes);
+
+					var binaryResult = Activator.CreateInstance<TResponse>();
+					var binary = (IBinaryResponse)binaryResult!;
+					binary.Content = bytes;
+					binary.ContentType = contentType;
+					return binaryResult;
+				}
+
+				var responseContent = await SendAsync(httpClient, uri, body, timeout, token,
+					response => response.Content.ReadAsStringAsync()).ConfigureAwait(false);
+
+				onRawResponseReceived?.Invoke(Encoding.UTF8.GetBytes(responseContent));
+
+				return JsonSerializer.Deserialize<TResponse>(responseContent, jsonOptions)!;
 			}
 			finally
 			{
 				body?.Dispose();
 			}
-
-			onRawResponseReceived?.Invoke(Encoding.UTF8.GetBytes(responseContent));
-
-			return JsonSerializer.Deserialize<TResponse>(responseContent, jsonOptions)!;
 		}
 
-		private static async Task<string> GetHttpResponseAsync(HttpClient httpClient, Uri uri, HttpContent? body, TimeSpan timeout, CancellationToken cancellationToken)
+		private static async Task<T> SendAsync<T>(HttpClient httpClient, Uri uri, HttpContent? body, TimeSpan timeout, CancellationToken cancellationToken, Func<HttpResponseMessage, Task<T>> readContent)
 		{
 			using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 			if (timeout != TimeSpan.FromMilliseconds(-1))
@@ -64,7 +80,7 @@ namespace GoogleMapsApi.Engine
 					? await httpClient.GetAsync(uri, cts.Token).ConfigureAwait(false)
 					: await httpClient.PostAsync(uri, body, cts.Token).ConfigureAwait(false);
 				await HandleHttpResponse(response, timeout).ConfigureAwait(false);
-				return await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+				return await readContent(response).ConfigureAwait(false);
 			}
 			catch (OperationCanceledException) when (cts.Token.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
 			{

--- a/GoogleMapsApi/Entities/Common/IBinaryResponse.cs
+++ b/GoogleMapsApi/Entities/Common/IBinaryResponse.cs
@@ -1,0 +1,17 @@
+namespace GoogleMapsApi.Entities.Common
+{
+    /// <summary>
+    /// Marks a response whose payload is raw bytes rather than JSON. When a response type
+    /// implements this interface the engine reads the HTTP body as binary and populates
+    /// <see cref="Content"/>/<see cref="ContentType"/> instead of deserializing JSON.
+    /// Used by endpoints such as the Solar API GeoTIFF download.
+    /// </summary>
+    public interface IBinaryResponse
+    {
+        /// <summary>The raw response body bytes.</summary>
+        byte[] Content { get; set; }
+
+        /// <summary>The response's <c>Content-Type</c> media type, if the server supplied one.</summary>
+        string? ContentType { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/Solar/Request/BuildingInsightsRequest.cs
+++ b/GoogleMapsApi/Entities/Solar/Request/BuildingInsightsRequest.cs
@@ -1,0 +1,48 @@
+using System;
+using GoogleMapsApi.Engine;
+using GoogleMapsApi.Entities.Common;
+
+namespace GoogleMapsApi.Entities.Solar.Request
+{
+    /// <summary>
+    /// Request for the Google Solar API <c>buildingInsights:findClosest</c> endpoint
+    /// (<c>GET https://solar.googleapis.com/v1/buildingInsights:findClosest</c>). Returns solar
+    /// potential, roof geometry, panel layouts and financial analyses for the building closest to
+    /// the supplied coordinate.
+    /// </summary>
+    /// <remarks>The Solar API is billable; calls beyond the free tier incur charges.</remarks>
+    public sealed class BuildingInsightsRequest : MapsBaseRequest
+    {
+        /// <summary>Latitude of the query point, in degrees. Required.</summary>
+        public double Latitude { get; set; }
+
+        /// <summary>Longitude of the query point, in degrees. Required.</summary>
+        public double Longitude { get; set; }
+
+        /// <summary>
+        /// Minimum imagery quality the result must meet. When null the API returns the best
+        /// available data regardless of quality.
+        /// </summary>
+        public ImageryQuality? RequiredQuality { get; set; }
+
+        /// <inheritdoc/>
+        public override Uri GetUri()
+        {
+            if (string.IsNullOrWhiteSpace(ApiKey))
+                throw new InvalidOperationException("ApiKey is required for the Solar API.");
+            if (!IsSSL)
+                throw new ArgumentException("Solar API requires SSL [IsSSL = true].");
+
+            var url =
+                "https://solar.googleapis.com/v1/buildingInsights:findClosest" +
+                $"?location.latitude={CoordinateFormatter.Format(Latitude)}" +
+                $"&location.longitude={CoordinateFormatter.Format(Longitude)}" +
+                $"&key={Uri.EscapeDataString(ApiKey!)}";
+
+            if (RequiredQuality.HasValue)
+                url += $"&requiredQuality={EnumMemberHelper.GetValue(RequiredQuality.Value)}";
+
+            return new Uri(url);
+        }
+    }
+}

--- a/GoogleMapsApi/Entities/Solar/Request/DataLayerView.cs
+++ b/GoogleMapsApi/Entities/Solar/Request/DataLayerView.cs
@@ -1,0 +1,26 @@
+using System.Runtime.Serialization;
+
+namespace GoogleMapsApi.Entities.Solar.Request
+{
+    /// <summary>Which subset of data layers the <c>dataLayers:get</c> endpoint should return.</summary>
+    public enum DataLayerView
+    {
+        /// <summary>Equivalent to <see cref="FullLayers"/>.</summary>
+        [EnumMember(Value = "DATA_LAYER_VIEW_UNSPECIFIED")] Unspecified,
+
+        /// <summary>Digital surface model (DSM) only.</summary>
+        [EnumMember(Value = "DSM_LAYER")] DsmLayer,
+
+        /// <summary>DSM, RGB and mask.</summary>
+        [EnumMember(Value = "IMAGERY_LAYERS")] ImageryLayers,
+
+        /// <summary>Imagery layers plus the annual flux map.</summary>
+        [EnumMember(Value = "IMAGERY_AND_ANNUAL_FLUX_LAYERS")] ImageryAndAnnualFluxLayers,
+
+        /// <summary>Imagery layers plus annual and monthly flux maps.</summary>
+        [EnumMember(Value = "IMAGERY_AND_ALL_FLUX_LAYERS")] ImageryAndAllFluxLayers,
+
+        /// <summary>Every available layer, including hourly shade.</summary>
+        [EnumMember(Value = "FULL_LAYERS")] FullLayers,
+    }
+}

--- a/GoogleMapsApi/Entities/Solar/Request/DataLayersRequest.cs
+++ b/GoogleMapsApi/Entities/Solar/Request/DataLayersRequest.cs
@@ -1,0 +1,75 @@
+using System;
+using GoogleMapsApi.Engine;
+using GoogleMapsApi.Entities.Common;
+
+namespace GoogleMapsApi.Entities.Solar.Request
+{
+    /// <summary>
+    /// Request for the Google Solar API <c>dataLayers:get</c> endpoint
+    /// (<c>GET https://solar.googleapis.com/v1/dataLayers:get</c>). Returns URLs to raster data
+    /// layers (DSM, RGB, mask, annual/monthly flux, hourly shade) covering a region around a point.
+    /// Download each layer with a <see cref="GeoTiffRequest"/>.
+    /// </summary>
+    /// <remarks>The Solar API is billable; calls beyond the free tier incur charges.</remarks>
+    public sealed class DataLayersRequest : MapsBaseRequest
+    {
+        /// <summary>Latitude of the region centre, in degrees. Required.</summary>
+        public double Latitude { get; set; }
+
+        /// <summary>Longitude of the region centre, in degrees. Required.</summary>
+        public double Longitude { get; set; }
+
+        /// <summary>
+        /// Radius, in meters, defining the region the data should cover. Required; the API clamps
+        /// values to the supported range (up to 100 m).
+        /// </summary>
+        public double RadiusMeters { get; set; }
+
+        /// <summary>Which subset of layers to return. When null the API returns all layers.</summary>
+        public DataLayerView? View { get; set; }
+
+        /// <summary>Minimum imagery quality the result must meet.</summary>
+        public ImageryQuality? RequiredQuality { get; set; }
+
+        /// <summary>
+        /// Minimum scale, in meters per pixel, of the returned data. Smaller values yield
+        /// finer rasters. When null the API picks a default based on imagery quality.
+        /// </summary>
+        public double? PixelSizeMeters { get; set; }
+
+        /// <summary>
+        /// When true the API returns an error rather than falling back to lower-quality imagery
+        /// if <see cref="RequiredQuality"/> cannot be met.
+        /// </summary>
+        public bool ExactQualityRequired { get; set; }
+
+        /// <inheritdoc/>
+        public override Uri GetUri()
+        {
+            if (string.IsNullOrWhiteSpace(ApiKey))
+                throw new InvalidOperationException("ApiKey is required for the Solar API.");
+            if (!IsSSL)
+                throw new ArgumentException("Solar API requires SSL [IsSSL = true].");
+            if (RadiusMeters <= 0)
+                throw new ArgumentException("RadiusMeters must be greater than zero.");
+
+            var url =
+                "https://solar.googleapis.com/v1/dataLayers:get" +
+                $"?location.latitude={CoordinateFormatter.Format(Latitude)}" +
+                $"&location.longitude={CoordinateFormatter.Format(Longitude)}" +
+                $"&radiusMeters={CoordinateFormatter.Format(RadiusMeters)}" +
+                $"&key={Uri.EscapeDataString(ApiKey!)}";
+
+            if (View.HasValue)
+                url += $"&view={EnumMemberHelper.GetValue(View.Value)}";
+            if (RequiredQuality.HasValue)
+                url += $"&requiredQuality={EnumMemberHelper.GetValue(RequiredQuality.Value)}";
+            if (PixelSizeMeters.HasValue)
+                url += $"&pixelSizeMeters={CoordinateFormatter.Format(PixelSizeMeters.Value)}";
+            if (ExactQualityRequired)
+                url += "&exactQualityRequired=true";
+
+            return new Uri(url);
+        }
+    }
+}

--- a/GoogleMapsApi/Entities/Solar/Request/GeoTiffRequest.cs
+++ b/GoogleMapsApi/Entities/Solar/Request/GeoTiffRequest.cs
@@ -1,0 +1,41 @@
+using System;
+using GoogleMapsApi.Entities.Common;
+
+namespace GoogleMapsApi.Entities.Solar.Request
+{
+    /// <summary>
+    /// Request for the Google Solar API <c>geoTiff:get</c> endpoint
+    /// (<c>GET https://solar.googleapis.com/v1/geoTiff:get</c>). Downloads the raw GeoTIFF bytes
+    /// for a data layer URL returned by a <see cref="DataLayersRequest"/>.
+    /// </summary>
+    /// <remarks>
+    /// Pass the layer URL from a <c>DataLayersResponse</c> (e.g. <c>DsmUrl</c>, <c>AnnualFluxUrl</c>)
+    /// as <see cref="Url"/>; the API key is appended automatically. The response is binary, not JSON.
+    /// </remarks>
+    public sealed class GeoTiffRequest : MapsBaseRequest
+    {
+        /// <summary>
+        /// A data-layer URL returned by the <c>dataLayers:get</c> endpoint
+        /// (e.g. <c>https://solar.googleapis.com/v1/geoTiff:get?id=...</c>). Required.
+        /// </summary>
+        public string Url { get; set; } = string.Empty;
+
+        /// <inheritdoc/>
+        public override Uri GetUri()
+        {
+            if (string.IsNullOrWhiteSpace(ApiKey))
+                throw new InvalidOperationException("ApiKey is required for the Solar API.");
+            if (!IsSSL)
+                throw new ArgumentException("Solar API requires SSL [IsSSL = true].");
+            if (string.IsNullOrWhiteSpace(Url))
+                throw new ArgumentException("Url is required; supply a data-layer URL from a DataLayersResponse.", nameof(Url));
+            if (!Uri.TryCreate(Url, UriKind.Absolute, out var layerUri) ||
+                layerUri.Scheme != Uri.UriSchemeHttps ||
+                !layerUri.Host.Equals("solar.googleapis.com", StringComparison.OrdinalIgnoreCase))
+                throw new ArgumentException("Url must be an absolute https solar.googleapis.com data-layer URL.", nameof(Url));
+
+            var separator = Url.Contains("?") ? "&" : "?";
+            return new Uri($"{Url}{separator}key={Uri.EscapeDataString(ApiKey!)}");
+        }
+    }
+}

--- a/GoogleMapsApi/Entities/Solar/Request/ImageryQuality.cs
+++ b/GoogleMapsApi/Entities/Solar/Request/ImageryQuality.cs
@@ -1,0 +1,27 @@
+using System.Runtime.Serialization;
+
+namespace GoogleMapsApi.Entities.Solar.Request
+{
+    /// <summary>
+    /// Quality of the imagery the Solar API used (or is required to use). Higher quality means
+    /// finer-resolution data. Used both as a request constraint (<c>requiredQuality</c>) and a
+    /// response field (<c>imageryQuality</c>).
+    /// </summary>
+    public enum ImageryQuality
+    {
+        /// <summary>No quality specified.</summary>
+        [EnumMember(Value = "IMAGERY_QUALITY_UNSPECIFIED")] Unspecified,
+
+        /// <summary>Imagery at 0.1 m/pixel.</summary>
+        [EnumMember(Value = "HIGH")] High,
+
+        /// <summary>Imagery at 0.25 m/pixel.</summary>
+        [EnumMember(Value = "MEDIUM")] Medium,
+
+        /// <summary>Imagery at 0.5 m/pixel.</summary>
+        [EnumMember(Value = "LOW")] Low,
+
+        /// <summary>Aerial or enhanced-aerial imagery, lower resolution than <see cref="Low"/>.</summary>
+        [EnumMember(Value = "BASE")] Base,
+    }
+}

--- a/GoogleMapsApi/Entities/Solar/Response/BuildingInsightsResponse.cs
+++ b/GoogleMapsApi/Entities/Solar/Response/BuildingInsightsResponse.cs
@@ -1,0 +1,57 @@
+using System.Text.Json.Serialization;
+using GoogleMapsApi.Entities.Common;
+using GoogleMapsApi.Entities.Solar.Request;
+
+namespace GoogleMapsApi.Entities.Solar.Response
+{
+    /// <summary>
+    /// Response from the Solar API <c>buildingInsights:findClosest</c> endpoint — solar potential
+    /// and geometry for the building closest to the requested coordinate.
+    /// </summary>
+    public sealed class BuildingInsightsResponse : IResponseFor<BuildingInsightsRequest>
+    {
+        /// <summary>Resource name of the building, of the form <c>buildings/{place_id}</c>.</summary>
+        [JsonPropertyName("name")]
+        public string? Name { get; set; }
+
+        /// <summary>A point near the centre of the building.</summary>
+        [JsonPropertyName("center")]
+        public LatLng? Center { get; set; }
+
+        /// <summary>The bounding box of the building.</summary>
+        [JsonPropertyName("boundingBox")]
+        public LatLngBox? BoundingBox { get; set; }
+
+        /// <summary>Date the underlying imagery was captured.</summary>
+        [JsonPropertyName("imageryDate")]
+        public Date? ImageryDate { get; set; }
+
+        /// <summary>Date the underlying imagery was processed.</summary>
+        [JsonPropertyName("imageryProcessedDate")]
+        public Date? ImageryProcessedDate { get; set; }
+
+        /// <summary>Postal code (e.g. US ZIP code) the building is in.</summary>
+        [JsonPropertyName("postalCode")]
+        public string? PostalCode { get; set; }
+
+        /// <summary>Administrative area 1 (e.g. US state) the building is in.</summary>
+        [JsonPropertyName("administrativeArea")]
+        public string? AdministrativeArea { get; set; }
+
+        /// <summary>Statistical area (e.g. US census tract) the building is in.</summary>
+        [JsonPropertyName("statisticalArea")]
+        public string? StatisticalArea { get; set; }
+
+        /// <summary>Region code (ISO 3166-1 alpha-2) of the country/region the building is in.</summary>
+        [JsonPropertyName("regionCode")]
+        public string? RegionCode { get; set; }
+
+        /// <summary>The building's solar potential: panels, production and financials.</summary>
+        [JsonPropertyName("solarPotential")]
+        public SolarPotential? SolarPotential { get; set; }
+
+        /// <summary>Quality of the imagery used to compute these results.</summary>
+        [JsonPropertyName("imageryQuality")]
+        public ImageryQuality ImageryQuality { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/Solar/Response/CashPurchaseSavings.cs
+++ b/GoogleMapsApi/Entities/Solar/Response/CashPurchaseSavings.cs
@@ -1,0 +1,28 @@
+using System.Text.Json.Serialization;
+
+namespace GoogleMapsApi.Entities.Solar.Response
+{
+    /// <summary>Cost and savings of buying the solar installation outright with cash.</summary>
+    public sealed class CashPurchaseSavings
+    {
+        /// <summary>Out-of-pocket cost before incentives.</summary>
+        [JsonPropertyName("outOfPocketCost")]
+        public Money? OutOfPocketCost { get; set; }
+
+        /// <summary>Total upfront cost (out-of-pocket plus deferred incentives).</summary>
+        [JsonPropertyName("upfrontCost")]
+        public Money? UpfrontCost { get; set; }
+
+        /// <summary>Total value of rebates.</summary>
+        [JsonPropertyName("rebateValue")]
+        public Money? RebateValue { get; set; }
+
+        /// <summary>Number of years until the installation pays for itself.</summary>
+        [JsonPropertyName("paybackYears")]
+        public float PaybackYears { get; set; }
+
+        /// <summary>Savings over time achieved by a cash purchase.</summary>
+        [JsonPropertyName("savings")]
+        public SavingsOverTime? Savings { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/Solar/Response/DataLayersResponse.cs
+++ b/GoogleMapsApi/Entities/Solar/Response/DataLayersResponse.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using GoogleMapsApi.Entities.Common;
+using GoogleMapsApi.Entities.Solar.Request;
+
+namespace GoogleMapsApi.Entities.Solar.Response
+{
+    /// <summary>
+    /// Response from the Solar API <c>dataLayers:get</c> endpoint — URLs to the raster data layers
+    /// for a region. Each URL is fetched (with the API key appended) via a <see cref="GeoTiffRequest"/>.
+    /// </summary>
+    public sealed class DataLayersResponse : IResponseFor<DataLayersRequest>
+    {
+        /// <summary>Date the underlying imagery was captured.</summary>
+        [JsonPropertyName("imageryDate")]
+        public Date? ImageryDate { get; set; }
+
+        /// <summary>Date the underlying imagery was processed.</summary>
+        [JsonPropertyName("imageryProcessedDate")]
+        public Date? ImageryProcessedDate { get; set; }
+
+        /// <summary>URL to the digital surface model (DSM) GeoTIFF.</summary>
+        [JsonPropertyName("dsmUrl")]
+        public string? DsmUrl { get; set; }
+
+        /// <summary>URL to the aerial RGB image GeoTIFF.</summary>
+        [JsonPropertyName("rgbUrl")]
+        public string? RgbUrl { get; set; }
+
+        /// <summary>URL to the building mask GeoTIFF (which pixels are part of a roof).</summary>
+        [JsonPropertyName("maskUrl")]
+        public string? MaskUrl { get; set; }
+
+        /// <summary>URL to the annual solar flux GeoTIFF (yearly sunlight per roof pixel).</summary>
+        [JsonPropertyName("annualFluxUrl")]
+        public string? AnnualFluxUrl { get; set; }
+
+        /// <summary>URL to the monthly solar flux GeoTIFF (a band per month).</summary>
+        [JsonPropertyName("monthlyFluxUrl")]
+        public string? MonthlyFluxUrl { get; set; }
+
+        /// <summary>URLs to the hourly shade GeoTIFFs, one entry per month of the year.</summary>
+        [JsonPropertyName("hourlyShadeUrls")]
+        public List<string>? HourlyShadeUrls { get; set; }
+
+        /// <summary>Quality of the imagery used to produce these layers.</summary>
+        [JsonPropertyName("imageryQuality")]
+        public ImageryQuality ImageryQuality { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/Solar/Response/Date.cs
+++ b/GoogleMapsApi/Entities/Solar/Response/Date.cs
@@ -1,0 +1,23 @@
+using System.Text.Json.Serialization;
+
+namespace GoogleMapsApi.Entities.Solar.Response
+{
+    /// <summary>
+    /// A whole or partial calendar date (mirrors <c>google.type.Date</c>); zero components mean
+    /// "not specified".
+    /// </summary>
+    public sealed class Date
+    {
+        /// <summary>Year of the date, or 0 for a date without a year.</summary>
+        [JsonPropertyName("year")]
+        public int Year { get; set; }
+
+        /// <summary>Month of the date (1–12), or 0 for a date without a month.</summary>
+        [JsonPropertyName("month")]
+        public int Month { get; set; }
+
+        /// <summary>Day of the month (1–31), or 0 for a date without a day.</summary>
+        [JsonPropertyName("day")]
+        public int Day { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/Solar/Response/FinancedPurchaseSavings.cs
+++ b/GoogleMapsApi/Entities/Solar/Response/FinancedPurchaseSavings.cs
@@ -1,0 +1,24 @@
+using System.Text.Json.Serialization;
+
+namespace GoogleMapsApi.Entities.Solar.Response
+{
+    /// <summary>Cost and savings of buying the solar installation with a loan.</summary>
+    public sealed class FinancedPurchaseSavings
+    {
+        /// <summary>Annual loan repayment amount.</summary>
+        [JsonPropertyName("annualLoanPayment")]
+        public Money? AnnualLoanPayment { get; set; }
+
+        /// <summary>Total value of rebates.</summary>
+        [JsonPropertyName("rebateValue")]
+        public Money? RebateValue { get; set; }
+
+        /// <summary>Loan annual percentage rate (APR) assumed, as a percentage.</summary>
+        [JsonPropertyName("loanInterestRate")]
+        public float LoanInterestRate { get; set; }
+
+        /// <summary>Savings over time achieved by a financed purchase.</summary>
+        [JsonPropertyName("savings")]
+        public SavingsOverTime? Savings { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/Solar/Response/FinancialAnalysis.cs
+++ b/GoogleMapsApi/Entities/Solar/Response/FinancialAnalysis.cs
@@ -1,0 +1,45 @@
+using System.Text.Json.Serialization;
+
+namespace GoogleMapsApi.Entities.Solar.Response
+{
+    /// <summary>
+    /// Cost/benefit analysis of a particular panel configuration against a particular monthly bill.
+    /// </summary>
+    public sealed class FinancialAnalysis
+    {
+        /// <summary>The monthly utility bill this analysis assumes.</summary>
+        [JsonPropertyName("monthlyBill")]
+        public Money? MonthlyBill { get; set; }
+
+        /// <summary>True if this is the analysis for the API's default monthly bill.</summary>
+        [JsonPropertyName("defaultBill")]
+        public bool DefaultBill { get; set; }
+
+        /// <summary>Average energy consumption per month, in kWh, implied by the monthly bill.</summary>
+        [JsonPropertyName("averageKwhPerMonth")]
+        public float AverageKwhPerMonth { get; set; }
+
+        /// <summary>
+        /// Index into <c>SolarPotential.SolarPanelConfigs</c> of the configuration analysed, or
+        /// -1 when no configuration is viable for the assumed bill.
+        /// </summary>
+        [JsonPropertyName("panelConfigIndex")]
+        public int PanelConfigIndex { get; set; }
+
+        /// <summary>Financial details common to every financing option below.</summary>
+        [JsonPropertyName("financialDetails")]
+        public FinancialDetails? FinancialDetails { get; set; }
+
+        /// <summary>Savings from leasing the installation.</summary>
+        [JsonPropertyName("leasingSavings")]
+        public LeasingSavings? LeasingSavings { get; set; }
+
+        /// <summary>Savings from purchasing the installation with cash.</summary>
+        [JsonPropertyName("cashPurchaseSavings")]
+        public CashPurchaseSavings? CashPurchaseSavings { get; set; }
+
+        /// <summary>Savings from purchasing the installation with a loan.</summary>
+        [JsonPropertyName("financedPurchaseSavings")]
+        public FinancedPurchaseSavings? FinancedPurchaseSavings { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/Solar/Response/FinancialDetails.cs
+++ b/GoogleMapsApi/Entities/Solar/Response/FinancialDetails.cs
@@ -1,0 +1,50 @@
+using System.Text.Json.Serialization;
+
+namespace GoogleMapsApi.Entities.Solar.Response
+{
+    /// <summary>
+    /// Financial details shared across all financing options for a given panel configuration.
+    /// </summary>
+    public sealed class FinancialDetails
+    {
+        /// <summary>Annual AC energy produced in the first year of operation, in kWh.</summary>
+        [JsonPropertyName("initialAcKwhPerYear")]
+        public float InitialAcKwhPerYear { get; set; }
+
+        /// <summary>Utility bill still owed over the installation's lifetime, after solar.</summary>
+        [JsonPropertyName("remainingLifetimeUtilityBill")]
+        public Money? RemainingLifetimeUtilityBill { get; set; }
+
+        /// <summary>Amount of federal tax incentive available.</summary>
+        [JsonPropertyName("federalIncentive")]
+        public Money? FederalIncentive { get; set; }
+
+        /// <summary>Amount of state tax incentive available.</summary>
+        [JsonPropertyName("stateIncentive")]
+        public Money? StateIncentive { get; set; }
+
+        /// <summary>Amount of utility incentive available.</summary>
+        [JsonPropertyName("utilityIncentive")]
+        public Money? UtilityIncentive { get; set; }
+
+        /// <summary>Total value of all Solar Renewable Energy Credits over the lifetime.</summary>
+        [JsonPropertyName("lifetimeSrecTotal")]
+        public Money? LifetimeSrecTotal { get; set; }
+
+        /// <summary>Total cost of electricity over the lifetime if no solar were installed.</summary>
+        [JsonPropertyName("costOfElectricityWithoutSolar")]
+        public Money? CostOfElectricityWithoutSolar { get; set; }
+
+        /// <summary>Whether net metering is allowed.</summary>
+        [JsonPropertyName("netMeteringAllowed")]
+        public bool NetMeteringAllowed { get; set; }
+
+        /// <summary>Percentage (0–100) of the consumer's energy use that solar supplies.</summary>
+        [JsonPropertyName("solarPercentage")]
+        public float SolarPercentage { get; set; }
+
+        /// <summary>Percentage (0–100) of solar production exported to the grid.</summary>
+        [JsonPropertyName("percentageExportedToGrid")]
+        public float PercentageExportedToGrid { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/Solar/Response/GeoTiffResponse.cs
+++ b/GoogleMapsApi/Entities/Solar/Response/GeoTiffResponse.cs
@@ -1,0 +1,19 @@
+using System;
+using GoogleMapsApi.Entities.Common;
+using GoogleMapsApi.Entities.Solar.Request;
+
+namespace GoogleMapsApi.Entities.Solar.Response
+{
+    /// <summary>
+    /// Response from the Solar API <c>geoTiff:get</c> endpoint — the raw GeoTIFF bytes of a data
+    /// layer. Being binary, this is populated directly by the engine rather than from JSON.
+    /// </summary>
+    public sealed class GeoTiffResponse : IResponseFor<GeoTiffRequest>, IBinaryResponse
+    {
+        /// <summary>The raw GeoTIFF bytes.</summary>
+        public byte[] Content { get; set; } = Array.Empty<byte>();
+
+        /// <summary>The response media type (typically <c>image/tiff</c>).</summary>
+        public string? ContentType { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/Solar/Response/LatLng.cs
+++ b/GoogleMapsApi/Entities/Solar/Response/LatLng.cs
@@ -1,0 +1,16 @@
+using System.Text.Json.Serialization;
+
+namespace GoogleMapsApi.Entities.Solar.Response
+{
+    /// <summary>A WGS84 latitude/longitude coordinate (mirrors <c>google.type.LatLng</c>).</summary>
+    public sealed class LatLng
+    {
+        /// <summary>Latitude in degrees, in the range [-90, 90].</summary>
+        [JsonPropertyName("latitude")]
+        public double Latitude { get; set; }
+
+        /// <summary>Longitude in degrees, in the range [-180, 180].</summary>
+        [JsonPropertyName("longitude")]
+        public double Longitude { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/Solar/Response/LatLngBox.cs
+++ b/GoogleMapsApi/Entities/Solar/Response/LatLngBox.cs
@@ -1,0 +1,16 @@
+using System.Text.Json.Serialization;
+
+namespace GoogleMapsApi.Entities.Solar.Response
+{
+    /// <summary>A latitude/longitude bounding box defined by its southwest and northeast corners.</summary>
+    public sealed class LatLngBox
+    {
+        /// <summary>The southwest corner of the box.</summary>
+        [JsonPropertyName("sw")]
+        public LatLng? Sw { get; set; }
+
+        /// <summary>The northeast corner of the box.</summary>
+        [JsonPropertyName("ne")]
+        public LatLng? Ne { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/Solar/Response/LeasingSavings.cs
+++ b/GoogleMapsApi/Entities/Solar/Response/LeasingSavings.cs
@@ -1,0 +1,24 @@
+using System.Text.Json.Serialization;
+
+namespace GoogleMapsApi.Entities.Solar.Response
+{
+    /// <summary>Cost and savings of leasing the solar installation.</summary>
+    public sealed class LeasingSavings
+    {
+        /// <summary>Whether leasing is allowed in this jurisdiction.</summary>
+        [JsonPropertyName("leasesAllowed")]
+        public bool LeasesAllowed { get; set; }
+
+        /// <summary>Whether leasing is supported by the Solar API for this region.</summary>
+        [JsonPropertyName("leasesSupported")]
+        public bool LeasesSupported { get; set; }
+
+        /// <summary>Estimated annual leasing cost.</summary>
+        [JsonPropertyName("annualLeasingCost")]
+        public Money? AnnualLeasingCost { get; set; }
+
+        /// <summary>Savings over time achieved by leasing.</summary>
+        [JsonPropertyName("savings")]
+        public SavingsOverTime? Savings { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/Solar/Response/Money.cs
+++ b/GoogleMapsApi/Entities/Solar/Response/Money.cs
@@ -1,0 +1,26 @@
+using System.Text.Json.Serialization;
+
+namespace GoogleMapsApi.Entities.Solar.Response
+{
+    /// <summary>An amount of money with its currency type (mirrors <c>google.type.Money</c>).</summary>
+    public sealed class Money
+    {
+        /// <summary>The three-letter ISO 4217 currency code (e.g. <c>"USD"</c>).</summary>
+        [JsonPropertyName("currencyCode")]
+        public string? CurrencyCode { get; set; }
+
+        /// <summary>
+        /// The whole units of the amount. The API encodes this int64 as a JSON string, so reading
+        /// from a string is enabled here.
+        /// </summary>
+        [JsonPropertyName("units")]
+        [JsonNumberHandling(JsonNumberHandling.AllowReadingFromString)]
+        public long? Units { get; set; }
+
+        /// <summary>
+        /// Fractional part of the amount in nano (10^-9) units; sign matches <see cref="Units"/>.
+        /// </summary>
+        [JsonPropertyName("nanos")]
+        public int Nanos { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/Solar/Response/RoofSegmentSizeAndSunshineStats.cs
+++ b/GoogleMapsApi/Entities/Solar/Response/RoofSegmentSizeAndSunshineStats.cs
@@ -1,0 +1,32 @@
+using System.Text.Json.Serialization;
+
+namespace GoogleMapsApi.Entities.Solar.Response
+{
+    /// <summary>Size, orientation and sunshine statistics for a single roof segment.</summary>
+    public sealed class RoofSegmentSizeAndSunshineStats
+    {
+        /// <summary>Angle of the roof segment relative to the horizontal, in degrees.</summary>
+        [JsonPropertyName("pitchDegrees")]
+        public float PitchDegrees { get; set; }
+
+        /// <summary>Compass direction the roof segment faces, in degrees (0 = north, 90 = east).</summary>
+        [JsonPropertyName("azimuthDegrees")]
+        public float AzimuthDegrees { get; set; }
+
+        /// <summary>Size and sunshine statistics for this segment.</summary>
+        [JsonPropertyName("stats")]
+        public SizeAndSunshineStats? Stats { get; set; }
+
+        /// <summary>The centre of the roof segment.</summary>
+        [JsonPropertyName("center")]
+        public LatLng? Center { get; set; }
+
+        /// <summary>The bounding box of the roof segment.</summary>
+        [JsonPropertyName("boundingBox")]
+        public LatLngBox? BoundingBox { get; set; }
+
+        /// <summary>Height of the roof-segment plane above sea level at its centre, in meters.</summary>
+        [JsonPropertyName("planeHeightAtCenterMeters")]
+        public float PlaneHeightAtCenterMeters { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/Solar/Response/RoofSegmentSummary.cs
+++ b/GoogleMapsApi/Entities/Solar/Response/RoofSegmentSummary.cs
@@ -1,0 +1,28 @@
+using System.Text.Json.Serialization;
+
+namespace GoogleMapsApi.Entities.Solar.Response
+{
+    /// <summary>How a panel configuration distributes panels across one roof segment.</summary>
+    public sealed class RoofSegmentSummary
+    {
+        /// <summary>Angle of the roof segment relative to the horizontal, in degrees.</summary>
+        [JsonPropertyName("pitchDegrees")]
+        public float PitchDegrees { get; set; }
+
+        /// <summary>Compass direction the roof segment faces, in degrees (0 = north, 90 = east).</summary>
+        [JsonPropertyName("azimuthDegrees")]
+        public float AzimuthDegrees { get; set; }
+
+        /// <summary>Number of panels placed on this segment in this configuration.</summary>
+        [JsonPropertyName("panelsCount")]
+        public int PanelsCount { get; set; }
+
+        /// <summary>Yearly energy these panels would produce, in DC kWh.</summary>
+        [JsonPropertyName("yearlyEnergyDcKwh")]
+        public float YearlyEnergyDcKwh { get; set; }
+
+        /// <summary>Index in <c>SolarPotential.RoofSegmentStats</c> of the segment this summary describes.</summary>
+        [JsonPropertyName("segmentIndex")]
+        public int SegmentIndex { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/Solar/Response/SavingsOverTime.cs
+++ b/GoogleMapsApi/Entities/Solar/Response/SavingsOverTime.cs
@@ -1,0 +1,32 @@
+using System.Text.Json.Serialization;
+
+namespace GoogleMapsApi.Entities.Solar.Response
+{
+    /// <summary>Financial savings a solar installation yields over various time horizons.</summary>
+    public sealed class SavingsOverTime
+    {
+        /// <summary>Utility-bill savings in the first year.</summary>
+        [JsonPropertyName("savingsYear1")]
+        public Money? SavingsYear1 { get; set; }
+
+        /// <summary>Total utility-bill savings over the first twenty years.</summary>
+        [JsonPropertyName("savingsYear20")]
+        public Money? SavingsYear20 { get; set; }
+
+        /// <summary>Present value of the twenty-year savings.</summary>
+        [JsonPropertyName("presentValueOfSavingsYear20")]
+        public Money? PresentValueOfSavingsYear20 { get; set; }
+
+        /// <summary>Total utility-bill savings over the installation's lifetime.</summary>
+        [JsonPropertyName("savingsLifetime")]
+        public Money? SavingsLifetime { get; set; }
+
+        /// <summary>Present value of the lifetime savings.</summary>
+        [JsonPropertyName("presentValueOfSavingsLifetime")]
+        public Money? PresentValueOfSavingsLifetime { get; set; }
+
+        /// <summary>Whether the financing option is considered financially viable.</summary>
+        [JsonPropertyName("financiallyViable")]
+        public bool FinanciallyViable { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/Solar/Response/SizeAndSunshineStats.cs
+++ b/GoogleMapsApi/Entities/Solar/Response/SizeAndSunshineStats.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace GoogleMapsApi.Entities.Solar.Response
+{
+    /// <summary>Size and sunshine quantiles for a roof area.</summary>
+    public sealed class SizeAndSunshineStats
+    {
+        /// <summary>The area of the roof or roof segment, in square meters.</summary>
+        [JsonPropertyName("areaMeters2")]
+        public float AreaMeters2 { get; set; }
+
+        /// <summary>
+        /// Quantiles of the pointwise sunniness across the area, in hours per year. The first and
+        /// last entries are the min and max; the middle entry is the median.
+        /// </summary>
+        [JsonPropertyName("sunshineQuantiles")]
+        public List<float>? SunshineQuantiles { get; set; }
+
+        /// <summary>The ground footprint area covered, in square meters.</summary>
+        [JsonPropertyName("groundAreaMeters2")]
+        public float GroundAreaMeters2 { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/Solar/Response/SolarPanel.cs
+++ b/GoogleMapsApi/Entities/Solar/Response/SolarPanel.cs
@@ -1,0 +1,24 @@
+using System.Text.Json.Serialization;
+
+namespace GoogleMapsApi.Entities.Solar.Response
+{
+    /// <summary>A single solar panel in a potential layout.</summary>
+    public sealed class SolarPanel
+    {
+        /// <summary>The centre of the panel.</summary>
+        [JsonPropertyName("center")]
+        public LatLng? Center { get; set; }
+
+        /// <summary>The orientation of the panel.</summary>
+        [JsonPropertyName("orientation")]
+        public SolarPanelOrientation Orientation { get; set; }
+
+        /// <summary>How much energy this panel would produce per year, in DC kWh.</summary>
+        [JsonPropertyName("yearlyEnergyDcKwh")]
+        public float YearlyEnergyDcKwh { get; set; }
+
+        /// <summary>Index in <c>SolarPotential.RoofSegmentStats</c> of the segment this panel sits on.</summary>
+        [JsonPropertyName("segmentIndex")]
+        public int SegmentIndex { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/Solar/Response/SolarPanelConfig.cs
+++ b/GoogleMapsApi/Entities/Solar/Response/SolarPanelConfig.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace GoogleMapsApi.Entities.Solar.Response
+{
+    /// <summary>
+    /// A potential layout of a given number of panels, ordered by descending energy production.
+    /// </summary>
+    public sealed class SolarPanelConfig
+    {
+        /// <summary>Total number of panels in this configuration.</summary>
+        [JsonPropertyName("panelsCount")]
+        public int PanelsCount { get; set; }
+
+        /// <summary>Total yearly energy this configuration would produce, in DC kWh.</summary>
+        [JsonPropertyName("yearlyEnergyDcKwh")]
+        public float YearlyEnergyDcKwh { get; set; }
+
+        /// <summary>Per-roof-segment breakdown of where the panels are placed.</summary>
+        [JsonPropertyName("roofSegmentSummaries")]
+        public List<RoofSegmentSummary>? RoofSegmentSummaries { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/Solar/Response/SolarPanelOrientation.cs
+++ b/GoogleMapsApi/Entities/Solar/Response/SolarPanelOrientation.cs
@@ -1,0 +1,17 @@
+using System.Runtime.Serialization;
+
+namespace GoogleMapsApi.Entities.Solar.Response
+{
+    /// <summary>Orientation of a solar panel relative to its roof segment.</summary>
+    public enum SolarPanelOrientation
+    {
+        /// <summary>No orientation specified.</summary>
+        [EnumMember(Value = "SOLAR_PANEL_ORIENTATION_UNSPECIFIED")] Unspecified,
+
+        /// <summary>The panel's long side runs horizontally (east–west).</summary>
+        [EnumMember(Value = "LANDSCAPE")] Landscape,
+
+        /// <summary>The panel's long side runs vertically (north–south).</summary>
+        [EnumMember(Value = "PORTRAIT")] Portrait,
+    }
+}

--- a/GoogleMapsApi/Entities/Solar/Response/SolarPotential.cs
+++ b/GoogleMapsApi/Entities/Solar/Response/SolarPotential.cs
@@ -1,0 +1,65 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace GoogleMapsApi.Entities.Solar.Response
+{
+    /// <summary>Solar potential of a building: how much energy it could generate and at what cost.</summary>
+    public sealed class SolarPotential
+    {
+        /// <summary>Maximum number of panels that can fit on the roof.</summary>
+        [JsonPropertyName("maxArrayPanelsCount")]
+        public int MaxArrayPanelsCount { get; set; }
+
+        /// <summary>Maximum roof area covered by panels, in square meters.</summary>
+        [JsonPropertyName("maxArrayAreaMeters2")]
+        public float MaxArrayAreaMeters2 { get; set; }
+
+        /// <summary>Maximum yearly sunshine on any point of the roof, in hours.</summary>
+        [JsonPropertyName("maxSunshineHoursPerYear")]
+        public float MaxSunshineHoursPerYear { get; set; }
+
+        /// <summary>Equivalent grid carbon intensity used for offset calculations, in kg CO2e per MWh.</summary>
+        [JsonPropertyName("carbonOffsetFactorKgPerMwh")]
+        public float CarbonOffsetFactorKgPerMwh { get; set; }
+
+        /// <summary>Size and sunshine statistics over the entire roof.</summary>
+        [JsonPropertyName("wholeRoofStats")]
+        public SizeAndSunshineStats? WholeRoofStats { get; set; }
+
+        /// <summary>Size and sunshine statistics over the whole building footprint.</summary>
+        [JsonPropertyName("buildingStats")]
+        public SizeAndSunshineStats? BuildingStats { get; set; }
+
+        /// <summary>Per-segment size and sunshine statistics, referenced by panel <c>SegmentIndex</c>.</summary>
+        [JsonPropertyName("roofSegmentStats")]
+        public List<RoofSegmentSizeAndSunshineStats>? RoofSegmentStats { get; set; }
+
+        /// <summary>Every individual panel position considered, ordered by descending production.</summary>
+        [JsonPropertyName("solarPanels")]
+        public List<SolarPanel>? SolarPanels { get; set; }
+
+        /// <summary>Candidate layouts of increasing panel count, ordered by descending production.</summary>
+        [JsonPropertyName("solarPanelConfigs")]
+        public List<SolarPanelConfig>? SolarPanelConfigs { get; set; }
+
+        /// <summary>Financial analyses for a range of assumed monthly bills.</summary>
+        [JsonPropertyName("financialAnalyses")]
+        public List<FinancialAnalysis>? FinancialAnalyses { get; set; }
+
+        /// <summary>Capacity of each panel assumed in the calculations, in watts.</summary>
+        [JsonPropertyName("panelCapacityWatts")]
+        public float PanelCapacityWatts { get; set; }
+
+        /// <summary>Height of each panel assumed in the calculations, in meters.</summary>
+        [JsonPropertyName("panelHeightMeters")]
+        public float PanelHeightMeters { get; set; }
+
+        /// <summary>Width of each panel assumed in the calculations, in meters.</summary>
+        [JsonPropertyName("panelWidthMeters")]
+        public float PanelWidthMeters { get; set; }
+
+        /// <summary>Assumed operational lifetime of the panels, in years.</summary>
+        [JsonPropertyName("panelLifetimeYears")]
+        public int PanelLifetimeYears { get; set; }
+    }
+}

--- a/GoogleMapsApi/GoogleMapsClient.cs
+++ b/GoogleMapsApi/GoogleMapsClient.cs
@@ -13,6 +13,8 @@ using GoogleMapsApi.Entities.Routes.Request;
 using GoogleMapsApi.Entities.Routes.Response;
 using GoogleMapsApi.Entities.PlacesNew.Request;
 using GoogleMapsApi.Entities.PlacesNew.Response;
+using GoogleMapsApi.Entities.Solar.Request;
+using GoogleMapsApi.Entities.Solar.Response;
 using GoogleMapsApi.Entities.TimeZone.Request;
 using GoogleMapsApi.Entities.TimeZone.Response;
 using System;
@@ -58,6 +60,9 @@ namespace GoogleMapsApi
             PlaceDetailsNew = new HttpClientEngineFacade<PlaceDetailsRequest, Place>(httpClient, options);
             PlacesAutocompleteNew = new HttpClientEngineFacade<AutocompleteRequest, AutocompleteResponse>(httpClient, options);
             PlacePhoto = new HttpClientEngineFacade<PlacePhotoRequest, PlacePhotoResponse>(httpClient, options);
+            SolarBuildingInsights = new HttpClientEngineFacade<BuildingInsightsRequest, BuildingInsightsResponse>(httpClient, options);
+            SolarDataLayers = new HttpClientEngineFacade<DataLayersRequest, DataLayersResponse>(httpClient, options);
+            SolarGeoTiff = new HttpClientEngineFacade<GeoTiffRequest, GeoTiffResponse>(httpClient, options);
         }
 
         /// <inheritdoc/>
@@ -95,5 +100,14 @@ namespace GoogleMapsApi
 
         /// <inheritdoc/>
         public IEngineFacade<PlacePhotoRequest, PlacePhotoResponse> PlacePhoto { get; }
+
+        /// <inheritdoc/>
+        public IEngineFacade<BuildingInsightsRequest, BuildingInsightsResponse> SolarBuildingInsights { get; }
+
+        /// <inheritdoc/>
+        public IEngineFacade<DataLayersRequest, DataLayersResponse> SolarDataLayers { get; }
+
+        /// <inheritdoc/>
+        public IEngineFacade<GeoTiffRequest, GeoTiffResponse> SolarGeoTiff { get; }
     }
 }

--- a/GoogleMapsApi/IGoogleMapsClient.cs
+++ b/GoogleMapsApi/IGoogleMapsClient.cs
@@ -12,6 +12,8 @@ using GoogleMapsApi.Entities.Routes.Request;
 using GoogleMapsApi.Entities.Routes.Response;
 using GoogleMapsApi.Entities.PlacesNew.Request;
 using GoogleMapsApi.Entities.PlacesNew.Response;
+using GoogleMapsApi.Entities.Solar.Request;
+using GoogleMapsApi.Entities.Solar.Response;
 using GoogleMapsApi.Entities.TimeZone.Request;
 using GoogleMapsApi.Entities.TimeZone.Response;
 using System;
@@ -62,5 +64,14 @@ namespace GoogleMapsApi
 
         /// <summary>Resolve a place photo reference to an image URI via the Places API (New).</summary>
         IEngineFacade<PlacePhotoRequest, PlacePhotoResponse> PlacePhoto { get; }
+
+        /// <summary>Get solar potential, roof geometry and financial analyses for a building via the Solar API (billable).</summary>
+        IEngineFacade<BuildingInsightsRequest, BuildingInsightsResponse> SolarBuildingInsights { get; }
+
+        /// <summary>Get URLs to solar raster data layers for a region via the Solar API (billable).</summary>
+        IEngineFacade<DataLayersRequest, DataLayersResponse> SolarDataLayers { get; }
+
+        /// <summary>Download a Solar API data layer as raw GeoTIFF bytes (billable).</summary>
+        IEngineFacade<GeoTiffRequest, GeoTiffResponse> SolarGeoTiff { get; }
     }
 }

--- a/GoogleMapsApi/PublicAPI.Unshipped.txt
+++ b/GoogleMapsApi/PublicAPI.Unshipped.txt
@@ -1,1 +1,306 @@
 #nullable enable
+GoogleMapsApi.Entities.Common.IBinaryResponse
+GoogleMapsApi.Entities.Common.IBinaryResponse.Content.get -> byte[]!
+GoogleMapsApi.Entities.Common.IBinaryResponse.Content.set -> void
+GoogleMapsApi.Entities.Common.IBinaryResponse.ContentType.get -> string?
+GoogleMapsApi.Entities.Common.IBinaryResponse.ContentType.set -> void
+GoogleMapsApi.Entities.Solar.Request.BuildingInsightsRequest
+GoogleMapsApi.Entities.Solar.Request.BuildingInsightsRequest.BuildingInsightsRequest() -> void
+GoogleMapsApi.Entities.Solar.Request.BuildingInsightsRequest.Latitude.get -> double
+GoogleMapsApi.Entities.Solar.Request.BuildingInsightsRequest.Latitude.set -> void
+GoogleMapsApi.Entities.Solar.Request.BuildingInsightsRequest.Longitude.get -> double
+GoogleMapsApi.Entities.Solar.Request.BuildingInsightsRequest.Longitude.set -> void
+GoogleMapsApi.Entities.Solar.Request.BuildingInsightsRequest.RequiredQuality.get -> GoogleMapsApi.Entities.Solar.Request.ImageryQuality?
+GoogleMapsApi.Entities.Solar.Request.BuildingInsightsRequest.RequiredQuality.set -> void
+GoogleMapsApi.Entities.Solar.Request.DataLayerView
+GoogleMapsApi.Entities.Solar.Request.DataLayerView.DsmLayer = 1 -> GoogleMapsApi.Entities.Solar.Request.DataLayerView
+GoogleMapsApi.Entities.Solar.Request.DataLayerView.FullLayers = 5 -> GoogleMapsApi.Entities.Solar.Request.DataLayerView
+GoogleMapsApi.Entities.Solar.Request.DataLayerView.ImageryAndAllFluxLayers = 4 -> GoogleMapsApi.Entities.Solar.Request.DataLayerView
+GoogleMapsApi.Entities.Solar.Request.DataLayerView.ImageryAndAnnualFluxLayers = 3 -> GoogleMapsApi.Entities.Solar.Request.DataLayerView
+GoogleMapsApi.Entities.Solar.Request.DataLayerView.ImageryLayers = 2 -> GoogleMapsApi.Entities.Solar.Request.DataLayerView
+GoogleMapsApi.Entities.Solar.Request.DataLayerView.Unspecified = 0 -> GoogleMapsApi.Entities.Solar.Request.DataLayerView
+GoogleMapsApi.Entities.Solar.Request.DataLayersRequest
+GoogleMapsApi.Entities.Solar.Request.DataLayersRequest.DataLayersRequest() -> void
+GoogleMapsApi.Entities.Solar.Request.DataLayersRequest.ExactQualityRequired.get -> bool
+GoogleMapsApi.Entities.Solar.Request.DataLayersRequest.ExactQualityRequired.set -> void
+GoogleMapsApi.Entities.Solar.Request.DataLayersRequest.Latitude.get -> double
+GoogleMapsApi.Entities.Solar.Request.DataLayersRequest.Latitude.set -> void
+GoogleMapsApi.Entities.Solar.Request.DataLayersRequest.Longitude.get -> double
+GoogleMapsApi.Entities.Solar.Request.DataLayersRequest.Longitude.set -> void
+GoogleMapsApi.Entities.Solar.Request.DataLayersRequest.PixelSizeMeters.get -> double?
+GoogleMapsApi.Entities.Solar.Request.DataLayersRequest.PixelSizeMeters.set -> void
+GoogleMapsApi.Entities.Solar.Request.DataLayersRequest.RadiusMeters.get -> double
+GoogleMapsApi.Entities.Solar.Request.DataLayersRequest.RadiusMeters.set -> void
+GoogleMapsApi.Entities.Solar.Request.DataLayersRequest.RequiredQuality.get -> GoogleMapsApi.Entities.Solar.Request.ImageryQuality?
+GoogleMapsApi.Entities.Solar.Request.DataLayersRequest.RequiredQuality.set -> void
+GoogleMapsApi.Entities.Solar.Request.DataLayersRequest.View.get -> GoogleMapsApi.Entities.Solar.Request.DataLayerView?
+GoogleMapsApi.Entities.Solar.Request.DataLayersRequest.View.set -> void
+GoogleMapsApi.Entities.Solar.Request.GeoTiffRequest
+GoogleMapsApi.Entities.Solar.Request.GeoTiffRequest.GeoTiffRequest() -> void
+GoogleMapsApi.Entities.Solar.Request.GeoTiffRequest.Url.get -> string!
+GoogleMapsApi.Entities.Solar.Request.GeoTiffRequest.Url.set -> void
+GoogleMapsApi.Entities.Solar.Request.ImageryQuality
+GoogleMapsApi.Entities.Solar.Request.ImageryQuality.Base = 4 -> GoogleMapsApi.Entities.Solar.Request.ImageryQuality
+GoogleMapsApi.Entities.Solar.Request.ImageryQuality.High = 1 -> GoogleMapsApi.Entities.Solar.Request.ImageryQuality
+GoogleMapsApi.Entities.Solar.Request.ImageryQuality.Low = 3 -> GoogleMapsApi.Entities.Solar.Request.ImageryQuality
+GoogleMapsApi.Entities.Solar.Request.ImageryQuality.Medium = 2 -> GoogleMapsApi.Entities.Solar.Request.ImageryQuality
+GoogleMapsApi.Entities.Solar.Request.ImageryQuality.Unspecified = 0 -> GoogleMapsApi.Entities.Solar.Request.ImageryQuality
+GoogleMapsApi.Entities.Solar.Response.BuildingInsightsResponse
+GoogleMapsApi.Entities.Solar.Response.BuildingInsightsResponse.AdministrativeArea.get -> string?
+GoogleMapsApi.Entities.Solar.Response.BuildingInsightsResponse.AdministrativeArea.set -> void
+GoogleMapsApi.Entities.Solar.Response.BuildingInsightsResponse.BoundingBox.get -> GoogleMapsApi.Entities.Solar.Response.LatLngBox?
+GoogleMapsApi.Entities.Solar.Response.BuildingInsightsResponse.BoundingBox.set -> void
+GoogleMapsApi.Entities.Solar.Response.BuildingInsightsResponse.BuildingInsightsResponse() -> void
+GoogleMapsApi.Entities.Solar.Response.BuildingInsightsResponse.Center.get -> GoogleMapsApi.Entities.Solar.Response.LatLng?
+GoogleMapsApi.Entities.Solar.Response.BuildingInsightsResponse.Center.set -> void
+GoogleMapsApi.Entities.Solar.Response.BuildingInsightsResponse.ImageryDate.get -> GoogleMapsApi.Entities.Solar.Response.Date?
+GoogleMapsApi.Entities.Solar.Response.BuildingInsightsResponse.ImageryDate.set -> void
+GoogleMapsApi.Entities.Solar.Response.BuildingInsightsResponse.ImageryProcessedDate.get -> GoogleMapsApi.Entities.Solar.Response.Date?
+GoogleMapsApi.Entities.Solar.Response.BuildingInsightsResponse.ImageryProcessedDate.set -> void
+GoogleMapsApi.Entities.Solar.Response.BuildingInsightsResponse.ImageryQuality.get -> GoogleMapsApi.Entities.Solar.Request.ImageryQuality
+GoogleMapsApi.Entities.Solar.Response.BuildingInsightsResponse.ImageryQuality.set -> void
+GoogleMapsApi.Entities.Solar.Response.BuildingInsightsResponse.Name.get -> string?
+GoogleMapsApi.Entities.Solar.Response.BuildingInsightsResponse.Name.set -> void
+GoogleMapsApi.Entities.Solar.Response.BuildingInsightsResponse.PostalCode.get -> string?
+GoogleMapsApi.Entities.Solar.Response.BuildingInsightsResponse.PostalCode.set -> void
+GoogleMapsApi.Entities.Solar.Response.BuildingInsightsResponse.RegionCode.get -> string?
+GoogleMapsApi.Entities.Solar.Response.BuildingInsightsResponse.RegionCode.set -> void
+GoogleMapsApi.Entities.Solar.Response.BuildingInsightsResponse.SolarPotential.get -> GoogleMapsApi.Entities.Solar.Response.SolarPotential?
+GoogleMapsApi.Entities.Solar.Response.BuildingInsightsResponse.SolarPotential.set -> void
+GoogleMapsApi.Entities.Solar.Response.BuildingInsightsResponse.StatisticalArea.get -> string?
+GoogleMapsApi.Entities.Solar.Response.BuildingInsightsResponse.StatisticalArea.set -> void
+GoogleMapsApi.Entities.Solar.Response.CashPurchaseSavings
+GoogleMapsApi.Entities.Solar.Response.CashPurchaseSavings.CashPurchaseSavings() -> void
+GoogleMapsApi.Entities.Solar.Response.CashPurchaseSavings.OutOfPocketCost.get -> GoogleMapsApi.Entities.Solar.Response.Money?
+GoogleMapsApi.Entities.Solar.Response.CashPurchaseSavings.OutOfPocketCost.set -> void
+GoogleMapsApi.Entities.Solar.Response.CashPurchaseSavings.PaybackYears.get -> float
+GoogleMapsApi.Entities.Solar.Response.CashPurchaseSavings.PaybackYears.set -> void
+GoogleMapsApi.Entities.Solar.Response.CashPurchaseSavings.RebateValue.get -> GoogleMapsApi.Entities.Solar.Response.Money?
+GoogleMapsApi.Entities.Solar.Response.CashPurchaseSavings.RebateValue.set -> void
+GoogleMapsApi.Entities.Solar.Response.CashPurchaseSavings.Savings.get -> GoogleMapsApi.Entities.Solar.Response.SavingsOverTime?
+GoogleMapsApi.Entities.Solar.Response.CashPurchaseSavings.Savings.set -> void
+GoogleMapsApi.Entities.Solar.Response.CashPurchaseSavings.UpfrontCost.get -> GoogleMapsApi.Entities.Solar.Response.Money?
+GoogleMapsApi.Entities.Solar.Response.CashPurchaseSavings.UpfrontCost.set -> void
+GoogleMapsApi.Entities.Solar.Response.DataLayersResponse
+GoogleMapsApi.Entities.Solar.Response.DataLayersResponse.AnnualFluxUrl.get -> string?
+GoogleMapsApi.Entities.Solar.Response.DataLayersResponse.AnnualFluxUrl.set -> void
+GoogleMapsApi.Entities.Solar.Response.DataLayersResponse.DataLayersResponse() -> void
+GoogleMapsApi.Entities.Solar.Response.DataLayersResponse.DsmUrl.get -> string?
+GoogleMapsApi.Entities.Solar.Response.DataLayersResponse.DsmUrl.set -> void
+GoogleMapsApi.Entities.Solar.Response.DataLayersResponse.HourlyShadeUrls.get -> System.Collections.Generic.List<string!>?
+GoogleMapsApi.Entities.Solar.Response.DataLayersResponse.HourlyShadeUrls.set -> void
+GoogleMapsApi.Entities.Solar.Response.DataLayersResponse.ImageryDate.get -> GoogleMapsApi.Entities.Solar.Response.Date?
+GoogleMapsApi.Entities.Solar.Response.DataLayersResponse.ImageryDate.set -> void
+GoogleMapsApi.Entities.Solar.Response.DataLayersResponse.ImageryProcessedDate.get -> GoogleMapsApi.Entities.Solar.Response.Date?
+GoogleMapsApi.Entities.Solar.Response.DataLayersResponse.ImageryProcessedDate.set -> void
+GoogleMapsApi.Entities.Solar.Response.DataLayersResponse.ImageryQuality.get -> GoogleMapsApi.Entities.Solar.Request.ImageryQuality
+GoogleMapsApi.Entities.Solar.Response.DataLayersResponse.ImageryQuality.set -> void
+GoogleMapsApi.Entities.Solar.Response.DataLayersResponse.MaskUrl.get -> string?
+GoogleMapsApi.Entities.Solar.Response.DataLayersResponse.MaskUrl.set -> void
+GoogleMapsApi.Entities.Solar.Response.DataLayersResponse.MonthlyFluxUrl.get -> string?
+GoogleMapsApi.Entities.Solar.Response.DataLayersResponse.MonthlyFluxUrl.set -> void
+GoogleMapsApi.Entities.Solar.Response.DataLayersResponse.RgbUrl.get -> string?
+GoogleMapsApi.Entities.Solar.Response.DataLayersResponse.RgbUrl.set -> void
+GoogleMapsApi.Entities.Solar.Response.Date
+GoogleMapsApi.Entities.Solar.Response.Date.Date() -> void
+GoogleMapsApi.Entities.Solar.Response.Date.Day.get -> int
+GoogleMapsApi.Entities.Solar.Response.Date.Day.set -> void
+GoogleMapsApi.Entities.Solar.Response.Date.Month.get -> int
+GoogleMapsApi.Entities.Solar.Response.Date.Month.set -> void
+GoogleMapsApi.Entities.Solar.Response.Date.Year.get -> int
+GoogleMapsApi.Entities.Solar.Response.Date.Year.set -> void
+GoogleMapsApi.Entities.Solar.Response.FinancedPurchaseSavings
+GoogleMapsApi.Entities.Solar.Response.FinancedPurchaseSavings.AnnualLoanPayment.get -> GoogleMapsApi.Entities.Solar.Response.Money?
+GoogleMapsApi.Entities.Solar.Response.FinancedPurchaseSavings.AnnualLoanPayment.set -> void
+GoogleMapsApi.Entities.Solar.Response.FinancedPurchaseSavings.FinancedPurchaseSavings() -> void
+GoogleMapsApi.Entities.Solar.Response.FinancedPurchaseSavings.LoanInterestRate.get -> float
+GoogleMapsApi.Entities.Solar.Response.FinancedPurchaseSavings.LoanInterestRate.set -> void
+GoogleMapsApi.Entities.Solar.Response.FinancedPurchaseSavings.RebateValue.get -> GoogleMapsApi.Entities.Solar.Response.Money?
+GoogleMapsApi.Entities.Solar.Response.FinancedPurchaseSavings.RebateValue.set -> void
+GoogleMapsApi.Entities.Solar.Response.FinancedPurchaseSavings.Savings.get -> GoogleMapsApi.Entities.Solar.Response.SavingsOverTime?
+GoogleMapsApi.Entities.Solar.Response.FinancedPurchaseSavings.Savings.set -> void
+GoogleMapsApi.Entities.Solar.Response.FinancialAnalysis
+GoogleMapsApi.Entities.Solar.Response.FinancialAnalysis.AverageKwhPerMonth.get -> float
+GoogleMapsApi.Entities.Solar.Response.FinancialAnalysis.AverageKwhPerMonth.set -> void
+GoogleMapsApi.Entities.Solar.Response.FinancialAnalysis.CashPurchaseSavings.get -> GoogleMapsApi.Entities.Solar.Response.CashPurchaseSavings?
+GoogleMapsApi.Entities.Solar.Response.FinancialAnalysis.CashPurchaseSavings.set -> void
+GoogleMapsApi.Entities.Solar.Response.FinancialAnalysis.DefaultBill.get -> bool
+GoogleMapsApi.Entities.Solar.Response.FinancialAnalysis.DefaultBill.set -> void
+GoogleMapsApi.Entities.Solar.Response.FinancialAnalysis.FinancedPurchaseSavings.get -> GoogleMapsApi.Entities.Solar.Response.FinancedPurchaseSavings?
+GoogleMapsApi.Entities.Solar.Response.FinancialAnalysis.FinancedPurchaseSavings.set -> void
+GoogleMapsApi.Entities.Solar.Response.FinancialAnalysis.FinancialAnalysis() -> void
+GoogleMapsApi.Entities.Solar.Response.FinancialAnalysis.FinancialDetails.get -> GoogleMapsApi.Entities.Solar.Response.FinancialDetails?
+GoogleMapsApi.Entities.Solar.Response.FinancialAnalysis.FinancialDetails.set -> void
+GoogleMapsApi.Entities.Solar.Response.FinancialAnalysis.LeasingSavings.get -> GoogleMapsApi.Entities.Solar.Response.LeasingSavings?
+GoogleMapsApi.Entities.Solar.Response.FinancialAnalysis.LeasingSavings.set -> void
+GoogleMapsApi.Entities.Solar.Response.FinancialAnalysis.MonthlyBill.get -> GoogleMapsApi.Entities.Solar.Response.Money?
+GoogleMapsApi.Entities.Solar.Response.FinancialAnalysis.MonthlyBill.set -> void
+GoogleMapsApi.Entities.Solar.Response.FinancialAnalysis.PanelConfigIndex.get -> int
+GoogleMapsApi.Entities.Solar.Response.FinancialAnalysis.PanelConfigIndex.set -> void
+GoogleMapsApi.Entities.Solar.Response.FinancialDetails
+GoogleMapsApi.Entities.Solar.Response.FinancialDetails.CostOfElectricityWithoutSolar.get -> GoogleMapsApi.Entities.Solar.Response.Money?
+GoogleMapsApi.Entities.Solar.Response.FinancialDetails.CostOfElectricityWithoutSolar.set -> void
+GoogleMapsApi.Entities.Solar.Response.FinancialDetails.FederalIncentive.get -> GoogleMapsApi.Entities.Solar.Response.Money?
+GoogleMapsApi.Entities.Solar.Response.FinancialDetails.FederalIncentive.set -> void
+GoogleMapsApi.Entities.Solar.Response.FinancialDetails.FinancialDetails() -> void
+GoogleMapsApi.Entities.Solar.Response.FinancialDetails.InitialAcKwhPerYear.get -> float
+GoogleMapsApi.Entities.Solar.Response.FinancialDetails.InitialAcKwhPerYear.set -> void
+GoogleMapsApi.Entities.Solar.Response.FinancialDetails.LifetimeSrecTotal.get -> GoogleMapsApi.Entities.Solar.Response.Money?
+GoogleMapsApi.Entities.Solar.Response.FinancialDetails.LifetimeSrecTotal.set -> void
+GoogleMapsApi.Entities.Solar.Response.FinancialDetails.NetMeteringAllowed.get -> bool
+GoogleMapsApi.Entities.Solar.Response.FinancialDetails.NetMeteringAllowed.set -> void
+GoogleMapsApi.Entities.Solar.Response.FinancialDetails.PercentageExportedToGrid.get -> float
+GoogleMapsApi.Entities.Solar.Response.FinancialDetails.PercentageExportedToGrid.set -> void
+GoogleMapsApi.Entities.Solar.Response.FinancialDetails.RemainingLifetimeUtilityBill.get -> GoogleMapsApi.Entities.Solar.Response.Money?
+GoogleMapsApi.Entities.Solar.Response.FinancialDetails.RemainingLifetimeUtilityBill.set -> void
+GoogleMapsApi.Entities.Solar.Response.FinancialDetails.SolarPercentage.get -> float
+GoogleMapsApi.Entities.Solar.Response.FinancialDetails.SolarPercentage.set -> void
+GoogleMapsApi.Entities.Solar.Response.FinancialDetails.StateIncentive.get -> GoogleMapsApi.Entities.Solar.Response.Money?
+GoogleMapsApi.Entities.Solar.Response.FinancialDetails.StateIncentive.set -> void
+GoogleMapsApi.Entities.Solar.Response.FinancialDetails.UtilityIncentive.get -> GoogleMapsApi.Entities.Solar.Response.Money?
+GoogleMapsApi.Entities.Solar.Response.FinancialDetails.UtilityIncentive.set -> void
+GoogleMapsApi.Entities.Solar.Response.GeoTiffResponse
+GoogleMapsApi.Entities.Solar.Response.GeoTiffResponse.Content.get -> byte[]!
+GoogleMapsApi.Entities.Solar.Response.GeoTiffResponse.Content.set -> void
+GoogleMapsApi.Entities.Solar.Response.GeoTiffResponse.ContentType.get -> string?
+GoogleMapsApi.Entities.Solar.Response.GeoTiffResponse.ContentType.set -> void
+GoogleMapsApi.Entities.Solar.Response.GeoTiffResponse.GeoTiffResponse() -> void
+GoogleMapsApi.Entities.Solar.Response.LatLng
+GoogleMapsApi.Entities.Solar.Response.LatLng.LatLng() -> void
+GoogleMapsApi.Entities.Solar.Response.LatLng.Latitude.get -> double
+GoogleMapsApi.Entities.Solar.Response.LatLng.Latitude.set -> void
+GoogleMapsApi.Entities.Solar.Response.LatLng.Longitude.get -> double
+GoogleMapsApi.Entities.Solar.Response.LatLng.Longitude.set -> void
+GoogleMapsApi.Entities.Solar.Response.LatLngBox
+GoogleMapsApi.Entities.Solar.Response.LatLngBox.LatLngBox() -> void
+GoogleMapsApi.Entities.Solar.Response.LatLngBox.Ne.get -> GoogleMapsApi.Entities.Solar.Response.LatLng?
+GoogleMapsApi.Entities.Solar.Response.LatLngBox.Ne.set -> void
+GoogleMapsApi.Entities.Solar.Response.LatLngBox.Sw.get -> GoogleMapsApi.Entities.Solar.Response.LatLng?
+GoogleMapsApi.Entities.Solar.Response.LatLngBox.Sw.set -> void
+GoogleMapsApi.Entities.Solar.Response.LeasingSavings
+GoogleMapsApi.Entities.Solar.Response.LeasingSavings.AnnualLeasingCost.get -> GoogleMapsApi.Entities.Solar.Response.Money?
+GoogleMapsApi.Entities.Solar.Response.LeasingSavings.AnnualLeasingCost.set -> void
+GoogleMapsApi.Entities.Solar.Response.LeasingSavings.LeasesAllowed.get -> bool
+GoogleMapsApi.Entities.Solar.Response.LeasingSavings.LeasesAllowed.set -> void
+GoogleMapsApi.Entities.Solar.Response.LeasingSavings.LeasesSupported.get -> bool
+GoogleMapsApi.Entities.Solar.Response.LeasingSavings.LeasesSupported.set -> void
+GoogleMapsApi.Entities.Solar.Response.LeasingSavings.LeasingSavings() -> void
+GoogleMapsApi.Entities.Solar.Response.LeasingSavings.Savings.get -> GoogleMapsApi.Entities.Solar.Response.SavingsOverTime?
+GoogleMapsApi.Entities.Solar.Response.LeasingSavings.Savings.set -> void
+GoogleMapsApi.Entities.Solar.Response.Money
+GoogleMapsApi.Entities.Solar.Response.Money.CurrencyCode.get -> string?
+GoogleMapsApi.Entities.Solar.Response.Money.CurrencyCode.set -> void
+GoogleMapsApi.Entities.Solar.Response.Money.Money() -> void
+GoogleMapsApi.Entities.Solar.Response.Money.Nanos.get -> int
+GoogleMapsApi.Entities.Solar.Response.Money.Nanos.set -> void
+GoogleMapsApi.Entities.Solar.Response.Money.Units.get -> long?
+GoogleMapsApi.Entities.Solar.Response.Money.Units.set -> void
+GoogleMapsApi.Entities.Solar.Response.RoofSegmentSizeAndSunshineStats
+GoogleMapsApi.Entities.Solar.Response.RoofSegmentSizeAndSunshineStats.AzimuthDegrees.get -> float
+GoogleMapsApi.Entities.Solar.Response.RoofSegmentSizeAndSunshineStats.AzimuthDegrees.set -> void
+GoogleMapsApi.Entities.Solar.Response.RoofSegmentSizeAndSunshineStats.BoundingBox.get -> GoogleMapsApi.Entities.Solar.Response.LatLngBox?
+GoogleMapsApi.Entities.Solar.Response.RoofSegmentSizeAndSunshineStats.BoundingBox.set -> void
+GoogleMapsApi.Entities.Solar.Response.RoofSegmentSizeAndSunshineStats.Center.get -> GoogleMapsApi.Entities.Solar.Response.LatLng?
+GoogleMapsApi.Entities.Solar.Response.RoofSegmentSizeAndSunshineStats.Center.set -> void
+GoogleMapsApi.Entities.Solar.Response.RoofSegmentSizeAndSunshineStats.PitchDegrees.get -> float
+GoogleMapsApi.Entities.Solar.Response.RoofSegmentSizeAndSunshineStats.PitchDegrees.set -> void
+GoogleMapsApi.Entities.Solar.Response.RoofSegmentSizeAndSunshineStats.PlaneHeightAtCenterMeters.get -> float
+GoogleMapsApi.Entities.Solar.Response.RoofSegmentSizeAndSunshineStats.PlaneHeightAtCenterMeters.set -> void
+GoogleMapsApi.Entities.Solar.Response.RoofSegmentSizeAndSunshineStats.RoofSegmentSizeAndSunshineStats() -> void
+GoogleMapsApi.Entities.Solar.Response.RoofSegmentSizeAndSunshineStats.Stats.get -> GoogleMapsApi.Entities.Solar.Response.SizeAndSunshineStats?
+GoogleMapsApi.Entities.Solar.Response.RoofSegmentSizeAndSunshineStats.Stats.set -> void
+GoogleMapsApi.Entities.Solar.Response.RoofSegmentSummary
+GoogleMapsApi.Entities.Solar.Response.RoofSegmentSummary.AzimuthDegrees.get -> float
+GoogleMapsApi.Entities.Solar.Response.RoofSegmentSummary.AzimuthDegrees.set -> void
+GoogleMapsApi.Entities.Solar.Response.RoofSegmentSummary.PanelsCount.get -> int
+GoogleMapsApi.Entities.Solar.Response.RoofSegmentSummary.PanelsCount.set -> void
+GoogleMapsApi.Entities.Solar.Response.RoofSegmentSummary.PitchDegrees.get -> float
+GoogleMapsApi.Entities.Solar.Response.RoofSegmentSummary.PitchDegrees.set -> void
+GoogleMapsApi.Entities.Solar.Response.RoofSegmentSummary.RoofSegmentSummary() -> void
+GoogleMapsApi.Entities.Solar.Response.RoofSegmentSummary.SegmentIndex.get -> int
+GoogleMapsApi.Entities.Solar.Response.RoofSegmentSummary.SegmentIndex.set -> void
+GoogleMapsApi.Entities.Solar.Response.RoofSegmentSummary.YearlyEnergyDcKwh.get -> float
+GoogleMapsApi.Entities.Solar.Response.RoofSegmentSummary.YearlyEnergyDcKwh.set -> void
+GoogleMapsApi.Entities.Solar.Response.SavingsOverTime
+GoogleMapsApi.Entities.Solar.Response.SavingsOverTime.FinanciallyViable.get -> bool
+GoogleMapsApi.Entities.Solar.Response.SavingsOverTime.FinanciallyViable.set -> void
+GoogleMapsApi.Entities.Solar.Response.SavingsOverTime.PresentValueOfSavingsLifetime.get -> GoogleMapsApi.Entities.Solar.Response.Money?
+GoogleMapsApi.Entities.Solar.Response.SavingsOverTime.PresentValueOfSavingsLifetime.set -> void
+GoogleMapsApi.Entities.Solar.Response.SavingsOverTime.PresentValueOfSavingsYear20.get -> GoogleMapsApi.Entities.Solar.Response.Money?
+GoogleMapsApi.Entities.Solar.Response.SavingsOverTime.PresentValueOfSavingsYear20.set -> void
+GoogleMapsApi.Entities.Solar.Response.SavingsOverTime.SavingsLifetime.get -> GoogleMapsApi.Entities.Solar.Response.Money?
+GoogleMapsApi.Entities.Solar.Response.SavingsOverTime.SavingsLifetime.set -> void
+GoogleMapsApi.Entities.Solar.Response.SavingsOverTime.SavingsOverTime() -> void
+GoogleMapsApi.Entities.Solar.Response.SavingsOverTime.SavingsYear1.get -> GoogleMapsApi.Entities.Solar.Response.Money?
+GoogleMapsApi.Entities.Solar.Response.SavingsOverTime.SavingsYear1.set -> void
+GoogleMapsApi.Entities.Solar.Response.SavingsOverTime.SavingsYear20.get -> GoogleMapsApi.Entities.Solar.Response.Money?
+GoogleMapsApi.Entities.Solar.Response.SavingsOverTime.SavingsYear20.set -> void
+GoogleMapsApi.Entities.Solar.Response.SizeAndSunshineStats
+GoogleMapsApi.Entities.Solar.Response.SizeAndSunshineStats.AreaMeters2.get -> float
+GoogleMapsApi.Entities.Solar.Response.SizeAndSunshineStats.AreaMeters2.set -> void
+GoogleMapsApi.Entities.Solar.Response.SizeAndSunshineStats.GroundAreaMeters2.get -> float
+GoogleMapsApi.Entities.Solar.Response.SizeAndSunshineStats.GroundAreaMeters2.set -> void
+GoogleMapsApi.Entities.Solar.Response.SizeAndSunshineStats.SizeAndSunshineStats() -> void
+GoogleMapsApi.Entities.Solar.Response.SizeAndSunshineStats.SunshineQuantiles.get -> System.Collections.Generic.List<float>?
+GoogleMapsApi.Entities.Solar.Response.SizeAndSunshineStats.SunshineQuantiles.set -> void
+GoogleMapsApi.Entities.Solar.Response.SolarPanel
+GoogleMapsApi.Entities.Solar.Response.SolarPanel.Center.get -> GoogleMapsApi.Entities.Solar.Response.LatLng?
+GoogleMapsApi.Entities.Solar.Response.SolarPanel.Center.set -> void
+GoogleMapsApi.Entities.Solar.Response.SolarPanel.Orientation.get -> GoogleMapsApi.Entities.Solar.Response.SolarPanelOrientation
+GoogleMapsApi.Entities.Solar.Response.SolarPanel.Orientation.set -> void
+GoogleMapsApi.Entities.Solar.Response.SolarPanel.SegmentIndex.get -> int
+GoogleMapsApi.Entities.Solar.Response.SolarPanel.SegmentIndex.set -> void
+GoogleMapsApi.Entities.Solar.Response.SolarPanel.SolarPanel() -> void
+GoogleMapsApi.Entities.Solar.Response.SolarPanel.YearlyEnergyDcKwh.get -> float
+GoogleMapsApi.Entities.Solar.Response.SolarPanel.YearlyEnergyDcKwh.set -> void
+GoogleMapsApi.Entities.Solar.Response.SolarPanelConfig
+GoogleMapsApi.Entities.Solar.Response.SolarPanelConfig.PanelsCount.get -> int
+GoogleMapsApi.Entities.Solar.Response.SolarPanelConfig.PanelsCount.set -> void
+GoogleMapsApi.Entities.Solar.Response.SolarPanelConfig.RoofSegmentSummaries.get -> System.Collections.Generic.List<GoogleMapsApi.Entities.Solar.Response.RoofSegmentSummary!>?
+GoogleMapsApi.Entities.Solar.Response.SolarPanelConfig.RoofSegmentSummaries.set -> void
+GoogleMapsApi.Entities.Solar.Response.SolarPanelConfig.SolarPanelConfig() -> void
+GoogleMapsApi.Entities.Solar.Response.SolarPanelConfig.YearlyEnergyDcKwh.get -> float
+GoogleMapsApi.Entities.Solar.Response.SolarPanelConfig.YearlyEnergyDcKwh.set -> void
+GoogleMapsApi.Entities.Solar.Response.SolarPanelOrientation
+GoogleMapsApi.Entities.Solar.Response.SolarPanelOrientation.Landscape = 1 -> GoogleMapsApi.Entities.Solar.Response.SolarPanelOrientation
+GoogleMapsApi.Entities.Solar.Response.SolarPanelOrientation.Portrait = 2 -> GoogleMapsApi.Entities.Solar.Response.SolarPanelOrientation
+GoogleMapsApi.Entities.Solar.Response.SolarPanelOrientation.Unspecified = 0 -> GoogleMapsApi.Entities.Solar.Response.SolarPanelOrientation
+GoogleMapsApi.Entities.Solar.Response.SolarPotential
+GoogleMapsApi.Entities.Solar.Response.SolarPotential.BuildingStats.get -> GoogleMapsApi.Entities.Solar.Response.SizeAndSunshineStats?
+GoogleMapsApi.Entities.Solar.Response.SolarPotential.BuildingStats.set -> void
+GoogleMapsApi.Entities.Solar.Response.SolarPotential.CarbonOffsetFactorKgPerMwh.get -> float
+GoogleMapsApi.Entities.Solar.Response.SolarPotential.CarbonOffsetFactorKgPerMwh.set -> void
+GoogleMapsApi.Entities.Solar.Response.SolarPotential.FinancialAnalyses.get -> System.Collections.Generic.List<GoogleMapsApi.Entities.Solar.Response.FinancialAnalysis!>?
+GoogleMapsApi.Entities.Solar.Response.SolarPotential.FinancialAnalyses.set -> void
+GoogleMapsApi.Entities.Solar.Response.SolarPotential.MaxArrayAreaMeters2.get -> float
+GoogleMapsApi.Entities.Solar.Response.SolarPotential.MaxArrayAreaMeters2.set -> void
+GoogleMapsApi.Entities.Solar.Response.SolarPotential.MaxArrayPanelsCount.get -> int
+GoogleMapsApi.Entities.Solar.Response.SolarPotential.MaxArrayPanelsCount.set -> void
+GoogleMapsApi.Entities.Solar.Response.SolarPotential.MaxSunshineHoursPerYear.get -> float
+GoogleMapsApi.Entities.Solar.Response.SolarPotential.MaxSunshineHoursPerYear.set -> void
+GoogleMapsApi.Entities.Solar.Response.SolarPotential.PanelCapacityWatts.get -> float
+GoogleMapsApi.Entities.Solar.Response.SolarPotential.PanelCapacityWatts.set -> void
+GoogleMapsApi.Entities.Solar.Response.SolarPotential.PanelHeightMeters.get -> float
+GoogleMapsApi.Entities.Solar.Response.SolarPotential.PanelHeightMeters.set -> void
+GoogleMapsApi.Entities.Solar.Response.SolarPotential.PanelLifetimeYears.get -> int
+GoogleMapsApi.Entities.Solar.Response.SolarPotential.PanelLifetimeYears.set -> void
+GoogleMapsApi.Entities.Solar.Response.SolarPotential.PanelWidthMeters.get -> float
+GoogleMapsApi.Entities.Solar.Response.SolarPotential.PanelWidthMeters.set -> void
+GoogleMapsApi.Entities.Solar.Response.SolarPotential.RoofSegmentStats.get -> System.Collections.Generic.List<GoogleMapsApi.Entities.Solar.Response.RoofSegmentSizeAndSunshineStats!>?
+GoogleMapsApi.Entities.Solar.Response.SolarPotential.RoofSegmentStats.set -> void
+GoogleMapsApi.Entities.Solar.Response.SolarPotential.SolarPanelConfigs.get -> System.Collections.Generic.List<GoogleMapsApi.Entities.Solar.Response.SolarPanelConfig!>?
+GoogleMapsApi.Entities.Solar.Response.SolarPotential.SolarPanelConfigs.set -> void
+GoogleMapsApi.Entities.Solar.Response.SolarPotential.SolarPanels.get -> System.Collections.Generic.List<GoogleMapsApi.Entities.Solar.Response.SolarPanel!>?
+GoogleMapsApi.Entities.Solar.Response.SolarPotential.SolarPanels.set -> void
+GoogleMapsApi.Entities.Solar.Response.SolarPotential.SolarPotential() -> void
+GoogleMapsApi.Entities.Solar.Response.SolarPotential.WholeRoofStats.get -> GoogleMapsApi.Entities.Solar.Response.SizeAndSunshineStats?
+GoogleMapsApi.Entities.Solar.Response.SolarPotential.WholeRoofStats.set -> void
+GoogleMapsApi.GoogleMapsClient.SolarBuildingInsights.get -> GoogleMapsApi.IEngineFacade<GoogleMapsApi.Entities.Solar.Request.BuildingInsightsRequest!, GoogleMapsApi.Entities.Solar.Response.BuildingInsightsResponse!>!
+GoogleMapsApi.GoogleMapsClient.SolarDataLayers.get -> GoogleMapsApi.IEngineFacade<GoogleMapsApi.Entities.Solar.Request.DataLayersRequest!, GoogleMapsApi.Entities.Solar.Response.DataLayersResponse!>!
+GoogleMapsApi.GoogleMapsClient.SolarGeoTiff.get -> GoogleMapsApi.IEngineFacade<GoogleMapsApi.Entities.Solar.Request.GeoTiffRequest!, GoogleMapsApi.Entities.Solar.Response.GeoTiffResponse!>!
+GoogleMapsApi.IGoogleMapsClient.SolarBuildingInsights.get -> GoogleMapsApi.IEngineFacade<GoogleMapsApi.Entities.Solar.Request.BuildingInsightsRequest!, GoogleMapsApi.Entities.Solar.Response.BuildingInsightsResponse!>!
+GoogleMapsApi.IGoogleMapsClient.SolarDataLayers.get -> GoogleMapsApi.IEngineFacade<GoogleMapsApi.Entities.Solar.Request.DataLayersRequest!, GoogleMapsApi.Entities.Solar.Response.DataLayersResponse!>!
+GoogleMapsApi.IGoogleMapsClient.SolarGeoTiff.get -> GoogleMapsApi.IEngineFacade<GoogleMapsApi.Entities.Solar.Request.GeoTiffRequest!, GoogleMapsApi.Entities.Solar.Response.GeoTiffResponse!>!
+override GoogleMapsApi.Entities.Solar.Request.BuildingInsightsRequest.GetUri() -> System.Uri!
+override GoogleMapsApi.Entities.Solar.Request.DataLayersRequest.GetUri() -> System.Uri!
+override GoogleMapsApi.Entities.Solar.Request.GeoTiffRequest.GetUri() -> System.Uri!

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Release history: see [CHANGELOG.md](CHANGELOG.md).
 
 # GoogleMapsApi
 
-A friendly, strongly-typed .NET wrapper for the Google Maps Web Services APIs — Geocoding, Routes, Directions, Distance Matrix, Elevation, Time Zone, Places, Address Validation, and Static Maps. Multi-framework (net10.0, net8.0, netstandard2.0 — the latter still covers .NET Framework 4.6.1+), async-first, and battle-tested with **2M+ downloads** on NuGet.
+A friendly, strongly-typed .NET wrapper for the Google Maps Web Services APIs — Geocoding, Routes, Directions, Distance Matrix, Elevation, Time Zone, Places, Address Validation, Solar, and Static Maps. Multi-framework (net10.0, net8.0, netstandard2.0 — the latter still covers .NET Framework 4.6.1+), async-first, and battle-tested with **2M+ downloads** on NuGet.
 
 ## Supported APIs
 
@@ -24,6 +24,7 @@ A friendly, strongly-typed .NET wrapper for the Google Maps Web Services APIs �
 | [Time Zone](https://developers.google.com/maps/documentation/timezone) | Time zone information for any coordinate |
 | [Places (New)](https://developers.google.com/maps/documentation/places/web-service/op-overview) | Modern Places API — Text Search, Nearby Search, Place Details, Autocomplete, Place Photos |
 | [Address Validation](https://developers.google.com/maps/documentation/address-validation) | Validate a postal address with component-level confirmation; USPS CASS for US/PR |
+| [Solar](https://developers.google.com/maps/documentation/solar) | Building solar potential, roof geometry, panel layouts, financial analyses, and raster data layers (billable) |
 | [Static Maps](https://developers.google.com/maps/documentation/maps-static) | Generate URLs for static map images with markers, paths, and styles |
 
 ## Why this vs Google's official SDKs
@@ -151,6 +152,38 @@ var request = new RoutesRequest
 var response = await maps.Routes.QueryAsync(request);
 var route = response.Routes![0];
 Console.WriteLine($"{route.DistanceMeters} m, {route.DurationSeconds} s");
+```
+
+### Solar API (building solar potential)
+
+The Solar API returns a building's solar potential — roof geometry, panel layouts, expected energy
+production, and financial analyses — plus downloadable raster data layers (DSM, flux, shade). It is
+a **billable** API, so calls beyond the free tier incur charges.
+
+``` C#
+using GoogleMapsApi;
+using GoogleMapsApi.Entities.Solar.Request;
+
+using var http = new HttpClient();
+var maps = new GoogleMapsClient(http, new GoogleMapsClientOptions { ApiKey = "your-google-maps-api-key" });
+
+// Solar potential for the building closest to a coordinate.
+var insights = await maps.SolarBuildingInsights.QueryAsync(new BuildingInsightsRequest
+{
+    Latitude = 37.4450,
+    Longitude = -122.1390,
+});
+Console.WriteLine($"Up to {insights.SolarPotential!.MaxArrayPanelsCount} panels");
+
+// Discover raster data layers, then download one as raw GeoTIFF bytes.
+var layers = await maps.SolarDataLayers.QueryAsync(new DataLayersRequest
+{
+    Latitude = 37.4450,
+    Longitude = -122.1390,
+    RadiusMeters = 50,
+});
+var dsm = await maps.SolarGeoTiff.QueryAsync(new GeoTiffRequest { Url = layers.DsmUrl! });
+await File.WriteAllBytesAsync("dsm.tiff", dsm.Content);
 ```
 
 ### Instance-based client (`IHttpClientFactory`-friendly)


### PR DESCRIPTION
## Summary
Adds the Google **Solar API** as a new strongly-typed service on `IGoogleMapsClient` — the first of the Environment APIs (Solar leads on enterprise interest for renewable installers). Covers all three endpoints with full response typing.

## Changes
- **`SolarBuildingInsights`** → `buildingInsights:findClosest`: roof geometry, panel layouts, energy production, and the full financial-analysis tree (lease / cash / financed savings).
- **`SolarDataLayers`** → `dataLayers:get`: URLs to DSM / RGB / mask / flux / hourly-shade raster layers.
- **`SolarGeoTiff`** → `geoTiff:get`: downloads a data layer as raw GeoTIFF **bytes**.
- **Engine: binary-response support.** New `IBinaryResponse` marker interface; `MapsAPIGenericEngine` branches on it to read bytes + content-type instead of JSON. Send/timeout/cancellation logic refactored into a shared `SendAsync<T>` helper. Every existing JSON API takes the identical path — no behavior change.
- **~25 response DTOs**, `[EnumMember]`-tagged enums (ride the existing global converter), and `Money` with int64-as-JSON-string handling. Two internal helpers: `CoordinateFormatter` (matches the library's non-scientific coordinate style) and `EnumMemberHelper` (enum → query-string value).
- `PublicAPI.Unshipped.txt` populated (analyzer treats `RS0016` as a build error). README supported-APIs table + usage example. `CHANGELOG.md` left untouched (auto-generated by `release.sh`).

## Test plan
- [x] `dotnet build` succeeds on all TFMs (net10.0 / net8.0 / net6.0 / netstandard2.0 / net481 / net462).
- [x] 11 hermetic Solar unit tests pass — URL generation, guard clauses, the binary engine path end-to-end, and deep JSON deserialization.
- [x] Existing `GoogleMapsClientTests` still green (confirms the shared engine change is non-breaking).
- [ ] Live check (billable): `RUN_BILLABLE_TESTS=true GOOGLE_API_KEY=<key-with-Solar-enabled> dotnet test --filter "FullyQualifiedName~SolarTests"` — confirms buildingInsights returns a populated `SolarPotential`, dataLayers returns layer URLs, and the geoTiff download returns non-empty bytes.

> Note: the Solar API is **billable**, so the integration fixture is `[BillableTest]` (skipped unless `RUN_BILLABLE_TESTS=true`).
