### PR TITLE
test(perf): add BenchmarkDotNet project for URL generation and JSON deserialization

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,45 @@
+name: Benchmarks
+
+# Benchmarks are noisy and slow, so they never gate PRs — run them manually on demand.
+on:
+  workflow_dispatch:
+    inputs:
+      filter:
+        description: 'BenchmarkDotNet --filter glob (which benchmarks to run)'
+        type: string
+        required: false
+        default: '*'
+
+permissions:
+  contents: read
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+    - name: Setup .NET
+      uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2  # v5.3.0
+      with:
+        # Both runtimes are required: the RuntimeMoniker jobs execute on net8.0 and net10.0.
+        dotnet-version: |
+          8.0.x
+          10.0.x
+    - name: Run benchmarks
+      # Pass the untrusted input via env (not string-interpolated into the shell) to avoid
+      # command injection. See https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/
+      env:
+        FILTER: ${{ inputs.filter }}
+      run: >
+        dotnet run -c Release -f net10.0
+        --project benchmarks/GoogleMapsApi.Benchmarks
+        --
+        --filter "$FILTER"
+    - name: Upload results
+      if: always()
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+      with:
+        name: benchmark-results
+        path: BenchmarkDotNet.Artifacts/**
+        if-no-files-found: warn

--- a/GoogleMapsApi.sln
+++ b/GoogleMapsApi.sln
@@ -31,6 +31,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GoogleMapsApi.Extensions.De
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GenericHost.DistanceMatrix", "samples\GenericHost.DistanceMatrix\GenericHost.DistanceMatrix.csproj", "{41652BB3-0385-4E9E-A220-22F1D28764F3}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "benchmarks", "benchmarks", "{66320409-64EC-F7C5-3DEF-65E7510DAAD1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GoogleMapsApi.Benchmarks", "benchmarks\GoogleMapsApi.Benchmarks\GoogleMapsApi.Benchmarks.csproj", "{6429978B-C1E9-415C-B289-DFBF9451393D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -170,6 +174,22 @@ Global
 		{41652BB3-0385-4E9E-A220-22F1D28764F3}.Release|x86.Build.0 = Release|Any CPU
 		{41652BB3-0385-4E9E-A220-22F1D28764F3}.Release|x64.ActiveCfg = Release|Any CPU
 		{41652BB3-0385-4E9E-A220-22F1D28764F3}.Release|x64.Build.0 = Release|Any CPU
+		{6429978B-C1E9-415C-B289-DFBF9451393D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6429978B-C1E9-415C-B289-DFBF9451393D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6429978B-C1E9-415C-B289-DFBF9451393D}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{6429978B-C1E9-415C-B289-DFBF9451393D}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{6429978B-C1E9-415C-B289-DFBF9451393D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6429978B-C1E9-415C-B289-DFBF9451393D}.Debug|x86.Build.0 = Debug|Any CPU
+		{6429978B-C1E9-415C-B289-DFBF9451393D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6429978B-C1E9-415C-B289-DFBF9451393D}.Debug|x64.Build.0 = Debug|Any CPU
+		{6429978B-C1E9-415C-B289-DFBF9451393D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6429978B-C1E9-415C-B289-DFBF9451393D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6429978B-C1E9-415C-B289-DFBF9451393D}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{6429978B-C1E9-415C-B289-DFBF9451393D}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{6429978B-C1E9-415C-B289-DFBF9451393D}.Release|x86.ActiveCfg = Release|Any CPU
+		{6429978B-C1E9-415C-B289-DFBF9451393D}.Release|x86.Build.0 = Release|Any CPU
+		{6429978B-C1E9-415C-B289-DFBF9451393D}.Release|x64.ActiveCfg = Release|Any CPU
+		{6429978B-C1E9-415C-B289-DFBF9451393D}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -183,6 +203,7 @@ Global
 		{BF7FCFA6-53A5-4881-B79E-BDD064F3DCA0} = {950E065F-B61E-4C05-8C74-5F03946AD7E2}
 		{3059B358-14F2-4835-9856-EBD07A578B7A} = {9D09CCCC-6AFA-41EA-BFB3-4698FC5830E6}
 		{41652BB3-0385-4E9E-A220-22F1D28764F3} = {19C7D2B1-FE79-42F7-9F9E-4F403BDA6033}
+		{6429978B-C1E9-415C-B289-DFBF9451393D} = {66320409-64EC-F7C5-3DEF-65E7510DAAD1}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {061AA237-7231-49DE-835A-296ED94715C4}

--- a/GoogleMapsApi/GoogleMapsApi.csproj
+++ b/GoogleMapsApi/GoogleMapsApi.csproj
@@ -36,6 +36,7 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="GoogleMapsApi.Test" />
+    <InternalsVisibleTo Include="GoogleMapsApi.Benchmarks" />
   </ItemGroup>
 
   <ItemGroup>

--- a/benchmarks/GoogleMapsApi.Benchmarks/GoogleMapsApi.Benchmarks.csproj
+++ b/benchmarks/GoogleMapsApi.Benchmarks/GoogleMapsApi.Benchmarks.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <!-- Multi-targeted so BenchmarkDotNet's RuntimeMoniker jobs can reference a build of this
+         assembly for each runtime under test. Launch the host with -f net10.0; the [SimpleJob]
+         attributes still execute every configured runtime (net8.0 + net10.0) in one run. -->
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\GoogleMapsApi\GoogleMapsApi.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="SampleData\*.json" />
+  </ItemGroup>
+
+</Project>

--- a/benchmarks/GoogleMapsApi.Benchmarks/JsonDeserializationBenchmarks.cs
+++ b/benchmarks/GoogleMapsApi.Benchmarks/JsonDeserializationBenchmarks.cs
@@ -1,0 +1,59 @@
+using System.Reflection;
+using System.Text.Json;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+using GoogleMapsApi.Engine;
+using GoogleMapsApi.Entities.Directions.Response;
+using GoogleMapsApi.Entities.DistanceMatrix.Response;
+using GoogleMapsApi.Entities.Geocoding.Response;
+
+namespace GoogleMapsApi.Benchmarks;
+
+/// <summary>
+/// Benchmarks the JSON deserialization path the engine actually uses — the production
+/// <see cref="JsonSerializerConfiguration"/> options (and their custom converters for enums,
+/// <c>Duration</c> and <c>OverviewPolyline</c>) — across the .NET 8 and .NET 10 runtimes.
+/// </summary>
+[MemoryDiagnoser]
+[SimpleJob(RuntimeMoniker.Net80)]
+[SimpleJob(RuntimeMoniker.Net10_0)]
+public class JsonDeserializationBenchmarks
+{
+    private JsonSerializerOptions _options = null!;
+    private string _geocodingJson = null!;
+    private string _directionsJson = null!;
+    private string _distanceMatrixJson = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        // Exact production options, incl. EnumMember/Duration/OverviewPolyline converters.
+        _options = JsonSerializerConfiguration.CreateOptions();
+
+        _geocodingJson = ReadSample("geocoding.json");
+        _directionsJson = ReadSample("directions.json");
+        _distanceMatrixJson = ReadSample("distancematrix.json");
+    }
+
+    private static string ReadSample(string fileName)
+    {
+        var assembly = Assembly.GetExecutingAssembly();
+        var resourceName = assembly.GetManifestResourceNames()
+            .Single(n => n.EndsWith("SampleData." + fileName, StringComparison.Ordinal));
+        using var stream = assembly.GetManifestResourceStream(resourceName)!;
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
+    }
+
+    [Benchmark]
+    public GeocodingResponse Geocoding() =>
+        JsonSerializer.Deserialize<GeocodingResponse>(_geocodingJson, _options)!;
+
+    [Benchmark]
+    public DirectionsResponse Directions() =>
+        JsonSerializer.Deserialize<DirectionsResponse>(_directionsJson, _options)!;
+
+    [Benchmark]
+    public DistanceMatrixResponse DistanceMatrix() =>
+        JsonSerializer.Deserialize<DistanceMatrixResponse>(_distanceMatrixJson, _options)!;
+}

--- a/benchmarks/GoogleMapsApi.Benchmarks/Program.cs
+++ b/benchmarks/GoogleMapsApi.Benchmarks/Program.cs
@@ -1,0 +1,5 @@
+using BenchmarkDotNet.Running;
+
+BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+
+public partial class Program;

--- a/benchmarks/GoogleMapsApi.Benchmarks/SampleData/directions.json
+++ b/benchmarks/GoogleMapsApi.Benchmarks/SampleData/directions.json
@@ -1,0 +1,61 @@
+{
+  "status": "OK",
+  "routes": [
+    {
+      "summary": "I-280 N",
+      "copyrights": "Map data ©2024 Google",
+      "warnings": [],
+      "waypoint_order": [],
+      "bounds": {
+        "southwest": { "lat": 37.3382082, "lng": -122.0842499 },
+        "northeast": { "lat": 37.7749295, "lng": -122.0312186 }
+      },
+      "overview_polyline": {
+        "points": "a~l~Fjk~uOwHJy@P~Ho@_FdH~F`AzCwAdA}A`FBdEbBpHwGtJrFvDk@bFlA~CcoAd@kQ}AeKjAa@vGfBkG?_GfHyAhDhCcA"
+      },
+      "legs": [
+        {
+          "start_address": "Mountain View, CA, USA",
+          "end_address": "San Francisco, CA, USA",
+          "start_location": { "lat": 37.4224764, "lng": -122.0842499 },
+          "end_location": { "lat": 37.7749295, "lng": -122.4194155 },
+          "distance": { "value": 61200, "text": "61.2 km" },
+          "duration": { "value": 2700, "text": "45 mins" },
+          "duration_in_traffic": { "value": 3100, "text": "52 mins" },
+          "steps": [
+            {
+              "html_instructions": "Head <b>north</b> on <b>Amphitheatre Pkwy</b>",
+              "travel_mode": "DRIVING",
+              "maneuver": "",
+              "distance": { "value": 400, "text": "0.4 km" },
+              "duration": { "value": 60, "text": "1 min" },
+              "start_location": { "lat": 37.4224764, "lng": -122.0842499 },
+              "end_location": { "lat": 37.4260000, "lng": -122.0838000 },
+              "polyline": { "points": "a~l~Fjk~uOwHJy@P~Ho@_FdH" }
+            },
+            {
+              "html_instructions": "Merge onto <b>US-101 N</b>",
+              "travel_mode": "DRIVING",
+              "maneuver": "merge",
+              "distance": { "value": 30000, "text": "30.0 km" },
+              "duration": { "value": 1320, "text": "22 mins" },
+              "start_location": { "lat": 37.4260000, "lng": -122.0838000 },
+              "end_location": { "lat": 37.6000000, "lng": -122.3800000 },
+              "polyline": { "points": "_p~iF~ps|U_ulLnnqC_mqNvxq`@" }
+            },
+            {
+              "html_instructions": "Continue onto <b>I-280 N</b>",
+              "travel_mode": "DRIVING",
+              "maneuver": "straight",
+              "distance": { "value": 30800, "text": "30.8 km" },
+              "duration": { "value": 1320, "text": "22 mins" },
+              "start_location": { "lat": 37.6000000, "lng": -122.3800000 },
+              "end_location": { "lat": 37.7749295, "lng": -122.4194155 },
+              "polyline": { "points": "_mqNvxq`@~oia@dewK" }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/benchmarks/GoogleMapsApi.Benchmarks/SampleData/distancematrix.json
+++ b/benchmarks/GoogleMapsApi.Benchmarks/SampleData/distancematrix.json
@@ -1,0 +1,36 @@
+{
+  "status": "OK",
+  "origin_addresses": [ "Mountain View, CA, USA", "Oakland, CA, USA" ],
+  "destination_addresses": [ "San Francisco, CA, USA", "Fresno, CA, USA" ],
+  "rows": [
+    {
+      "elements": [
+        {
+          "status": "OK",
+          "distance": { "value": 61200, "text": "61.2 km" },
+          "duration": { "value": 2700, "text": "45 mins" },
+          "duration_in_traffic": { "value": 3100, "text": "52 mins" }
+        },
+        {
+          "status": "OK",
+          "distance": { "value": 304000, "text": "304 km" },
+          "duration": { "value": 10800, "text": "3 hours" }
+        }
+      ]
+    },
+    {
+      "elements": [
+        {
+          "status": "OK",
+          "distance": { "value": 21000, "text": "21.0 km" },
+          "duration": { "value": 1500, "text": "25 mins" }
+        },
+        {
+          "status": "OK",
+          "distance": { "value": 290000, "text": "290 km" },
+          "duration": { "value": 10200, "text": "2 hours 50 mins" }
+        }
+      ]
+    }
+  ]
+}

--- a/benchmarks/GoogleMapsApi.Benchmarks/SampleData/geocoding.json
+++ b/benchmarks/GoogleMapsApi.Benchmarks/SampleData/geocoding.json
@@ -1,0 +1,59 @@
+{
+  "status": "OK",
+  "results": [
+    {
+      "types": [ "street_address" ],
+      "formatted_address": "1600 Amphitheatre Pkwy, Mountain View, CA 94043, USA",
+      "address_components": [
+        { "types": [ "street_number" ], "long_name": "1600", "short_name": "1600" },
+        { "types": [ "route" ], "long_name": "Amphitheatre Parkway", "short_name": "Amphitheatre Pkwy" },
+        { "types": [ "locality", "political" ], "long_name": "Mountain View", "short_name": "Mountain View" },
+        { "types": [ "administrative_area_level_2", "political" ], "long_name": "Santa Clara County", "short_name": "Santa Clara County" },
+        { "types": [ "administrative_area_level_1", "political" ], "long_name": "California", "short_name": "CA" },
+        { "types": [ "country", "political" ], "long_name": "United States", "short_name": "US" },
+        { "types": [ "postal_code" ], "long_name": "94043", "short_name": "94043" }
+      ],
+      "geometry": {
+        "location": { "lat": 37.4224764, "lng": -122.0842499 },
+        "location_type": "ROOFTOP",
+        "viewport": {
+          "southwest": { "lat": 37.4211274, "lng": -122.0855989 },
+          "northeast": { "lat": 37.4238254, "lng": -122.0829009 }
+        },
+        "bounds": {
+          "southwest": { "lat": 37.4211274, "lng": -122.0855989 },
+          "northeast": { "lat": 37.4238254, "lng": -122.0829009 }
+        }
+      },
+      "partial_match": false,
+      "place_id": "ChIJ2eUgeAK6j4ARbn5u_wAGqWA"
+    },
+    {
+      "types": [ "premise" ],
+      "formatted_address": "1600 Amphitheatre Parkway, Googleplex, Mountain View, CA 94043, USA",
+      "address_components": [
+        { "types": [ "premise" ], "long_name": "Googleplex", "short_name": "Googleplex" },
+        { "types": [ "street_number" ], "long_name": "1600", "short_name": "1600" },
+        { "types": [ "route" ], "long_name": "Amphitheatre Parkway", "short_name": "Amphitheatre Pkwy" },
+        { "types": [ "locality", "political" ], "long_name": "Mountain View", "short_name": "Mountain View" },
+        { "types": [ "administrative_area_level_1", "political" ], "long_name": "California", "short_name": "CA" },
+        { "types": [ "country", "political" ], "long_name": "United States", "short_name": "US" },
+        { "types": [ "postal_code" ], "long_name": "94043", "short_name": "94043" }
+      ],
+      "geometry": {
+        "location": { "lat": 37.4220656, "lng": -122.0840897 },
+        "location_type": "ROOFTOP",
+        "viewport": {
+          "southwest": { "lat": 37.4205196, "lng": -122.0855087 },
+          "northeast": { "lat": 37.4258740, "lng": -122.0812900 }
+        },
+        "bounds": {
+          "southwest": { "lat": 37.4209668, "lng": -122.0853157 },
+          "northeast": { "lat": 37.4234650, "lng": -122.0825347 }
+        }
+      },
+      "partial_match": false,
+      "place_id": "ChIJj38IfwK6j4ARNcyPDnEGa9g"
+    }
+  ]
+}

--- a/benchmarks/GoogleMapsApi.Benchmarks/UrlGenerationBenchmarks.cs
+++ b/benchmarks/GoogleMapsApi.Benchmarks/UrlGenerationBenchmarks.cs
@@ -1,0 +1,116 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+using GoogleMapsApi.Entities.Common;
+using GoogleMapsApi.Entities.DistanceMatrix.Request;
+using GoogleMapsApi.Entities.Directions.Request;
+using GoogleMapsApi.Entities.Elevation.Request;
+using GoogleMapsApi.Entities.Geocoding.Request;
+using GoogleMapsApi.Entities.TimeZone.Request;
+using GoogleMapsApi.StaticMaps;
+using GoogleMapsApi.StaticMaps.Entities;
+
+namespace GoogleMapsApi.Benchmarks;
+
+/// <summary>
+/// Benchmarks the network-free request-URL composition path (<c>MapsBaseRequest.GetUri()</c>
+/// and the Static Maps engine) across the .NET 8 and .NET 10 runtimes.
+/// </summary>
+[MemoryDiagnoser]
+[SimpleJob(RuntimeMoniker.Net80)]
+[SimpleJob(RuntimeMoniker.Net10_0)]
+public class UrlGenerationBenchmarks
+{
+    private const string ApiKey = "benchmark-dummy-key";
+
+    private GeocodingRequest _geocoding = null!;
+    private DirectionsRequest _directions = null!;
+    private DirectionsRequest _directionsWithWaypoints = null!;
+    private DistanceMatrixRequest _distanceMatrix = null!;
+    private ElevationRequest _elevation = null!;
+    private TimeZoneRequest _timeZone = null!;
+    private StaticMapsEngine _staticMapsEngine = null!;
+    private StaticMapRequest _staticMap = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _geocoding = new GeocodingRequest
+        {
+            Address = "1600 Amphitheatre Parkway, Mountain View, CA",
+            ApiKey = ApiKey,
+        };
+
+        _directions = new DirectionsRequest
+        {
+            Origin = "Mountain View, CA",
+            Destination = "San Francisco, CA",
+            TravelMode = TravelMode.Driving,
+            ApiKey = ApiKey,
+        };
+
+        _directionsWithWaypoints = new DirectionsRequest
+        {
+            Origin = "Mountain View, CA",
+            Destination = "San Francisco, CA",
+            Waypoints = new[] { "Palo Alto, CA", "San Mateo, CA", "Daly City, CA" },
+            OptimizeWaypoints = true,
+            TravelMode = TravelMode.Driving,
+            ApiKey = ApiKey,
+        };
+
+        _distanceMatrix = new DistanceMatrixRequest
+        {
+            Origins = new[] { "Mountain View, CA", "Oakland, CA" },
+            Destinations = new[] { "San Francisco, CA", "Fresno, CA" },
+            ApiKey = ApiKey,
+        };
+
+        _elevation = new ElevationRequest
+        {
+            Locations = new[]
+            {
+                new Location(37.4224764, -122.0842499),
+                new Location(37.7749295, -122.4194155),
+            },
+            ApiKey = ApiKey,
+        };
+
+        _timeZone = new TimeZoneRequest
+        {
+            Location = new Location(37.4224764, -122.0842499),
+            TimeStamp = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            ApiKey = ApiKey,
+        };
+
+        _staticMapsEngine = new StaticMapsEngine();
+        _staticMap = new StaticMapRequest(
+            new AddressLocation("Times Square, New York, NY"),
+            zoom: 13,
+            imageSize: new ImageSize(500, 400))
+        {
+            ApiKey = ApiKey,
+            IsSSL = true,
+        };
+    }
+
+    [Benchmark]
+    public Uri Geocoding() => _geocoding.GetUri();
+
+    [Benchmark]
+    public Uri Directions() => _directions.GetUri();
+
+    [Benchmark]
+    public Uri Directions_WithWaypoints() => _directionsWithWaypoints.GetUri();
+
+    [Benchmark]
+    public Uri DistanceMatrix() => _distanceMatrix.GetUri();
+
+    [Benchmark]
+    public Uri Elevation() => _elevation.GetUri();
+
+    [Benchmark]
+    public Uri TimeZone() => _timeZone.GetUri();
+
+    [Benchmark]
+    public string StaticMap() => _staticMapsEngine.GenerateStaticMapURL(_staticMap);
+}


### PR DESCRIPTION
## What

Adds a **`GoogleMapsApi.Benchmarks`** BenchmarkDotNet project measuring the two network-free hot paths, across **.NET 8 and .NET 10**:

1. **URL generation** — `MapsBaseRequest.GetUri()` (Geocoding, Directions, DistanceMatrix, Elevation, TimeZone) and the Static Maps engine.
2. **JSON deserialization** — the *real* engine path via the internal `JsonSerializerConfiguration.CreateOptions()` and its enum / `Duration` / `OverviewPolyline` converters.

This gives measurable proof of performance and a baseline to catch regressions (timings **and** allocations).

## How it works

- Cross-runtime comparison uses BenchmarkDotNet `RuntimeMoniker` jobs. The host **multi-targets `net8.0;net10.0`** so each job can reference a matching build of the assembly (a single-TFM host fails `NU1201` for the other runtime). Launch with `-f net10.0`; both runtimes are still benchmarked in one run.
- Sample API responses ship as **embedded resources** (`SampleData/*.json`) — the repo has no recorded cassettes, so these are hand-authored to Google's response shapes and exercise the custom converters.
- `InternalsVisibleTo "GoogleMapsApi.Benchmarks"` lets the benchmark call the internal serializer options — **not a public-API change** (`PublicAPI.*.txt` untouched), same pattern the Test project uses.
- New **`benchmarks.yml`** workflow: manual `workflow_dispatch` only (benchmarks are noisy/slow), uploads results as an artifact. It does **not** post to PRs or gate them.

## Sample results (Apple M3 Pro / Arm64 — local, not CI)

URL generation: Geocoding **281 ns** / Directions **371 ns** / StaticMap **272 ns** (.NET 10), ~1–2.6 KB allocated.
Deserialization: Geocoding **8.6 µs** / Directions **7.1 µs** / DistanceMatrix **3.1 µs** (.NET 10).
.NET 10 is ~15–30% faster than .NET 8 across the board with identical allocations.

> CI runs on `ubuntu-latest` x64, so absolute numbers there will differ — the cross-runtime ratios and allocation figures are the useful signal.

## Run locally

```bash
dotnet run -c Release -f net10.0 --project benchmarks/GoogleMapsApi.Benchmarks
dotnet run -c Release -f net10.0 --project benchmarks/GoogleMapsApi.Benchmarks -- --filter '*UrlGeneration*'
```
