### PR TITLE
test: prove Polly resilience handler retries Google's HTTP 429

### DIFF
--- a/.agents/dependency-injection.md
+++ b/.agents/dependency-injection.md
@@ -35,6 +35,31 @@ into your services and call `maps.Geocode.QueryAsync(...)`, etc.
 - **Ambient key is per-request fill, not global state** — see the ambient-key section in
   [`architecture.md`](architecture.md).
 
+## Resilience (Polly)
+
+Because `AddGoogleMaps` returns an `IHttpClientBuilder`, resilience is opt-in chaining — the core
+library takes **no** dependency on Polly. Add the standard handler from
+`Microsoft.Extensions.Http.Resilience`:
+
+```csharp
+services.AddGoogleMaps(o => o.ApiKey = "…")
+        .AddStandardResilienceHandler();
+```
+
+Tuning for Google's APIs:
+
+- The stock handler's retry **and** circuit-breaker strategies already treat **HTTP 429** (Google's
+  throttling response), 408, 5xx, `HttpRequestException`, and timeouts as transient, and honor
+  `Retry-After`. So 429 backoff works out of the box — no custom `ShouldHandle` needed.
+- Defaults: 3 retries, exponential backoff, ~2s base delay, 30s total request timeout, 10% failure-
+  ratio circuit breaker. Override via `AddStandardResilienceHandler(options => …)`.
+- Maps requests are reads, so the default "retry all methods" is fine. If you ever proxy writes
+  through the same client, scope retries with `options.Retry.DisableForUnsafeHttpMethods()`.
+- Regression-tested in `GoogleMapsApi.Extensions.DependencyInjection.Test/ResilienceTests.cs`
+  (429 → retry → 200, hermetic).
+
+See [Build resilient HTTP apps](https://learn.microsoft.com/dotnet/core/resilience/http-resilience).
+
 ## Versioning
 
 Core + DI packages are versioned in **lockstep** from the same `v*` git tag (MinVer), and the DI package

--- a/GoogleMapsApi.Extensions.DependencyInjection.Test/GoogleMapsApi.Extensions.DependencyInjection.Test.csproj
+++ b/GoogleMapsApi.Extensions.DependencyInjection.Test/GoogleMapsApi.Extensions.DependencyInjection.Test.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="JunitXml.TestLogger" Version="*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.7.0" />
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.14.0">

--- a/GoogleMapsApi.Extensions.DependencyInjection.Test/ResilienceTests.cs
+++ b/GoogleMapsApi.Extensions.DependencyInjection.Test/ResilienceTests.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using GoogleMapsApi.Entities.Geocoding.Request;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using Polly;
+
+namespace GoogleMapsApi.Extensions.DependencyInjection.Test
+{
+    /// <summary>
+    /// Proves that the <see cref="IHttpClientBuilder"/> returned by <c>AddGoogleMaps</c> composes with
+    /// <c>AddStandardResilienceHandler()</c> from <c>Microsoft.Extensions.Http.Resilience</c>, and that
+    /// the standard handler retries Google's HTTP 429 (throttling) response. Hermetic — no live calls.
+    /// </summary>
+    [TestFixture]
+    public class ResilienceTests
+    {
+        private const string OkGeocodingJson = "{\"status\":\"OK\",\"results\":[]}";
+
+        [Test]
+        public async Task AddStandardResilienceHandler_RetriesAfter429_ThenSucceeds()
+        {
+            var handler = new SequencedHandler(HttpStatusCode.TooManyRequests, HttpStatusCode.OK);
+            var services = new ServiceCollection();
+            services.AddGoogleMaps(o => o.ApiKey = "k")
+                    .ConfigurePrimaryHttpMessageHandler(() => handler)
+                    .AddStandardResilienceHandler(options =>
+                    {
+                        options.Retry.Delay = TimeSpan.Zero;
+                        options.Retry.UseJitter = false;
+                        options.Retry.BackoffType = DelayBackoffType.Constant;
+                    });
+
+            using var provider = services.BuildServiceProvider();
+            var client = provider.GetRequiredService<IGoogleMapsClient>();
+
+            await client.Geocode.QueryAsync(new GeocodingRequest { Address = "Pier 39" });
+
+            Assert.That(handler.SendCount, Is.EqualTo(2), "The 429 should be retried, producing a second request.");
+        }
+
+        [Test]
+        public void AddStandardResilienceHandler_ChainsOffEveryOverload()
+        {
+            var configuration = new ConfigurationBuilder().Build();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(new ServiceCollection().AddGoogleMaps().AddStandardResilienceHandler(), Is.Not.Null);
+                Assert.That(new ServiceCollection().AddGoogleMaps(o => o.ApiKey = "k").AddStandardResilienceHandler(), Is.Not.Null);
+                Assert.That(new ServiceCollection().AddGoogleMaps(configuration).AddStandardResilienceHandler(), Is.Not.Null);
+            });
+        }
+
+        /// <summary>
+        /// Returns each supplied status code on successive calls (the last one repeats), so a test can
+        /// model "429 then 200". <see cref="HttpStatusCode.OK"/> responses carry a valid geocoding body.
+        /// </summary>
+        private sealed class SequencedHandler : HttpMessageHandler
+        {
+            private readonly HttpStatusCode[] _statuses;
+
+            public SequencedHandler(params HttpStatusCode[] statuses)
+            {
+                _statuses = statuses;
+            }
+
+            public int SendCount { get; private set; }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var status = _statuses[Math.Min(SendCount, _statuses.Length - 1)];
+                SendCount++;
+
+                var response = new HttpResponseMessage(status);
+                if (status == HttpStatusCode.OK)
+                {
+                    response.Content = new StringContent(OkGeocodingJson);
+                }
+
+                return Task.FromResult(response);
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -241,8 +241,21 @@ public class GeocodingService(IGoogleMapsClient maps)
 ```
 
 `AddGoogleMaps` returns an `IHttpClientBuilder`, so you can chain resilience and other
-`HttpClient` configuration — e.g. `.AddStandardResilienceHandler()` from
-`Microsoft.Extensions.Http.Resilience`.
+`HttpClient` configuration. Google's APIs throttle with HTTP 429; rather than hand-rolling retries,
+add the standard Polly-backed resilience handler from `Microsoft.Extensions.Http.Resilience`:
+
+``` bash
+dotnet add package Microsoft.Extensions.Http.Resilience
+```
+
+``` C#
+services.AddGoogleMaps(options => options.ApiKey = "your-google-maps-api-key")
+        .AddStandardResilienceHandler();
+```
+
+The standard handler retries transient failures — including **HTTP 429 (throttling)**, 408, and
+5xx — with exponential backoff and a circuit breaker, so callers no longer need to wrap calls in
+retry logic.
 
 Prefer not to take the extra package? The core library still works with hand-wired DI:
 


### PR DESCRIPTION
## Summary

`AddGoogleMaps` already returns an `IHttpClientBuilder`, so `.AddStandardResilienceHandler()` from `Microsoft.Extensions.Http.Resilience` composes onto the Google Maps client without the core library taking any dependency on Polly. This PR proves that path with a regression test and documents it.

## Related issue

n/a

## Changes

- Add `GoogleMapsApi.Extensions.DependencyInjection.Test/ResilienceTests.cs`: a hermetic test proving the standard handler retries a 429 then succeeds (429 → retry → 200), plus a smoke test that it chains off every `AddGoogleMaps` overload.
- Reference `Microsoft.Extensions.Http.Resilience` 10.7.0 in the **test project only** (no new dependency on the core or DI library).
- Expand `README.md` and `.agents/dependency-injection.md` with the install step, chaining example, and a tuning note (429/408/5xx retried by default, `Retry-After` honored, `DisableForUnsafeHttpMethods()` for writes).

## Test plan

- `dotnet test` on the DI test project: 9/9 pass on net8.0 and net10.0 (7 existing + 2 new); the 429 test asserts the fake handler was invoked twice, proving the retry fired.

## Checklist

- [x] `dotnet format` has been run.
- [x] `dotnet test` passes locally (DI test project; no `GOOGLE_API_KEY` needed — tests are hermetic).
- [ ] Multi-framework build passes (netstandard2.0, net8.0, net10.0).
- [x] XML documentation updated if public API surface changed. (No public API change.)