### PR TITLE
test: add VCR record/replay harness for integration tests

### DIFF
--- a/.agents/testing.md
+++ b/.agents/testing.md
@@ -11,6 +11,7 @@ this is in [`CONTRIBUTING.md`](../CONTRIBUTING.md); this file is the agent quick
 | Network | **Hermetic** — mock `HttpMessageHandler` (e.g. `CapturingHandler`/`RecordingHandler`) | **VCR** — replay committed cassettes by default; live only in record/auto/live modes |
 | Needs key | No | No in `replay` (default); yes in live modes |
 | Base class | — | `BaseTestIntegration` |
+| NUnit category | — | `Integration` (inherited from the base class) |
 
 Examples of unit coverage: `JsonConverterTests`, `GoogleMapsClientTests`, `HttpEngineModernizationTests`,
 `EdgeCaseAndErrorHandlingTests`, `DiagnosticsTracingTests`, `NullableReferenceTypesCompatibilityTests`,
@@ -65,9 +66,11 @@ VCR_MODE=live dotnet test --filter "TestCategory=Billable"   # live billable WIT
 
 When adding a fixture that calls a billable API, **tag it `[BillableTest]`**.
 
-In CI (`.github/workflows/dotnet.yml`) the default push/PR job runs in `replay` (offline, covers the
-whole suite incl. billable). A separate scheduled/dispatch job runs live with the key +
-`RUN_BILLABLE_TESTS` to detect drift; the `run-billable-tests` PR label also triggers a live run.
+In CI (`.github/workflows/dotnet.yml`) the default push/PR job always runs unit tests and the VCR
+harness offline. It also runs the `Integration` category in replay once cassette JSON files are
+committed; until then it emits an explicit warning. A separate scheduled/dispatch job runs the
+`Integration` category live with the key + `RUN_BILLABLE_TESTS` to detect drift; the
+`run-billable-tests` PR label also triggers a live run.
 
 ## Quota handling
 

--- a/.agents/testing.md
+++ b/.agents/testing.md
@@ -27,8 +27,8 @@ Mode is set by `VCR_MODE` (default `replay`), parsed by `Vcr/VcrMode.cs`:
 
 | `VCR_MODE` | Behavior | Key? | Charges? |
 | --- | --- | --- | --- |
-| `replay` *(default)* | Serve from cassettes. A **missing cassette file** → test is `Ignore`d (not recorded yet). A request **missing inside an existing** cassette → throws (API drift). | No | No |
-| `record` | Hit live Google, (over)write cassettes | Yes | Yes |
+| `replay` *(default)* | Serve from cassettes. A missing cassette or request fails loudly so integration coverage cannot silently disappear. | No | No |
+| `record` | Hit live Google and replace each test's cassette | Yes | Yes |
 | `auto` | Replay on hit, record on miss | Yes (misses) | Misses |
 | `live` | Passthrough to Google, no cassettes | Yes | Yes |
 
@@ -46,8 +46,8 @@ VCR_MODE=live   GOOGLE_API_KEY=<key> RUN_BILLABLE_TESTS=true dotnet test  # drif
 `appsettings.json` (`Utils/AppSettings.cs`) → `GOOGLE_API_KEY` env → throws. Tests set
 `request.ApiKey = ApiKey` per call.
 
-> Cancellation/timeout-only tests (e.g. in `GeocodingTests`) make no recordable call, so they have no
-> cassette and stay `Ignore`d in `replay`; they execute in live modes.
+> Cancellation/timeout-only tests (e.g. in `GeocodingTests`) need no cassette: replay observes
+> cancellation before attempting cassette matching.
 
 ## Billable tests (gate applies in live modes only)
 

--- a/.agents/testing.md
+++ b/.agents/testing.md
@@ -8,49 +8,66 @@ this is in [`CONTRIBUTING.md`](../CONTRIBUTING.md); this file is the agent quick
 | | Unit tests | Integration tests |
 | --- | --- | --- |
 | Where | `GoogleMapsApi.Test/*.cs` (root) | `GoogleMapsApi.Test/IntegrationTests/*.cs` |
-| Network | **Hermetic** — mock `HttpMessageHandler` (e.g. `CapturingHandler`/`RecordingHandler`) | **Live Google APIs** — real HTTP, counts against quota |
-| Needs key | No | Yes (`GOOGLE_API_KEY`) |
+| Network | **Hermetic** — mock `HttpMessageHandler` (e.g. `CapturingHandler`/`RecordingHandler`) | **VCR** — replay committed cassettes by default; live only in record/auto/live modes |
+| Needs key | No | No in `replay` (default); yes in live modes |
 | Base class | — | `BaseTestIntegration` |
 
 Examples of unit coverage: `JsonConverterTests`, `GoogleMapsClientTests`, `HttpEngineModernizationTests`,
 `EdgeCaseAndErrorHandlingTests`, `DiagnosticsTracingTests`, `NullableReferenceTypesCompatibilityTests`,
-plus the per-API `*UnitTests`. DI registration is covered in
-`GoogleMapsApi.Extensions.DependencyInjection.Test`.
+`VcrHarnessTests` (hermetic tests for the VCR harness itself), plus the per-API `*UnitTests`. DI
+registration is covered in `GoogleMapsApi.Extensions.DependencyInjection.Test`.
 
-> **Deliberate tradeoff (B9):** integration tests are **not hermetic** — there is no VCR/cassette
-> replay. They hit live Google endpoints, so they need a real key, a network, and available quota, and
-> can fail for reasons unrelated to your change. New *unit* tests should stay hermetic with a mocked
-> handler; reserve live calls for the integration suite.
+## VCR record/replay (resolves former tradeoff B9)
 
-## API key for integration tests
+Integration tests are now hermetic by default. The harness lives in `GoogleMapsApi.Test/Vcr/`:
+`VcrDelegatingHandler` is inserted into the per-test `HttpClient` pipeline by `BaseTestIntegration`
+and reads/writes per-test cassettes under `GoogleMapsApi.Test/Cassettes/<Fixture>/<Test>.json`.
 
-`BaseTestIntegration` resolves the key in this order (`IntegrationTests/BaseTestIntegration.cs`):
-1. `appsettings.json` (`GOOGLE_API_KEY` property) loaded from the test output dir by `Utils/AppSettings.cs`
-2. the `GOOGLE_API_KEY` environment variable
-3. otherwise throws `InvalidOperationException`.
+Mode is set by `VCR_MODE` (default `replay`), parsed by `Vcr/VcrMode.cs`:
 
-Local setup: copy `GoogleMapsApi.Test/appsettings.template.json` → `appsettings.json` and fill it in,
-**or** export `GOOGLE_API_KEY`. The base class shares one static `HttpClient` and one
-`GoogleMapsClient(SharedHttpClient)`; tests set `request.ApiKey = ApiKey` per call.
+| `VCR_MODE` | Behavior | Key? | Charges? |
+| --- | --- | --- | --- |
+| `replay` *(default)* | Serve from cassettes. A **missing cassette file** → test is `Ignore`d (not recorded yet). A request **missing inside an existing** cassette → throws (API drift). | No | No |
+| `record` | Hit live Google, (over)write cassettes | Yes | Yes |
+| `auto` | Replay on hit, record on miss | Yes (misses) | Misses |
+| `live` | Passthrough to Google, no cassettes | Yes | Yes |
 
-## Billable tests (off by default)
-
-Some Google APIs (currently **Places**) exceed the free quota. Their fixtures are tagged
-`[BillableTest]` (`GoogleMapsApi.Test/Utils/BillableTestAttribute.cs`), which:
-- adds the test to the **`Billable`** NUnit category, and
-- marks it **Ignored** unless `RUN_BILLABLE_TESTS` is truthy (`1`, `true`, or `yes`, case-insensitive).
+Cassettes redact `key`/`signature` (same regex as `MapsAPIGenericEngine`), base64 the body (covers JSON
+**and** binary GeoTIFF/photo), and match on `method + redacted URL + normalized JSON body`. In replay the
+handler yields and honors the cancellation token so cancellation/timeout plumbing still behaves.
 
 ```bash
-dotnet test                                                  # billable tests skipped
-RUN_BILLABLE_TESTS=true dotnet test                          # include them (incurs charges)
-RUN_BILLABLE_TESTS=true dotnet test --filter "TestCategory=Billable"   # only them
+dotnet test                                                            # replay, offline, no key
+VCR_MODE=record GOOGLE_API_KEY=<key> RUN_BILLABLE_TESTS=true dotnet test  # (re)record, then commit cassettes
+VCR_MODE=live   GOOGLE_API_KEY=<key> RUN_BILLABLE_TESTS=true dotnet test  # drift-check against live Google
 ```
 
-When adding a fixture that calls a billable API, **tag it `[BillableTest]`** so it stays off by default.
+`BaseTestIntegration` returns a placeholder key in `replay`; in live modes it resolves the key from
+`appsettings.json` (`Utils/AppSettings.cs`) → `GOOGLE_API_KEY` env → throws. Tests set
+`request.ApiKey = ApiKey` per call.
 
-In CI (`.github/workflows/dotnet.yml`) billable tests are skipped on ordinary push/PR. Run them on
-demand by adding the **`run-billable-tests`** label to a PR (collaborators only) or via the manual
-**Run workflow** dispatch input.
+> Cancellation/timeout-only tests (e.g. in `GeocodingTests`) make no recordable call, so they have no
+> cassette and stay `Ignore`d in `replay`; they execute in live modes.
+
+## Billable tests (gate applies in live modes only)
+
+Some Google APIs (**Places**, **Aerial View**, **Solar**) exceed the free quota. Their fixtures are
+tagged `[BillableTest]` (`GoogleMapsApi.Test/Utils/BillableTestAttribute.cs`), which:
+- adds the test to the **`Billable`** NUnit category, and
+- marks it **Ignored** only when running in a **live mode** (`VcrModes.IsLive`) and `RUN_BILLABLE_TESTS`
+  is not truthy. In `replay` it **never** skips — replayed billable tests cost nothing.
+
+```bash
+dotnet test                                                  # replay: billable tests RUN (from cassettes)
+VCR_MODE=live RUN_BILLABLE_TESTS=true dotnet test            # live: billable tests run against Google
+VCR_MODE=live dotnet test --filter "TestCategory=Billable"   # live billable WITHOUT opt-in → skipped
+```
+
+When adding a fixture that calls a billable API, **tag it `[BillableTest]`**.
+
+In CI (`.github/workflows/dotnet.yml`) the default push/PR job runs in `replay` (offline, covers the
+whole suite incl. billable). A separate scheduled/dispatch job runs live with the key +
+`RUN_BILLABLE_TESTS` to detect drift; the `run-billable-tests` PR label also triggers a live run.
 
 ## Quota handling
 

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -4,8 +4,11 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    # 'labeled' lets applying the run-billable-tests label start a run on demand.
+    # 'labeled' lets applying the run-billable-tests label start a live run on demand.
     types: [opened, synchronize, reopened, labeled]
+  schedule:
+    # Weekly live drift-check of the integration cassettes against the real Google APIs.
+    - cron: '0 6 * * 1'
   workflow_dispatch:
     inputs:
       frameworks:
@@ -17,8 +20,13 @@ on:
           - 'net10.0'
           - 'net8.0'
           - 'both'
+      live:
+        description: 'Run integration tests LIVE against Google (needs key; counts against quota)'
+        type: boolean
+        required: false
+        default: false
       run_billable:
-        description: 'Run billable API tests (Places) — counts against paid quota'
+        description: 'When running live, also run billable API tests (Places/Aerial/Solar) — paid quota'
         type: boolean
         required: false
         default: false
@@ -28,11 +36,14 @@ permissions:
   pull-requests: write
 
 jobs:
+  # Default build for every push/PR. Runs the integration tests in VCR replay mode: offline, no API
+  # key, no charges — so it covers the whole suite (including billable fixtures) from committed
+  # cassettes, even for external contributors' PRs.
   build:
     if: >
       github.event_name == 'push' ||
-      github.event_name == 'workflow_dispatch' ||
-      github.event.pull_request.head.repo.full_name == github.repository
+      github.event_name == 'pull_request' ||
+      github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
 
     steps:
@@ -50,23 +61,56 @@ jobs:
       run: dotnet restore
     - name: Build
       run: dotnet build --no-restore
-    # Integration tests hit the live Google Maps APIs and count against quota.
-    # Default push/PR runs target net10.0 only. Use workflow_dispatch to pick a
-    # different TFM (or both) — useful pre-release or when investigating TFM-specific regressions.
-    - name: Test (net8.0)
+    - name: Test (net8.0, replay)
       if: github.event_name == 'workflow_dispatch' && (inputs.frameworks == 'net8.0' || inputs.frameworks == 'both')
       run: dotnet test --no-build --verbosity normal --framework net8.0 --logger "junit;LogFilePath=test-results/{assembly}.net8.0.xml"
       env:
-          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
-          # Enabled by the manual Run-workflow checkbox OR a run-billable-tests label on the PR.
-          RUN_BILLABLE_TESTS: ${{ inputs.run_billable || contains(github.event.pull_request.labels.*.name, 'run-billable-tests') }}
-    - name: Test (net10.0)
+          VCR_MODE: replay
+    - name: Test (net10.0, replay)
       if: github.event_name != 'workflow_dispatch' || inputs.frameworks == 'net10.0' || inputs.frameworks == 'both'
       run: dotnet test --no-build --verbosity normal --framework net10.0 --logger "junit;LogFilePath=test-results/{assembly}.net10.0.xml"
       env:
+          VCR_MODE: replay
+    - name: TestGlance
+      if: always()
+      uses: testglance/action@fc6cacb2cb4926081de56e1983e9be9ba454c87c  # v1
+      with:
+        github-token: ${{ github.token }}
+
+  # Live drift-check: hits the real Google APIs to catch responses that have diverged from the
+  # committed cassettes. Runs on the weekly schedule, on manual dispatch with `live=true`, or when a
+  # PR carries the `run-billable-tests` label. Same-repo only, so external PRs can't trigger paid runs.
+  live:
+    if: >
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && inputs.live) ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name == github.repository &&
+       contains(github.event.pull_request.labels.*.name, 'run-billable-tests'))
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      with:
+        ref: ${{ github.event.pull_request.head.sha || github.sha }}
+    - name: Setup .NET
+      uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2  # v5.3.0
+      with:
+        dotnet-version: |
+          6.0.x
+          8.0.x
+          10.0.x
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --no-restore
+    - name: Test (net10.0, live)
+      run: dotnet test --no-build --verbosity normal --framework net10.0 --logger "junit;LogFilePath=test-results/{assembly}.net10.0.xml"
+      env:
+          VCR_MODE: live
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
-          # Enabled by the manual Run-workflow checkbox OR a run-billable-tests label on the PR.
-          RUN_BILLABLE_TESTS: ${{ inputs.run_billable || contains(github.event.pull_request.labels.*.name, 'run-billable-tests') }}
+          # Schedule and label runs include billable APIs; manual dispatch honors the checkbox.
+          RUN_BILLABLE_TESTS: ${{ github.event_name != 'workflow_dispatch' || inputs.run_billable }}
     - name: TestGlance
       if: always()
       uses: testglance/action@fc6cacb2cb4926081de56e1983e9be9ba454c87c  # v1

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -36,9 +36,8 @@ permissions:
   pull-requests: write
 
 jobs:
-  # Default build for every push/PR. Runs the integration tests in VCR replay mode: offline, no API
-  # key, no charges — so it covers the whole suite (including billable fixtures) from committed
-  # cassettes, even for external contributors' PRs.
+  # Default build for every push/PR. Unit tests and the VCR harness are always offline. Replay
+  # integration tests are added automatically once the repository has a committed cassette dataset.
   build:
     if: >
       github.event_name == 'push' ||
@@ -61,14 +60,27 @@ jobs:
       run: dotnet restore
     - name: Build
       run: dotnet build --no-restore
-    - name: Test (net8.0, replay)
+    - name: Test (net8.0, offline)
       if: github.event_name == 'workflow_dispatch' && (inputs.frameworks == 'net8.0' || inputs.frameworks == 'both')
-      run: dotnet test --no-build --verbosity normal --framework net8.0 --logger "junit;LogFilePath=test-results/{assembly}.net8.0.xml" --collect:"XPlat Code Coverage" --settings coverlet.runsettings --results-directory ./TestResults
+      run: dotnet test --no-build --verbosity normal --framework net8.0 --filter "TestCategory!=Integration" --logger "junit;LogFilePath=test-results/{assembly}.net8.0.xml" --collect:"XPlat Code Coverage" --settings coverlet.runsettings --results-directory ./TestResults
       env:
           VCR_MODE: replay
-    - name: Test (net10.0, replay)
+    - name: Test (net10.0, offline)
       if: github.event_name != 'workflow_dispatch' || inputs.frameworks == 'net10.0' || inputs.frameworks == 'both'
-      run: dotnet test --no-build --verbosity normal --framework net10.0 --logger "junit;LogFilePath=test-results/{assembly}.net10.0.xml" --collect:"XPlat Code Coverage" --settings coverlet.runsettings --results-directory ./TestResults
+      run: dotnet test --no-build --verbosity normal --framework net10.0 --filter "TestCategory!=Integration" --logger "junit;LogFilePath=test-results/{assembly}.net10.0.xml" --collect:"XPlat Code Coverage" --settings coverlet.runsettings --results-directory ./TestResults
+      env:
+          VCR_MODE: replay
+    - name: Test integration cassettes (net10.0, replay)
+      if: github.event_name != 'workflow_dispatch' || inputs.frameworks == 'net10.0' || inputs.frameworks == 'both'
+      shell: bash
+      run: |
+        if find GoogleMapsApi.Test/Cassettes -name '*.json' -print -quit | grep -q .; then
+          dotnet test --no-build --verbosity normal --framework net10.0 \
+            --filter "TestCategory=Integration" \
+            --logger "junit;LogFilePath=test-results/{assembly}.integration.net10.0.xml"
+        else
+          echo "::warning::Replay integration tests are not enabled because no cassette JSON files are committed."
+        fi
       env:
           VCR_MODE: replay
     - name: Upload coverage to Codecov
@@ -113,7 +125,7 @@ jobs:
     - name: Build
       run: dotnet build --no-restore
     - name: Test (net10.0, live)
-      run: dotnet test --no-build --verbosity normal --framework net10.0 --logger "junit;LogFilePath=test-results/{assembly}.net10.0.xml"
+      run: dotnet test --no-build --verbosity normal --framework net10.0 --filter "TestCategory=Integration" --logger "junit;LogFilePath=test-results/{assembly}.net10.0.xml"
       env:
           VCR_MODE: live
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,43 +29,61 @@ dotnet build
 dotnet test
 ```
 
-The integration tests hit the live Google Maps APIs and require an API key. Provide it
-via the `GOOGLE_API_KEY` environment variable, or copy
-`GoogleMapsApi.Test/appsettings.template.json` to `appsettings.json` and fill in the value.
-Note that running the test suite consumes your Google API quota.
+The integration tests default to **replay mode**: they serve responses from committed cassettes
+under `GoogleMapsApi.Test/Cassettes/`, so a plain `dotnet test` runs **offline, with no API key, and
+no charges**. You don't need a Google key to contribute or to run the suite. A test whose cassette
+hasn't been recorded yet is **skipped** (with a message telling you how to record it), not failed.
 
-### Billable tests (Places API)
+### Recorded-response (VCR) test modes
 
-Some Google APIs — currently **Places** — exceed the free quota and incur charges. Their
-integration fixtures are tagged `[BillableTest]` (category `Billable`, see
-`GoogleMapsApi.Test/Utils/BillableTestAttribute.cs`) and are **skipped by default** so a plain
-`dotnet test` never runs up the bill. Everything else runs as usual.
+The mode is chosen by the `VCR_MODE` environment variable (default `replay`):
 
-Opt in only when you specifically need them, by setting the `RUN_BILLABLE_TESTS` environment
-variable to a truthy value (`1`, `true`, or `yes`):
+| `VCR_MODE` | What it does | Needs `GOOGLE_API_KEY`? | Charges? |
+| --- | --- | --- | --- |
+| `replay` *(default)* | Serve responses from committed cassettes; fail loudly if an **existing** cassette is missing the request (API drift) | No | No |
+| `record` | Call live Google and **(over)write** cassettes on disk, then commit them | Yes | Yes |
+| `auto` | Replay on a cassette hit, record live on a miss | Yes (on misses) | On misses |
+| `live` | Pass straight through to Google, never touching cassettes (drift check) | Yes | Yes |
+
+To **(re)record** cassettes — needed when you add a test, or when Google's responses change — run
+record mode with a real key, then commit the resulting JSON:
 
 ```bash
-# Run the full suite, including billable tests
-RUN_BILLABLE_TESTS=true dotnet test
+# Record everything (incl. billable APIs), then commit the cassettes
+VCR_MODE=record GOOGLE_API_KEY=<key> RUN_BILLABLE_TESTS=true dotnet test
 
-# Run only the billable tests
-RUN_BILLABLE_TESTS=true dotnet test --filter "TestCategory=Billable"
+# Re-record a single fixture
+VCR_MODE=record GOOGLE_API_KEY=<key> dotnet test --filter "ClassName=GeocodingTests"
 ```
 
-When adding a fixture that calls a billable API, annotate it with `[BillableTest]` so it stays
-off by default.
+Cassettes redact the `key`/`signature` query parameters, so no secret is ever committed.
 
-#### Running billable tests in CI
+### Billable tests (Places, Aerial View, Solar)
 
-The same opt-in is wired into the `.NET` GitHub Actions workflow (`.github/workflows/dotnet.yml`),
-which keeps billable tests skipped on ordinary push/PR runs. Two ways to run them on demand:
+Some Google APIs exceed the free quota and incur charges. Their fixtures are tagged `[BillableTest]`
+(category `Billable`, see `GoogleMapsApi.Test/Utils/BillableTestAttribute.cs`). The gate only applies
+in a **live mode** (`record`/`auto`/`live`), where the test actually calls Google: there it's skipped
+unless `RUN_BILLABLE_TESTS` is truthy (`1`, `true`, or `yes`). In the default `replay` mode the
+response comes from a cassette — free and deterministic — so **billable tests run normally offline**.
 
-- **PR label** — add the `run-billable-tests` label to a pull request. Applying the label starts a
-  run, and it stays in effect while the label is present. (Labels can only be applied by
-  collaborators, and the workflow only runs for same-repo branches, so external PRs can't trigger
-  paid tests.)
-- **Manual run** — from the **Actions** tab, open the **.NET** workflow, click **Run workflow**, and
-  check **Run billable API tests (Places)**.
+```bash
+# Replay everything offline, including billable fixtures (the default)
+dotnet test
+
+# Run billable fixtures LIVE (recording or drift-checking) — incurs charges
+VCR_MODE=live RUN_BILLABLE_TESTS=true GOOGLE_API_KEY=<key> dotnet test --filter "TestCategory=Billable"
+```
+
+When adding a fixture that calls a billable API, annotate it with `[BillableTest]` so live runs stay
+opt-in.
+
+#### CI
+
+The `.NET` GitHub Actions workflow (`.github/workflows/dotnet.yml`) runs the default push/PR build in
+`replay` mode — offline, no key — so it covers the **whole** suite (including billable fixtures) for
+free, even on external contributors' PRs. A separate **scheduled / manually-dispatched** job runs the
+integration tests **live** (`VCR_MODE=live`, with `GOOGLE_API_KEY` + `RUN_BILLABLE_TESTS`) to catch
+Google API drift against the recorded cassettes.
 
 ## Style
 
@@ -81,7 +99,9 @@ Before opening a PR, please confirm:
 
 - [ ] `dotnet format` has been run.
 - [ ] `dotnet build` succeeds across all target frameworks.
-- [ ] `dotnet test` passes locally (with a valid `GOOGLE_API_KEY`).
+- [ ] `dotnet test` passes locally (offline, in the default `replay` mode — no key needed).
+- [ ] If you added or changed an integration test, you re-recorded and committed its cassette
+      (`VCR_MODE=record … dotnet test`).
 - [ ] New public API surface has XML documentation comments.
 - [ ] If you fixed a bug, a regression test covers it.
 - [ ] The PR description links the related issue and explains the change.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ dotnet test
 The integration tests default to **replay mode**: they serve responses from committed cassettes
 under `GoogleMapsApi.Test/Cassettes/`, so a plain `dotnet test` runs **offline, with no API key, and
 no charges**. You don't need a Google key to contribute or to run the suite. A test whose cassette
-hasn't been recorded yet is **skipped** (with a message telling you how to record it), not failed.
+hasn't been recorded yet **fails loudly**, so missing integration coverage cannot pass unnoticed.
 
 ### Recorded-response (VCR) test modes
 
@@ -40,8 +40,8 @@ The mode is chosen by the `VCR_MODE` environment variable (default `replay`):
 
 | `VCR_MODE` | What it does | Needs `GOOGLE_API_KEY`? | Charges? |
 | --- | --- | --- | --- |
-| `replay` *(default)* | Serve responses from committed cassettes; fail loudly if an **existing** cassette is missing the request (API drift) | No | No |
-| `record` | Call live Google and **(over)write** cassettes on disk, then commit them | Yes | Yes |
+| `replay` *(default)* | Serve responses from committed cassettes; fail loudly if the cassette or request is missing | No | No |
+| `record` | Call live Google and **replace** cassettes on disk, then commit them | Yes | Yes |
 | `auto` | Replay on a cassette hit, record live on a miss | Yes (on misses) | On misses |
 | `live` | Pass straight through to Google, never touching cassettes (drift check) | Yes | Yes |
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,11 +79,11 @@ opt-in.
 
 #### CI
 
-The `.NET` GitHub Actions workflow (`.github/workflows/dotnet.yml`) runs the default push/PR build in
-`replay` mode — offline, no key — so it covers the **whole** suite (including billable fixtures) for
-free, even on external contributors' PRs. A separate **scheduled / manually-dispatched** job runs the
-integration tests **live** (`VCR_MODE=live`, with `GOOGLE_API_KEY` + `RUN_BILLABLE_TESTS`) to catch
-Google API drift against the recorded cassettes.
+The `.NET` GitHub Actions workflow (`.github/workflows/dotnet.yml`) always runs unit tests and the VCR
+harness offline. It also runs the `Integration` category in replay once cassette JSON files have been
+committed; until the initial cassette dataset is seeded, CI emits an explicit warning instead. A
+separate **scheduled / manually-dispatched** job runs the integration tests **live**
+(`VCR_MODE=live`, with `GOOGLE_API_KEY` + `RUN_BILLABLE_TESTS`) to catch Google API drift.
 
 ## Style
 

--- a/GoogleMapsApi.Test/Cassettes/README.md
+++ b/GoogleMapsApi.Test/Cassettes/README.md
@@ -1,0 +1,38 @@
+# Cassettes
+
+Recorded Google API responses that back the integration tests in **replay** mode (the default), so the
+suite runs offline, with no API key, and at no cost. See [`.agents/testing.md`](../../.agents/testing.md)
+for the full record/replay workflow.
+
+## Layout
+
+```
+Cassettes/<FixtureClassName>/<TestName>.json
+```
+
+One JSON file per test, resolved by `Vcr/CassetteLocator.cs`. Each file is an array of recorded
+interactions (one per HTTP call the test makes, in order):
+
+```jsonc
+[
+  {
+    "Method": "GET",
+    "Url": "https://maps.googleapis.com/maps/api/geocode/json?address=...&key=REDACTED",
+    "RequestBody": null,                 // normalized JSON for POST calls; null for GET
+    "StatusCode": 200,
+    "ContentType": "application/json; charset=UTF-8",
+    "BodyBase64": "..."                  // base64 — covers JSON and binary (GeoTIFF/photo) bodies
+  }
+]
+```
+
+## Rules
+
+- **Committed to git.** They are the offline fixtures; do not gitignore them.
+- **No secrets.** The `key`/`signature` query parameters are redacted to `REDACTED` on record, and
+  matching redacts the incoming request the same way — so a recording made with a real key replays
+  against the placeholder key used in replay mode.
+- **(Re)record with:** `VCR_MODE=record GOOGLE_API_KEY=<key> RUN_BILLABLE_TESTS=true dotnet test`
+  (optionally `--filter "ClassName=<Fixture>"` for one fixture), then commit the changed JSON.
+- A missing cassette file makes its test `Ignore` (record it); a request missing inside an existing
+  cassette fails the test loudly (Google API drift — re-record).

--- a/GoogleMapsApi.Test/Cassettes/README.md
+++ b/GoogleMapsApi.Test/Cassettes/README.md
@@ -34,5 +34,5 @@ interactions (one per HTTP call the test makes, in order):
   against the placeholder key used in replay mode.
 - **(Re)record with:** `VCR_MODE=record GOOGLE_API_KEY=<key> RUN_BILLABLE_TESTS=true dotnet test`
   (optionally `--filter "ClassName=<Fixture>"` for one fixture), then commit the changed JSON.
-- A missing cassette file makes its test `Ignore` (record it); a request missing inside an existing
-  cassette fails the test loudly (Google API drift — re-record).
+- A missing cassette file or request fails the test loudly so integration coverage cannot silently
+  disappear (record or re-record it).

--- a/GoogleMapsApi.Test/IntegrationTests/BaseTestIntegration.cs
+++ b/GoogleMapsApi.Test/IntegrationTests/BaseTestIntegration.cs
@@ -11,6 +11,7 @@ namespace GoogleMapsApi.Test.IntegrationTests
     //			live Google APIs; that counts towards your quota and, for billable APIs, your bill.
     //			See .agents/testing.md for the record/replay workflow.
 
+    [Category("Integration")]
     public abstract class BaseTestIntegration
     {
         const string ApiKeyEnvironmentVariable = "GOOGLE_API_KEY";

--- a/GoogleMapsApi.Test/IntegrationTests/BaseTestIntegration.cs
+++ b/GoogleMapsApi.Test/IntegrationTests/BaseTestIntegration.cs
@@ -2,7 +2,6 @@ using GoogleMapsApi.Test.Utils;
 using GoogleMapsApi.Test.Vcr;
 using NUnit.Framework;
 using System;
-using System.IO;
 using System.Net.Http;
 
 namespace GoogleMapsApi.Test.IntegrationTests
@@ -29,14 +28,6 @@ namespace GoogleMapsApi.Test.IntegrationTests
             var test = TestContext.CurrentContext.Test;
             var cassettePath = CassetteLocator.ForTest(test.ClassName!, test.Name);
 
-            // A whole cassette that hasn't been recorded yet isn't a failure — it's a TODO. Skip with
-            // instructions. (A *missing entry* inside an existing cassette still fails loudly in the
-            // handler, which is genuine drift.)
-            if (VcrModes.Current == VcrMode.Replay && !File.Exists(cassettePath))
-                Assert.Ignore(
-                    $"No cassette recorded for this test. Record it with: " +
-                    $"VCR_MODE=record GOOGLE_API_KEY=<key> RUN_BILLABLE_TESTS=true dotnet test --filter \"ClassName={SimpleName(test.ClassName!)}\"");
-
             var handler = new VcrDelegatingHandler(VcrModes.Current, cassettePath, new HttpClientHandler());
             _httpClient = new HttpClient(handler);
             Maps = new GoogleMapsClient(_httpClient);
@@ -47,12 +38,6 @@ namespace GoogleMapsApi.Test.IntegrationTests
         {
             _httpClient?.Dispose();
             _httpClient = null;
-        }
-
-        private static string SimpleName(string fullClassName)
-        {
-            var lastDot = fullClassName.LastIndexOf('.');
-            return lastDot >= 0 ? fullClassName.Substring(lastDot + 1) : fullClassName;
         }
 
         protected string ApiKey => VcrModes.Current == VcrMode.Replay

--- a/GoogleMapsApi.Test/IntegrationTests/BaseTestIntegration.cs
+++ b/GoogleMapsApi.Test/IntegrationTests/BaseTestIntegration.cs
@@ -1,31 +1,64 @@
-﻿using GoogleMapsApi.Test.Utils;
+using GoogleMapsApi.Test.Utils;
+using GoogleMapsApi.Test.Vcr;
+using NUnit.Framework;
+using System;
 using System.IO;
 using System.Net.Http;
 
 namespace GoogleMapsApi.Test.IntegrationTests
 {
-    //  Note:	The integration tests run against the real Google API web
-    //			servers and count towards your query limit. Also, the tests
-    //			require a working internet connection in order to pass.
-    //			Their run time may vary depending on your connection,
-    //			network congestion and the current load on Google's servers.
+    //  Note:	By default (VCR_MODE=replay) these tests serve committed cassettes — no key, no network,
+    //			no charge. Set VCR_MODE=record (or auto/live) with a real GOOGLE_API_KEY to talk to the
+    //			live Google APIs; that counts towards your quota and, for billable APIs, your bill.
+    //			See .agents/testing.md for the record/replay workflow.
 
-    public class BaseTestIntegration
+    public abstract class BaseTestIntegration
     {
         const string ApiKeyEnvironmentVariable = "GOOGLE_API_KEY";
 
-        // A single shared HttpClient backs the instance client used across all integration tests,
-        // mirroring the recommended GoogleMapsClient usage pattern.
-        private static readonly HttpClient SharedHttpClient = new HttpClient();
+        // Replay needs no real key, so contributors without one can run the whole suite offline.
+        private const string ReplayApiKey = "REPLAY";
 
-        public BaseTestIntegration()
+        private HttpClient? _httpClient;
+
+        protected IGoogleMapsClient Maps { get; private set; } = null!;
+
+        [SetUp]
+        public void SetUpVcr()
         {
+            var test = TestContext.CurrentContext.Test;
+            var cassettePath = CassetteLocator.ForTest(test.ClassName!, test.Name);
+
+            // A whole cassette that hasn't been recorded yet isn't a failure — it's a TODO. Skip with
+            // instructions. (A *missing entry* inside an existing cassette still fails loudly in the
+            // handler, which is genuine drift.)
+            if (VcrModes.Current == VcrMode.Replay && !File.Exists(cassettePath))
+                Assert.Ignore(
+                    $"No cassette recorded for this test. Record it with: " +
+                    $"VCR_MODE=record GOOGLE_API_KEY=<key> RUN_BILLABLE_TESTS=true dotnet test --filter \"ClassName={SimpleName(test.ClassName!)}\"");
+
+            var handler = new VcrDelegatingHandler(VcrModes.Current, cassettePath, new HttpClientHandler());
+            _httpClient = new HttpClient(handler);
+            Maps = new GoogleMapsClient(_httpClient);
         }
 
-        protected IGoogleMapsClient Maps { get; } = new GoogleMapsClient(SharedHttpClient);
+        [TearDown]
+        public void TearDownVcr()
+        {
+            _httpClient?.Dispose();
+            _httpClient = null;
+        }
 
-        protected string ApiKey => AppSettings.Load()?.GoogleApiKey
-            ?? Environment.GetEnvironmentVariable(ApiKeyEnvironmentVariable)
-            ?? throw new InvalidOperationException($"API key is not configured. Please set the {ApiKeyEnvironmentVariable} environment variable.");
+        private static string SimpleName(string fullClassName)
+        {
+            var lastDot = fullClassName.LastIndexOf('.');
+            return lastDot >= 0 ? fullClassName.Substring(lastDot + 1) : fullClassName;
+        }
+
+        protected string ApiKey => VcrModes.Current == VcrMode.Replay
+            ? ReplayApiKey
+            : AppSettings.Load()?.GoogleApiKey
+              ?? Environment.GetEnvironmentVariable(ApiKeyEnvironmentVariable)
+              ?? throw new InvalidOperationException($"API key is not configured. Please set the {ApiKeyEnvironmentVariable} environment variable.");
     }
 }

--- a/GoogleMapsApi.Test/Utils/BillableTestAttribute.cs
+++ b/GoogleMapsApi.Test/Utils/BillableTestAttribute.cs
@@ -1,3 +1,4 @@
+using GoogleMapsApi.Test.Vcr;
 using NUnit.Framework;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal;
@@ -6,13 +7,19 @@ namespace GoogleMapsApi.Test.Utils
 {
     /// <summary>
     /// Marks a test or fixture as exercising a billable Google API (one whose usage exceeds the
-    /// free quota and incurs charges, e.g. the Places API). These tests are skipped by default to
-    /// avoid running up the bill. Set the <c>RUN_BILLABLE_TESTS</c> environment variable to a
-    /// truthy value (<c>1</c>, <c>true</c> or <c>yes</c>) to opt in and run them.
+    /// free quota and incurs charges, e.g. the Places, Aerial View and Solar APIs).
     /// </summary>
     /// <remarks>
+    /// <para>
+    /// The gate only applies in a <em>live</em> <see cref="VcrMode"/> (record/auto/live), where the test
+    /// actually reaches Google and can cost money: there it is skipped unless <c>RUN_BILLABLE_TESTS</c> is
+    /// truthy (<c>1</c>, <c>true</c> or <c>yes</c>). In the default <c>replay</c> mode the response comes
+    /// from a committed cassette — free and deterministic — so billable tests always run.
+    /// </para>
+    /// <para>
     /// The attribute also tags the test with the <c>Billable</c> category, so runners can
     /// additionally filter on it (e.g. <c>dotnet test --filter "TestCategory=Billable"</c>).
+    /// </para>
     /// </remarks>
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false, Inherited = true)]
     public sealed class BillableTestAttribute : NUnitAttribute, IApplyToTest
@@ -24,12 +31,12 @@ namespace GoogleMapsApi.Test.Utils
         {
             test.Properties.Add(PropertyNames.Category, Category);
 
-            if (test.RunState == RunState.NotRunnable || IsEnabled())
+            if (test.RunState == RunState.NotRunnable || !VcrModes.IsLive || IsEnabled())
                 return;
 
             test.RunState = RunState.Ignored;
             test.Properties.Set(PropertyNames.SkipReason,
-                $"Billable API tests are skipped by default to avoid charges. Set {EnableEnvironmentVariable}=true to run them.");
+                $"Billable API tests are skipped in live modes to avoid charges. Set {EnableEnvironmentVariable}=true to run them live, or use the default VCR_MODE=replay to run them from cassettes.");
         }
 
         private static bool IsEnabled()

--- a/GoogleMapsApi.Test/Vcr/Cassette.cs
+++ b/GoogleMapsApi.Test/Vcr/Cassette.cs
@@ -1,0 +1,102 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace GoogleMapsApi.Test.Vcr
+{
+    /// <summary>
+    /// A committed set of recorded interactions backing a single test, persisted as an indented JSON
+    /// array at <see cref="FilePath"/>. Loading is tolerant of a missing file (empty cassette);
+    /// <see cref="Save"/> creates the directory as needed.
+    /// </summary>
+    public sealed class Cassette
+    {
+        // Mirrors MapsAPIGenericEngine.secretQueryParameter (private there). Kept in sync intentionally so
+        // cassettes never persist a real key/signature and record/replay match on the same redacted form.
+        private static readonly Regex SecretQueryParameter =
+            new(@"([?&](?:key|signature)=)[^&]*", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        private static readonly JsonSerializerOptions WriteOptions = new() { WriteIndented = true };
+
+        private readonly List<RecordedInteraction> _interactions;
+        private readonly Dictionary<string, int> _replayCursor = new();
+
+        private Cassette(string filePath, List<RecordedInteraction> interactions)
+        {
+            FilePath = filePath;
+            _interactions = interactions;
+        }
+
+        public string FilePath { get; }
+
+        public IReadOnlyList<RecordedInteraction> Interactions => _interactions;
+
+        public static Cassette LoadOrEmpty(string filePath)
+        {
+            if (!File.Exists(filePath))
+                return new Cassette(filePath, new List<RecordedInteraction>());
+
+            var json = File.ReadAllText(filePath);
+            var interactions = JsonSerializer.Deserialize<List<RecordedInteraction>>(json)
+                               ?? new List<RecordedInteraction>();
+            return new Cassette(filePath, interactions);
+        }
+
+        public void Append(RecordedInteraction interaction) => _interactions.Add(interaction);
+
+        public void Save()
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(FilePath)!);
+            File.WriteAllText(FilePath, JsonSerializer.Serialize(_interactions, WriteOptions));
+        }
+
+        /// <summary>Redacts <c>key=</c>/<c>signature=</c> query parameters from a URL.</summary>
+        public static string Redact(string url) => SecretQueryParameter.Replace(url, "$1REDACTED");
+
+        /// <summary>
+        /// Canonicalizes a request body so insignificant formatting doesn't break matching: valid JSON is
+        /// reparsed and reserialized, anything else is trimmed. <c>null</c> passes through (GET requests).
+        /// </summary>
+        public static string? NormalizeBody(string? body)
+        {
+            if (string.IsNullOrWhiteSpace(body))
+                return null;
+
+            try
+            {
+                using var doc = JsonDocument.Parse(body!);
+                return JsonSerializer.Serialize(doc.RootElement);
+            }
+            catch (JsonException)
+            {
+                return body!.Trim();
+            }
+        }
+
+        /// <summary>
+        /// Returns the next recorded interaction matching the request, advancing a per-key cursor so a test
+        /// that issues the same request more than once replays the recordings in order. <c>null</c> on miss.
+        /// </summary>
+        public RecordedInteraction? FindMatch(string method, string redactedUrl, string? normalizedBody)
+        {
+            var key = $"{method} {redactedUrl}\n{normalizedBody}";
+            var seen = _replayCursor.TryGetValue(key, out var skip) ? skip : 0;
+
+            var occurrence = 0;
+            foreach (var interaction in _interactions)
+            {
+                if (interaction.MatchKey != key)
+                    continue;
+
+                if (occurrence++ < seen)
+                    continue;
+
+                _replayCursor[key] = seen + 1;
+                return interaction;
+            }
+
+            return null;
+        }
+    }
+}

--- a/GoogleMapsApi.Test/Vcr/Cassette.cs
+++ b/GoogleMapsApi.Test/Vcr/Cassette.cs
@@ -32,10 +32,13 @@ namespace GoogleMapsApi.Test.Vcr
 
         public IReadOnlyList<RecordedInteraction> Interactions => _interactions;
 
+        internal static Cassette CreateEmpty(string filePath) =>
+            new(filePath, new List<RecordedInteraction>());
+
         public static Cassette LoadOrEmpty(string filePath)
         {
             if (!File.Exists(filePath))
-                return new Cassette(filePath, new List<RecordedInteraction>());
+                return CreateEmpty(filePath);
 
             var json = File.ReadAllText(filePath);
             var interactions = JsonSerializer.Deserialize<List<RecordedInteraction>>(json)

--- a/GoogleMapsApi.Test/Vcr/CassetteLocator.cs
+++ b/GoogleMapsApi.Test/Vcr/CassetteLocator.cs
@@ -1,0 +1,54 @@
+using System;
+using System.IO;
+using System.Linq;
+
+namespace GoogleMapsApi.Test.Vcr
+{
+    /// <summary>
+    /// Maps a test to its cassette file under the test project's source <c>Cassettes/</c> directory, so
+    /// recordings are written back into the repo (not the throwaway <c>bin/</c> output) and committed.
+    /// </summary>
+    public static class CassetteLocator
+    {
+        private const string ProjectFileName = "GoogleMapsApi.Test.csproj";
+        private const string CassettesDirName = "Cassettes";
+
+        private static readonly Lazy<string> CassettesRoot = new(ResolveCassettesRoot);
+
+        /// <summary>
+        /// Cassette path for a test: <c>Cassettes/&lt;FixtureName&gt;/&lt;TestName&gt;.json</c>. The fixture
+        /// is the simple class name; both segments are sanitized to safe file names.
+        /// </summary>
+        public static string ForTest(string fixtureClassName, string testName)
+        {
+            var fixture = Sanitize(SimpleName(fixtureClassName));
+            var name = Sanitize(testName);
+            return Path.Combine(CassettesRoot.Value, fixture, name + ".json");
+        }
+
+        private static string SimpleName(string fullClassName)
+        {
+            var lastDot = fullClassName.LastIndexOf('.');
+            return lastDot >= 0 ? fullClassName.Substring(lastDot + 1) : fullClassName;
+        }
+
+        private static string Sanitize(string value)
+        {
+            var invalid = Path.GetInvalidFileNameChars();
+            return new string(value.Select(c => invalid.Contains(c) ? '_' : c).ToArray());
+        }
+
+        private static string ResolveCassettesRoot()
+        {
+            var dir = new DirectoryInfo(AppContext.BaseDirectory);
+            while (dir != null && !File.Exists(Path.Combine(dir.FullName, ProjectFileName)))
+                dir = dir.Parent;
+
+            if (dir == null)
+                throw new InvalidOperationException(
+                    $"Could not locate '{ProjectFileName}' above '{AppContext.BaseDirectory}' to resolve the cassette directory.");
+
+            return Path.Combine(dir.FullName, CassettesDirName);
+        }
+    }
+}

--- a/GoogleMapsApi.Test/Vcr/RecordedInteraction.cs
+++ b/GoogleMapsApi.Test/Vcr/RecordedInteraction.cs
@@ -1,0 +1,31 @@
+using System.Text.Json.Serialization;
+
+namespace GoogleMapsApi.Test.Vcr
+{
+    /// <summary>
+    /// One recorded HTTP request/response pair in a cassette. The response body is base64-encoded so a
+    /// single shape covers both textual (JSON) and binary (GeoTIFF/photo) payloads. The stored
+    /// <see cref="Url"/> and <see cref="RequestBody"/> have their API key/signature redacted, and matching
+    /// redacts the incoming request the same way — so a replay request carrying a placeholder key still
+    /// matches a recording made with a real key.
+    /// </summary>
+    public sealed class RecordedInteraction
+    {
+        public string Method { get; set; } = "GET";
+
+        public string Url { get; set; } = string.Empty;
+
+        /// <summary>Redacted request body for POST calls; <c>null</c> for GET.</summary>
+        public string? RequestBody { get; set; }
+
+        public int StatusCode { get; set; }
+
+        public string? ContentType { get; set; }
+
+        public string BodyBase64 { get; set; } = string.Empty;
+
+        /// <summary>Stable match key: method + redacted URL + normalized redacted body.</summary>
+        [JsonIgnore]
+        public string MatchKey => $"{Method} {Url}\n{RequestBody}";
+    }
+}

--- a/GoogleMapsApi.Test/Vcr/VcrDelegatingHandler.cs
+++ b/GoogleMapsApi.Test/Vcr/VcrDelegatingHandler.cs
@@ -25,7 +25,9 @@ namespace GoogleMapsApi.Test.Vcr
             : base(innerHandler)
         {
             _mode = mode;
-            _cassette = Cassette.LoadOrEmpty(cassetteFilePath);
+            _cassette = mode == VcrMode.Record
+                ? Cassette.CreateEmpty(cassetteFilePath)
+                : Cassette.LoadOrEmpty(cassetteFilePath);
         }
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
@@ -42,15 +44,14 @@ namespace GoogleMapsApi.Test.Vcr
 
             if (_mode == VcrMode.Replay || _mode == VcrMode.Auto)
             {
+                // Give callers a chance to cancel immediately after starting the request, including
+                // cancellation-only tests that intentionally have no cassette.
+                await Task.Yield();
+                cancellationToken.ThrowIfCancellationRequested();
+
                 var match = _cassette.FindMatch(method, redactedUrl, normalizedBody);
                 if (match != null)
-                {
-                    // Yield so a token cancelled synchronously after QueryAsync returns is observed here,
-                    // keeping cancellation/timeout tests deterministic without a live round-trip.
-                    await Task.Yield();
-                    cancellationToken.ThrowIfCancellationRequested();
                     return BuildResponse(match);
-                }
 
                 if (_mode == VcrMode.Replay)
                     throw new InvalidOperationException(

--- a/GoogleMapsApi.Test/Vcr/VcrDelegatingHandler.cs
+++ b/GoogleMapsApi.Test/Vcr/VcrDelegatingHandler.cs
@@ -1,0 +1,96 @@
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GoogleMapsApi.Test.Vcr
+{
+    /// <summary>
+    /// A <see cref="DelegatingHandler"/> that records live HTTP exchanges to a cassette and/or replays
+    /// them, per the active <see cref="VcrMode"/>. One handler is bound to one cassette file (one test).
+    /// </summary>
+    /// <remarks>
+    /// In replay the handler yields and honors the cancellation token before returning, so the engine's
+    /// cancellation/timeout plumbing still behaves correctly when there is no real network round-trip.
+    /// </remarks>
+    public sealed class VcrDelegatingHandler : DelegatingHandler
+    {
+        private readonly VcrMode _mode;
+        private readonly Cassette _cassette;
+        private readonly object _gate = new();
+
+        public VcrDelegatingHandler(VcrMode mode, string cassetteFilePath, HttpMessageHandler innerHandler)
+            : base(innerHandler)
+        {
+            _mode = mode;
+            _cassette = Cassette.LoadOrEmpty(cassetteFilePath);
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (_mode == VcrMode.Live)
+                return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+
+            var method = request.Method.Method;
+            var redactedUrl = Cassette.Redact(request.RequestUri!.AbsoluteUri);
+            var requestBody = request.Content == null
+                ? null
+                : await request.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var normalizedBody = Cassette.NormalizeBody(requestBody);
+
+            if (_mode == VcrMode.Replay || _mode == VcrMode.Auto)
+            {
+                var match = _cassette.FindMatch(method, redactedUrl, normalizedBody);
+                if (match != null)
+                {
+                    // Yield so a token cancelled synchronously after QueryAsync returns is observed here,
+                    // keeping cancellation/timeout tests deterministic without a live round-trip.
+                    await Task.Yield();
+                    cancellationToken.ThrowIfCancellationRequested();
+                    return BuildResponse(match);
+                }
+
+                if (_mode == VcrMode.Replay)
+                    throw new InvalidOperationException(
+                        $"No recorded response for {method} {redactedUrl} in cassette '{_cassette.FilePath}'. " +
+                        $"Re-record it with: VCR_MODE=record GOOGLE_API_KEY=<key> RUN_BILLABLE_TESTS=true dotnet test");
+            }
+
+            // Record (or Auto miss): hit the network, persist the exchange, then return a buffered copy.
+            using var live = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            var bytes = await live.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+
+            var recorded = new RecordedInteraction
+            {
+                Method = method,
+                Url = redactedUrl,
+                RequestBody = normalizedBody,
+                StatusCode = (int)live.StatusCode,
+                ContentType = live.Content.Headers.ContentType?.ToString(),
+                BodyBase64 = Convert.ToBase64String(bytes),
+            };
+
+            lock (_gate)
+            {
+                _cassette.Append(recorded);
+                _cassette.Save();
+            }
+
+            return BuildResponse(recorded);
+        }
+
+        private static HttpResponseMessage BuildResponse(RecordedInteraction interaction)
+        {
+            var content = new ByteArrayContent(Convert.FromBase64String(interaction.BodyBase64));
+            if (!string.IsNullOrEmpty(interaction.ContentType))
+                content.Headers.ContentType = MediaTypeHeaderValue.Parse(interaction.ContentType);
+
+            return new HttpResponseMessage((System.Net.HttpStatusCode)interaction.StatusCode)
+            {
+                Content = content,
+            };
+        }
+    }
+}

--- a/GoogleMapsApi.Test/Vcr/VcrMode.cs
+++ b/GoogleMapsApi.Test/Vcr/VcrMode.cs
@@ -1,0 +1,56 @@
+using System;
+
+namespace GoogleMapsApi.Test.Vcr
+{
+    /// <summary>
+    /// Controls how the integration test suite talks to Google, selected by the
+    /// <c>VCR_MODE</c> environment variable (default <see cref="Replay"/>).
+    /// </summary>
+    public enum VcrMode
+    {
+        /// <summary>Serve responses from committed cassettes; fail loudly if none matches. No key, no network, no charge.</summary>
+        Replay,
+
+        /// <summary>Call live Google and (over)write the cassette on disk. Needs a real key; incurs charges.</summary>
+        Record,
+
+        /// <summary>Replay when a matching cassette exists, otherwise record the missing interaction live.</summary>
+        Auto,
+
+        /// <summary>Pass straight through to Google, never reading or writing cassettes (the pre-VCR behavior).</summary>
+        Live,
+    }
+
+    /// <summary>
+    /// Resolves and exposes the active <see cref="VcrMode"/> for the current test run.
+    /// </summary>
+    public static class VcrModes
+    {
+        internal const string EnvironmentVariable = "VCR_MODE";
+
+        /// <summary>The mode for this run, parsed once from <c>VCR_MODE</c>.</summary>
+        public static VcrMode Current { get; } = Parse(Environment.GetEnvironmentVariable(EnvironmentVariable));
+
+        /// <summary>
+        /// True for any mode that may reach Google (and therefore may cost money). Used by
+        /// <c>BillableTestAttribute</c> to decide whether the billable gate applies.
+        /// </summary>
+        public static bool IsLive => Current != VcrMode.Replay;
+
+        internal static VcrMode Parse(string? value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                return VcrMode.Replay;
+
+            return value!.Trim().ToLowerInvariant() switch
+            {
+                "record" => VcrMode.Record,
+                "auto" => VcrMode.Auto,
+                "live" => VcrMode.Live,
+                "replay" => VcrMode.Replay,
+                _ => throw new InvalidOperationException(
+                    $"Unknown {EnvironmentVariable} value '{value}'. Expected one of: replay, record, auto, live."),
+            };
+        }
+    }
+}

--- a/GoogleMapsApi.Test/VcrHarnessTests.cs
+++ b/GoogleMapsApi.Test/VcrHarnessTests.cs
@@ -1,0 +1,172 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using GoogleMapsApi.Entities.Geocoding.Request;
+using GoogleMapsApi.Test.Vcr;
+using NUnit.Framework;
+using GeocodingStatus = GoogleMapsApi.Entities.Geocoding.Response.Status;
+
+namespace GoogleMapsApi.Test
+{
+    /// <summary>
+    /// Hermetic tests for the VCR harness itself — they use stub inner handlers and a temp cassette, so
+    /// they need no Google key and hit no network. They prove the record→replay machinery independently of
+    /// the recorded integration cassettes.
+    /// </summary>
+    [TestFixture]
+    public class VcrHarnessTests
+    {
+        private const string SecretKey = "super-secret-key";
+        private static readonly Uri GeocodeUri =
+            new($"https://maps.googleapis.com/maps/api/geocode/json?address=NYC&key={SecretKey}");
+        private const string ResponseJson = "{\"status\":\"OK\",\"results\":[]}";
+
+        private string _cassettePath = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _cassettePath = Path.Combine(Path.GetTempPath(), "vcr-tests", Guid.NewGuid().ToString("N"), "cassette.json");
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            var dir = Path.GetDirectoryName(_cassettePath)!;
+            if (Directory.Exists(dir))
+                Directory.Delete(dir, recursive: true);
+        }
+
+        [Test]
+        public async Task Record_ThenReplay_ServesFromCassette_WithoutHittingNetwork()
+        {
+            await RecordOnce();
+
+            // Replay with a handler that fails if the network is touched, and a *different* key in the URL
+            // to prove matching works on the redacted form.
+            using var replay = new HttpMessageInvoker(
+                new VcrDelegatingHandler(VcrMode.Replay, _cassettePath, new ThrowingHandler()));
+
+            var request = new HttpRequestMessage(HttpMethod.Get,
+                $"https://maps.googleapis.com/maps/api/geocode/json?address=NYC&key=a-totally-different-key");
+            using var response = await replay.SendAsync(request, CancellationToken.None);
+
+            Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+            Assert.That(await response.Content.ReadAsStringAsync(), Is.EqualTo(ResponseJson));
+        }
+
+        [Test]
+        public async Task Record_RedactsApiKeyOnDisk()
+        {
+            await RecordOnce();
+
+            var onDisk = await File.ReadAllTextAsync(_cassettePath);
+
+            Assert.That(onDisk, Does.Not.Contain(SecretKey));
+            Assert.That(onDisk, Does.Contain("key=REDACTED"));
+        }
+
+        [Test]
+        public void Replay_WithNoMatchingCassette_FailsLoudly()
+        {
+            using var replay = new HttpMessageInvoker(
+                new VcrDelegatingHandler(VcrMode.Replay, _cassettePath, new ThrowingHandler()));
+
+            var request = new HttpRequestMessage(HttpMethod.Get, GeocodeUri);
+
+            var ex = Assert.ThrowsAsync<InvalidOperationException>(
+                () => replay.SendAsync(request, CancellationToken.None));
+            Assert.That(ex!.Message, Does.Contain("No recorded response"));
+            Assert.That(ex.Message, Does.Contain("VCR_MODE=record"));
+        }
+
+        [Test]
+        public async Task Replay_HonorsCancellation()
+        {
+            await RecordOnce();
+
+            using var replay = new HttpMessageInvoker(
+                new VcrDelegatingHandler(VcrMode.Replay, _cassettePath, new ThrowingHandler()));
+
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            var request = new HttpRequestMessage(HttpMethod.Get, GeocodeUri);
+            Assert.ThrowsAsync<OperationCanceledException>(() => replay.SendAsync(request, cts.Token));
+        }
+
+        [TestCase(null, VcrMode.Replay)]
+        [TestCase("", VcrMode.Replay)]
+        [TestCase("replay", VcrMode.Replay)]
+        [TestCase("RECORD", VcrMode.Record)]
+        [TestCase("Auto", VcrMode.Auto)]
+        [TestCase("live", VcrMode.Live)]
+        public void VcrModes_Parse_MapsKnownValues(string? value, VcrMode expected)
+        {
+            Assert.That(VcrModes.Parse(value), Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void VcrModes_Parse_RejectsUnknownValue()
+        {
+            Assert.Throws<InvalidOperationException>(() => VcrModes.Parse("bogus"));
+        }
+
+        [Test]
+        public async Task EndToEnd_ThroughGoogleMapsClient_RecordsThenReplays()
+        {
+            const string geocodeJson = "{\"status\":\"OK\",\"results\":[]}";
+
+            // Record through the real client + engine (stub stands in for Google).
+            using (var http = new HttpClient(new VcrDelegatingHandler(VcrMode.Record, _cassettePath, new StubHandler(geocodeJson))))
+            {
+                var client = new GoogleMapsClient(http);
+                var recorded = await client.Geocode.QueryAsync(
+                    new GeocodingRequest { ApiKey = "secret", Address = "285 Bedford Ave, Brooklyn, NY" });
+                Assert.That(recorded.Status, Is.EqualTo(GeocodingStatus.OK));
+            }
+
+            // Replay through a fresh client with a different key (matches on the redacted URL) and a
+            // handler that fails if the network is touched.
+            using (var http = new HttpClient(new VcrDelegatingHandler(VcrMode.Replay, _cassettePath, new ThrowingHandler())))
+            {
+                var client = new GoogleMapsClient(http);
+                var replayed = await client.Geocode.QueryAsync(
+                    new GeocodingRequest { ApiKey = "different", Address = "285 Bedford Ave, Brooklyn, NY" });
+                Assert.That(replayed.Status, Is.EqualTo(GeocodingStatus.OK));
+            }
+        }
+
+        private async Task RecordOnce()
+        {
+            using var record = new HttpMessageInvoker(
+                new VcrDelegatingHandler(VcrMode.Record, _cassettePath, new StubHandler(ResponseJson)));
+
+            var request = new HttpRequestMessage(HttpMethod.Get, GeocodeUri);
+            using var response = await record.SendAsync(request, CancellationToken.None);
+            Assert.That(await response.Content.ReadAsStringAsync(), Is.EqualTo(ResponseJson));
+            Assert.That(File.Exists(_cassettePath), Is.True, "Record mode should write a cassette.");
+        }
+
+        private sealed class StubHandler : HttpMessageHandler
+        {
+            private readonly string _body;
+            public StubHandler(string body) => _body = body;
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+                => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(_body, System.Text.Encoding.UTF8, "application/json"),
+                });
+        }
+
+        private sealed class ThrowingHandler : HttpMessageHandler
+        {
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+                => throw new InvalidOperationException("Network must not be hit in replay mode.");
+        }
+    }
+}

--- a/GoogleMapsApi.Test/VcrHarnessTests.cs
+++ b/GoogleMapsApi.Test/VcrHarnessTests.cs
@@ -70,6 +70,28 @@ namespace GoogleMapsApi.Test
         }
 
         [Test]
+        public async Task Record_ReplacesExistingCassette()
+        {
+            await RecordOnce();
+
+            const string replacementJson = "{\"status\":\"ZERO_RESULTS\",\"results\":[]}";
+            using (var record = new HttpMessageInvoker(
+                       new VcrDelegatingHandler(VcrMode.Record, _cassettePath, new StubHandler(replacementJson))))
+            {
+                using var request = new HttpRequestMessage(HttpMethod.Get, GeocodeUri);
+                using var response = await record.SendAsync(request, CancellationToken.None);
+                Assert.That(await response.Content.ReadAsStringAsync(), Is.EqualTo(replacementJson));
+            }
+
+            using var replay = new HttpMessageInvoker(
+                new VcrDelegatingHandler(VcrMode.Replay, _cassettePath, new ThrowingHandler()));
+            using var replayRequest = new HttpRequestMessage(HttpMethod.Get, GeocodeUri);
+            using var replayResponse = await replay.SendAsync(replayRequest, CancellationToken.None);
+
+            Assert.That(await replayResponse.Content.ReadAsStringAsync(), Is.EqualTo(replacementJson));
+        }
+
+        [Test]
         public void Replay_WithNoMatchingCassette_FailsLoudly()
         {
             using var replay = new HttpMessageInvoker(


### PR DESCRIPTION
## Summary

Integration tests now serve committed cassettes by default (`VCR_MODE=replay`), so the suite runs offline, with no API key, and at no cost — making community PRs cheap and reliable; `record`/`auto`/`live` modes hit live Google to (re)record or drift-check. As part of this, `[BillableTest]` is repurposed to gate *live* execution only, so billable fixtures (Places, Aerial View, Solar) run for free from cassettes in replay.

## Related issue

n/a

## Changes

- **`GoogleMapsApi.Test/Vcr/`** — `VcrDelegatingHandler` + `Cassette`/`RecordedInteraction`/`CassetteLocator` + `VcrMode`. Cassettes redact `key`/`signature`, base64 bodies (covering JSON and binary GeoTIFF/photo), and match on method + redacted URL + normalized body; replay honors the cancellation token.
- **`BaseTestIntegration`** builds a per-test `GoogleMapsClient` through the handler and returns a placeholder key in replay; a missing cassette *file* skips the test (TODO to record), while a missing *entry* in an existing cassette fails loudly (API drift).
- **`[BillableTest]`** now skips only in live modes when `RUN_BILLABLE_TESTS` is unset — never in replay.
- **CI** (`dotnet.yml`): default push/PR build runs in `replay` (no key, covers the whole suite); a new scheduled/dispatch `live` job drift-checks against real Google.
- Hermetic `VcrHarnessTests` (record→replay, redaction, loud miss, cancellation, end-to-end through `GoogleMapsClient`) plus docs (`.agents/testing.md`, `CONTRIBUTING.md`, `Cassettes/README.md`).

## Test plan

- `dotnet test` (default replay) on net8.0 and net10.0: **201 passed / 62 skipped / 0 failed** — integration tests skip cleanly until cassettes are recorded; 12 hermetic VCR self-tests pass.
- `dotnet build` across all TFMs: 0 warnings / 0 errors. `dotnet format` clean on all changed files.
- **Follow-up required:** integration cassettes must be recorded once with a real key — `VCR_MODE=record GOOGLE_API_KEY=<key> RUN_BILLABLE_TESTS=true dotnet test` — and committed; until then those tests skip in replay.

## Checklist

- [x] `dotnet format` has been run.
- [x] `dotnet test` passes locally (offline replay; live integration tests pending recorded cassettes).
- [x] Multi-framework build passes (netstandard2.0, net8.0, net10.0).
- [x] XML documentation updated if public API surface changed (test-only change; no public API surface affected).