### PR TITLE
ci: add Codecov coverage upload and badge

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -55,18 +55,26 @@ jobs:
     # different TFM (or both) — useful pre-release or when investigating TFM-specific regressions.
     - name: Test (net8.0)
       if: github.event_name == 'workflow_dispatch' && (inputs.frameworks == 'net8.0' || inputs.frameworks == 'both')
-      run: dotnet test --no-build --verbosity normal --framework net8.0 --logger "junit;LogFilePath=test-results/{assembly}.net8.0.xml"
+      run: dotnet test --no-build --verbosity normal --framework net8.0 --logger "junit;LogFilePath=test-results/{assembly}.net8.0.xml" --collect:"XPlat Code Coverage" --settings coverlet.runsettings --results-directory ./TestResults
       env:
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           # Enabled by the manual Run-workflow checkbox OR a run-billable-tests label on the PR.
           RUN_BILLABLE_TESTS: ${{ inputs.run_billable || contains(github.event.pull_request.labels.*.name, 'run-billable-tests') }}
     - name: Test (net10.0)
       if: github.event_name != 'workflow_dispatch' || inputs.frameworks == 'net10.0' || inputs.frameworks == 'both'
-      run: dotnet test --no-build --verbosity normal --framework net10.0 --logger "junit;LogFilePath=test-results/{assembly}.net10.0.xml"
+      run: dotnet test --no-build --verbosity normal --framework net10.0 --logger "junit;LogFilePath=test-results/{assembly}.net10.0.xml" --collect:"XPlat Code Coverage" --settings coverlet.runsettings --results-directory ./TestResults
       env:
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           # Enabled by the manual Run-workflow checkbox OR a run-billable-tests label on the PR.
           RUN_BILLABLE_TESTS: ${{ inputs.run_billable || contains(github.event.pull_request.labels.*.name, 'run-billable-tests') }}
+    - name: Upload coverage to Codecov
+      if: always()
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        directory: ./TestResults
+        fail_ci_if_error: false
+        verbose: true
     - name: TestGlance
       if: always()
       uses: testglance/action@fc6cacb2cb4926081de56e1983e9be9ba454c87c  # v1

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![NuGet Version](https://img.shields.io/nuget/v/GoogleMapsApi.svg)](https://www.nuget.org/packages/GoogleMapsApi/)
 [![Build Status](https://github.com/maximn/google-maps/actions/workflows/dotnet.yml/badge.svg)](https://github.com/maximn/google-maps/actions/workflows/dotnet.yml)
 [![CodeQL](https://github.com/maximn/google-maps/actions/workflows/codeql.yml/badge.svg)](https://github.com/maximn/google-maps/actions/workflows/codeql.yml)
+[![codecov](https://codecov.io/gh/maximn/google-maps/branch/master/graph/badge.svg)](https://codecov.io/gh/maximn/google-maps)
 [![OpenSSF Scorecard](https://img.shields.io/ossf-scorecard/github.com/maximn/google-maps?label=openssf%20scorecard)](https://scorecard.dev/viewer/?uri=github.com/maximn/google-maps)
 [![License: BSD-2-Clause](https://img.shields.io/badge/License-BSD_2--Clause-blue.svg)](LICENSE.md)
 [![.NET](https://img.shields.io/badge/.NET-net10.0%20%7C%20net8.0%20%7C%20netstandard2.0-512BD4)](https://dotnet.microsoft.com/)

--- a/coverlet.runsettings
+++ b/coverlet.runsettings
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat Code Coverage">
+        <Configuration>
+          <Format>cobertura</Format>
+          <!-- Only measure the shipped libraries, not test/sample/benchmark assemblies. -->
+          <Include>[GoogleMapsApi]*,[GoogleMapsApi.Extensions.DependencyInjection]*</Include>
+          <ExcludeByAttribute>Obsolete,GeneratedCodeAttribute,CompilerGeneratedAttribute</ExcludeByAttribute>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>


### PR DESCRIPTION
## Summary

Publish test coverage to Codecov so PR reviewers get an inline coverage heatmap, and add a coverage badge to the README. No new test packages were needed — `coverlet.collector` was already referenced in both test projects.

## Related issue

n/a

## Changes

- Collect Cobertura coverage in both CI test steps (net8.0/net10.0) and upload it via `codecov/codecov-action` (pinned to a commit SHA), running with `if: always()` so the heatmap uploads even on test failure.
- Add `coverlet.runsettings` scoping coverage to the shipped `GoogleMapsApi` and `GoogleMapsApi.Extensions.DependencyInjection` assemblies (excludes test/sample/benchmark code).
- Add a Codecov badge to the README badge block.

## Test plan

- Ran `dotnet test ... --collect:"XPlat Code Coverage" --settings coverlet.runsettings` locally; a `coverage.cobertura.xml` is produced and contains only the two shipped assemblies.

> [!IMPORTANT]
> Requires a `CODECOV_TOKEN` repository secret before the upload step works in CI; the badge renders after the first upload to `master`.

## Checklist

- [x] `dotnet format` has been run. <!-- no C# changed -->
- [x] `dotnet test` passes locally (with a valid `GOOGLE_API_KEY` for integration tests).
- [ ] Multi-framework build passes (netstandard2.0, net8.0, net10.0).
- [x] XML documentation updated if public API surface changed. <!-- no public API change -->