### PR TITLE
docs: add Polyglot Notebook samples per API surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Or via .NET CLI:
 dotnet add package GoogleMapsApi
 ```
 
-Looking for runnable examples? See [`samples/`](samples/) — console, ASP.NET Core minimal API, and Blazor Server.
+Looking for runnable examples? See [`samples/`](samples/) — console, ASP.NET Core minimal API, and Blazor Server — or the [interactive notebooks](samples/notebooks/) (one live, runnable `.dib` per API surface).
 
 # Quickstart
 

--- a/samples/README.md
+++ b/samples/README.md
@@ -13,4 +13,15 @@ All samples read the Google Maps API key from the `GOOGLE_API_KEY` environment v
 
 The **Minimal API** and **Generic Host** samples are the showcases for the [`GoogleMapsApi.Extensions.DependencyInjection`](../GoogleMapsApi.Extensions.DependencyInjection/) package — both register `IGoogleMapsClient` (backed by `IHttpClientFactory`) plus an ambient API key in one `AddGoogleMaps(...)` call, so individual requests don't repeat the key. They demonstrate the two ways to supply the key: Minimal API uses the `Action<GoogleMapsClientOptions>` overload, Generic Host binds it from configuration with the `IConfiguration` overload. The Console and Blazor samples use the core library directly — Blazor shows the manual `AddHttpClient<IGoogleMapsClient, GoogleMapsClient>()` registration when you'd rather not take the extra package.
 
+## Interactive notebooks
+
+Prefer to explore an API cell-by-cell instead of running a whole project? The
+[`notebooks/`](notebooks/) folder has a live [Polyglot Notebook](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.dotnet-interactive-vscode)
+(`.dib`) for **every API surface** — Geocoding, Routes, Directions, Distance Matrix, Elevation, Time
+Zone, Address Validation, Roads, Static Maps, plus the billable Places (New), Solar, and Aerial View
+APIs. Each references the published `GoogleMapsApi` NuGet package, so they run without building this
+repo: set `GOOGLE_API_KEY`, open a notebook in VS Code (or `dotnet repl`), and run the cells top to
+bottom to see real responses rendered inline. See [`notebooks/README.md`](notebooks/) for the full
+index.
+
 > Get an API key in the [Google Cloud Console](https://console.cloud.google.com/) and enable the Geocoding and/or Directions API for your project.

--- a/samples/notebooks/AddressValidation.dib
+++ b/samples/notebooks/AddressValidation.dib
@@ -1,0 +1,132 @@
+#!meta
+
+{"kernelInfo":{"defaultKernelName":"csharp","items":[{"name":"csharp","languageName":"C#"}]}}
+
+#!markdown
+
+# Address Validation API
+
+Validate and standardize a postal address, getting back a verdict (was it complete? were components
+inferred or replaced?), the address as Google understands it, and geocoding data. This notebook calls
+[`IGoogleMapsClient.AddressValidation`](https://maximn.github.io/google-maps/). Unlike the other APIs
+in these samples, this one is a **POST** request with a JSON body.
+
+- Google docs: <https://developers.google.com/maps/documentation/address-validation>
+- Library types: `AddressValidationRequest` → `AddressValidationResponse`
+- **Cost:** free tier — not billable in this library's test gate.
+
+**How to run:** open this file in VS Code with the
+[Polyglot Notebooks](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.dotnet-interactive-vscode)
+extension, set the `GOOGLE_API_KEY` environment variable, then run the cells top to bottom.
+
+#!markdown
+
+## 1. Reference the package and import the namespaces
+
+#!csharp
+
+#r "nuget: GoogleMapsApi, 2.4.0"
+
+using GoogleMapsApi;
+using GoogleMapsApi.Entities.Common;
+using GoogleMapsApi.Entities.AddressValidation.Request;
+using GoogleMapsApi.Entities.AddressValidation.Response;
+
+#!markdown
+
+## 2. Read your API key
+
+The notebook reads the key from the `GOOGLE_API_KEY` environment variable, matching the project's
+samples. Prefer to type it in instead? Replace the cell with
+`var apiKey = await Microsoft.DotNet.Interactive.Kernel.GetInputAsync("Google Maps API key");`.
+
+#!csharp
+
+var apiKey = Environment.GetEnvironmentVariable("GOOGLE_API_KEY");
+if (string.IsNullOrWhiteSpace(apiKey))
+    throw new InvalidOperationException("Set the GOOGLE_API_KEY environment variable before running the API cells.");
+
+#!markdown
+
+## 3. Construct the client
+
+Build one `GoogleMapsClient` over a reused `HttpClient`. Passing the key via `GoogleMapsClientOptions`
+makes it ambient, so individual requests don't repeat it.
+
+#!csharp
+
+var http = new HttpClient();
+var maps = new GoogleMapsClient(http, new GoogleMapsClientOptions { ApiKey = apiKey });
+
+#!markdown
+
+## 4. Validate a US street address
+
+The address is a `PostalAddress`. `RegionCode` (CLDR country code, e.g. `"US"`) is required; supply
+`AddressLines` plus locality / administrative area / postal code for a meaningful result.
+
+#!csharp
+
+var request = new AddressValidationRequest
+{
+    Address = new PostalAddress
+    {
+        RegionCode = "US",
+        AddressLines = new List<string> { "1600 Amphitheatre Pkwy" },
+        Locality = "Mountain View",
+        AdministrativeArea = "CA",
+        PostalCode = "94043",
+    },
+};
+
+AddressValidationResponse response = await maps.AddressValidation.QueryAsync(request);
+
+var result = response.Result ?? throw new Exception("Address Validation returned no result.");
+var verdict = result.Verdict;
+
+new[] { result }.Select(_ => new
+{
+    FormattedAddress = result.Address?.FormattedAddress,
+    AddressComplete = verdict?.AddressComplete,
+    HasInferredComponents = verdict?.HasInferredComponents,
+    HasReplacedComponents = verdict?.HasReplacedComponents,
+    HasUnconfirmedComponents = verdict?.HasUnconfirmedComponents,
+    ValidationGranularity = verdict?.ValidationGranularity,
+    Latitude = result.Geocode?.Location?.Latitude,
+    Longitude = result.Geocode?.Location?.Longitude,
+})
+
+#!markdown
+
+## 5. Inspect what Google corrected or inferred
+
+The validated address breaks down into components, and the verdict flags which were missing,
+unconfirmed, inferred, or replaced. Here we surface the formatted result alongside any unresolved or
+missing pieces — useful for a "did you mean…?" prompt after a user submits an address.
+
+#!csharp
+
+var partial = new AddressValidationRequest
+{
+    Address = new PostalAddress
+    {
+        RegionCode = "US",
+        AddressLines = new List<string> { "1600 Amphitheatre Pkwy" },
+        Locality = "Mountain View",
+        // intentionally omit state and ZIP to let Google infer them
+    },
+};
+
+AddressValidationResponse partialResponse = await maps.AddressValidation.QueryAsync(partial);
+
+var partialResult = partialResponse.Result ?? throw new Exception("Address Validation returned no result.");
+
+new[] { partialResult }.Select(_ => new
+{
+    FormattedAddress = partialResult.Address?.FormattedAddress,
+    MissingComponents = string.Join(", ", partialResult.Address?.MissingComponentTypes ?? new List<string>()),
+    UnconfirmedComponents = string.Join(", ", partialResult.Address?.UnconfirmedComponentTypes ?? new List<string>()),
+    UnresolvedTokens = string.Join(", ", partialResult.Address?.UnresolvedTokens ?? new List<string>()),
+    InputGranularity = partialResult.Verdict?.InputGranularity,
+    ValidationGranularity = partialResult.Verdict?.ValidationGranularity,
+})

--- a/samples/notebooks/AerialView.dib
+++ b/samples/notebooks/AerialView.dib
@@ -1,0 +1,157 @@
+#!meta
+
+{"kernelInfo":{"defaultKernelName":"csharp","items":[{"name":"csharp","languageName":"C#"}]}}
+
+#!markdown
+
+# Aerial View API
+
+Render a cinematic flyover video for a US address, then poll until it is ready and read its signed
+media URIs. This notebook calls `maps.AerialView.RenderVideo` and `maps.AerialView.LookupVideo` on
+[`IGoogleMapsClient`](https://maximn.github.io/google-maps/).
+
+- Google docs: <https://developers.google.com/maps/documentation/aerial-view>
+- Library types: `RenderVideoRequest` / `LookupVideoRequest` → `AerialViewVideoResponse`
+- **Cost:** billable ⚠️ (RenderVideo is free; **LookupVideo is billed**)
+
+**How to run:** open this file in VS Code with the
+[Polyglot Notebooks](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.dotnet-interactive-vscode)
+extension, set the `GOOGLE_API_KEY` environment variable, then run the cells top to bottom.
+
+#!markdown
+
+> [!WARNING]
+> **This API is billable.** Running the cells below calls a paid Google Maps API and **will incur charges** on your Google Cloud project. Only run them if you accept the cost.
+
+#!markdown
+
+## 1. Reference the package and import the namespaces
+
+#!csharp
+
+#r "nuget: GoogleMapsApi, 2.4.0"
+
+using GoogleMapsApi;
+using GoogleMapsApi.Entities.Common;
+using GoogleMapsApi.Entities.AerialView.Request;
+using GoogleMapsApi.Entities.AerialView.Response;
+
+#!markdown
+
+## 2. Read your API key
+
+The notebook reads the key from the `GOOGLE_API_KEY` environment variable, matching the project's
+samples. Prefer to type it in instead? Replace the cell with
+`var apiKey = await Microsoft.DotNet.Interactive.Kernel.GetInputAsync("Google Maps API key");`.
+
+#!csharp
+
+var apiKey = Environment.GetEnvironmentVariable("GOOGLE_API_KEY");
+if (string.IsNullOrWhiteSpace(apiKey))
+    throw new InvalidOperationException("Set the GOOGLE_API_KEY environment variable before running the API cells.");
+
+#!markdown
+
+## 3. Construct the client
+
+Build one `GoogleMapsClient` over a reused `HttpClient`. Passing the key via `GoogleMapsClientOptions`
+makes it ambient, so individual requests don't repeat it.
+
+#!csharp
+
+var http = new HttpClient();
+var maps = new GoogleMapsClient(http, new GoogleMapsClientOptions { ApiKey = apiKey });
+
+#!markdown
+
+## 4. Render Video — enqueue a flyover (free, asynchronous)
+
+`RenderVideoRequest` takes a US postal `Address`. Rendering is asynchronous: the call returns
+immediately, usually with `State == Processing` and a video id in `Metadata.VideoId`. If a video for
+the address already exists it may come back `Active` straight away. The render endpoint itself is not
+billed.
+
+#!csharp
+
+var address = "1600 Amphitheatre Parkway, Mountain View, CA 94043";
+
+var renderRequest = new RenderVideoRequest { Address = address };
+
+AerialViewVideoResponse render = await maps.AerialView.RenderVideo.QueryAsync(renderRequest);
+
+var videoId = render.Metadata?.VideoId;
+
+new[]
+{
+    new
+    {
+        render.State,
+        VideoId = videoId,
+    },
+}
+
+#!markdown
+
+## 5. Look up Video — poll until Active (billable)
+
+`LookupVideoRequest` accepts either a `VideoId` (preferred) or an `Address` — supply exactly one.
+We poll a few times with a delay until `State == Active`, then stop. Each `LookupVideo` call is
+billed, so the loop is capped at a small number of attempts; a real video can take minutes to hours,
+so it may still be `Processing` when the loop ends.
+
+#!csharp
+
+const int maxAttempts = 5;
+var delay = TimeSpan.FromSeconds(10);
+
+AerialViewVideoResponse lookup = render;
+
+for (int attempt = 1; attempt <= maxAttempts && lookup.State != VideoState.Active; attempt++)
+{
+    var lookupRequest = !string.IsNullOrWhiteSpace(videoId)
+        ? new LookupVideoRequest { VideoId = videoId }
+        : new LookupVideoRequest { Address = address };
+
+    lookup = await maps.AerialView.LookupVideo.QueryAsync(lookupRequest);
+
+    if (lookup.State == VideoState.Active || lookup.State == VideoState.Failed)
+        break;
+
+    await Task.Delay(delay);
+}
+
+new[]
+{
+    new
+    {
+        lookup.State,
+        VideoId = lookup.Metadata?.VideoId,
+        Duration = lookup.Metadata?.DurationValue,
+        FormatsAvailable = lookup.Uris?.Count ?? 0,
+    },
+}
+
+#!markdown
+
+## 6. Media URIs — the signed links, once Active
+
+When `State == Active`, `Uris` is populated with signed, short-lived links keyed by media format
+(`"MP4_HIGH"`, `"HLS"`, …). Each `AerialViewUris` has a landscape (16:9) and portrait (9:16) URI.
+Use the strongly-typed `TryGetUris(MediaFormat, out ...)` helper to pull a known format. These links
+expire, so fetch them fresh rather than caching.
+
+#!csharp
+
+if (lookup.State != VideoState.Active || lookup.Uris is null)
+{
+    $"Video is not Active yet (state: {lookup.State}). Re-run the polling cell later."
+}
+else
+{
+    lookup.Uris.Select(kvp => new
+    {
+        Format = kvp.Key,
+        Landscape = kvp.Value.LandscapeUri,
+        Portrait = kvp.Value.PortraitUri,
+    })
+}

--- a/samples/notebooks/Directions.dib
+++ b/samples/notebooks/Directions.dib
@@ -1,0 +1,114 @@
+#!meta
+
+{"kernelInfo":{"defaultKernelName":"csharp","items":[{"name":"csharp","languageName":"C#"}]}}
+
+#!markdown
+
+# Directions API
+
+Compute a route between an origin and a destination string with the legacy Directions API. This notebook
+calls [`IGoogleMapsClient.Directions`](https://maximn.github.io/google-maps/) and mirrors the
+[`MinimalApi.Directions`](../MinimalApi.Directions/) sample.
+
+- Google docs: <https://developers.google.com/maps/documentation/directions>
+- Library types: `DirectionsRequest` → `DirectionsResponse`
+- **Cost:** free tier — not billable in this library's test gate.
+
+> ⚠️ Legacy API (feature-frozen as of 2025-03-01, closed to new Cloud projects). For new integrations prefer the [Routes notebook](Routes.dib).
+
+**How to run:** open this file in VS Code with the
+[Polyglot Notebooks](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.dotnet-interactive-vscode)
+extension, set the `GOOGLE_API_KEY` environment variable, then run the cells top to bottom.
+
+#!markdown
+
+## 1. Reference the package and import the namespaces
+
+#!csharp
+
+#r "nuget: GoogleMapsApi, 2.4.0"
+
+using GoogleMapsApi;
+using GoogleMapsApi.Entities.Directions.Request;
+using GoogleMapsApi.Entities.Directions.Response;
+
+#!markdown
+
+## 2. Read your API key
+
+The notebook reads the key from the `GOOGLE_API_KEY` environment variable, matching the project's
+samples. Prefer to type it in instead? Replace the cell with
+`var apiKey = await Microsoft.DotNet.Interactive.Kernel.GetInputAsync("Google Maps API key");`.
+
+#!csharp
+
+var apiKey = Environment.GetEnvironmentVariable("GOOGLE_API_KEY");
+if (string.IsNullOrWhiteSpace(apiKey))
+    throw new InvalidOperationException("Set the GOOGLE_API_KEY environment variable before running the API cells.");
+
+#!markdown
+
+## 3. Construct the client
+
+Build one `GoogleMapsClient` over a reused `HttpClient`. Passing the key via `GoogleMapsClientOptions`
+makes it ambient, so individual requests don't repeat it.
+
+#!csharp
+
+var http = new HttpClient();
+var maps = new GoogleMapsClient(http, new GoogleMapsClientOptions { ApiKey = apiKey });
+
+#!markdown
+
+## 4. Get directions between two places
+
+`Origin` and `Destination` are plain strings — an address or a `"lat,lng"` pair. Check `Status` against
+`DirectionsStatusCodes.OK` before reading the routes.
+
+#!csharp
+
+var request = new DirectionsRequest
+{
+    Origin = "New York, NY",
+    Destination = "Philadelphia, PA",
+    TravelMode = TravelMode.Driving,
+};
+
+DirectionsResponse response = await maps.Directions.QueryAsync(request);
+
+if (response.Status != DirectionsStatusCodes.OK || response.Routes is null)
+    throw new Exception($"Directions failed: {response.Status} {response.ErrorMessage}");
+
+response.Routes.Select(route =>
+{
+    var leg = route.Legs?.FirstOrDefault();
+    return new
+    {
+        route.Summary,
+        StartAddress = leg?.StartAddress,
+        EndAddress = leg?.EndAddress,
+        Distance = leg?.Distance?.Text,
+        Duration = leg?.Duration?.Text,
+        route.Copyrights,
+    };
+})
+
+#!markdown
+
+## 5. List the turn-by-turn steps of the first leg
+
+Each `Leg` exposes a `Steps` collection; project the per-step distance and duration text.
+
+#!csharp
+
+var route = response.Routes.First();
+var firstLeg = route.Legs?.First();
+
+firstLeg?.Steps?.Select((step, i) => new
+{
+    Step = i + 1,
+    Instructions = step.HtmlInstructions,
+    Distance = step.Distance?.Text,
+    Duration = step.Duration?.Text,
+    step.TravelMode,
+})

--- a/samples/notebooks/DistanceMatrix.dib
+++ b/samples/notebooks/DistanceMatrix.dib
@@ -1,0 +1,128 @@
+#!meta
+
+{"kernelInfo":{"defaultKernelName":"csharp","items":[{"name":"csharp","languageName":"C#"}]}}
+
+#!markdown
+
+# Distance Matrix API
+
+Get travel distance and duration for a matrix of origins and destinations with the legacy Distance
+Matrix API. This notebook calls [`IGoogleMapsClient.DistanceMatrix`](https://maximn.github.io/google-maps/)
+and mirrors the [`GenericHost.DistanceMatrix`](../GenericHost.DistanceMatrix/) sample.
+
+- Google docs: <https://developers.google.com/maps/documentation/distance-matrix>
+- Library types: `DistanceMatrixRequest` → `DistanceMatrixResponse`
+- **Cost:** free tier — not billable in this library's test gate.
+
+> ⚠️ Legacy API (feature-frozen as of 2025-03-01, closed to new Cloud projects). For new integrations prefer the [Routes notebook](Routes.dib).
+
+**How to run:** open this file in VS Code with the
+[Polyglot Notebooks](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.dotnet-interactive-vscode)
+extension, set the `GOOGLE_API_KEY` environment variable, then run the cells top to bottom.
+
+#!markdown
+
+## 1. Reference the package and import the namespaces
+
+#!csharp
+
+#r "nuget: GoogleMapsApi, 2.4.0"
+
+using GoogleMapsApi;
+using GoogleMapsApi.Entities.DistanceMatrix.Request;
+using GoogleMapsApi.Entities.DistanceMatrix.Response;
+
+#!markdown
+
+## 2. Read your API key
+
+The notebook reads the key from the `GOOGLE_API_KEY` environment variable, matching the project's
+samples. Prefer to type it in instead? Replace the cell with
+`var apiKey = await Microsoft.DotNet.Interactive.Kernel.GetInputAsync("Google Maps API key");`.
+
+#!csharp
+
+var apiKey = Environment.GetEnvironmentVariable("GOOGLE_API_KEY");
+if (string.IsNullOrWhiteSpace(apiKey))
+    throw new InvalidOperationException("Set the GOOGLE_API_KEY environment variable before running the API cells.");
+
+#!markdown
+
+## 3. Construct the client
+
+Build one `GoogleMapsClient` over a reused `HttpClient`. Passing the key via `GoogleMapsClientOptions`
+makes it ambient, so individual requests don't repeat it.
+
+#!csharp
+
+var http = new HttpClient();
+var maps = new GoogleMapsClient(http, new GoogleMapsClientOptions { ApiKey = apiKey });
+
+#!markdown
+
+## 4. One origin to one destination
+
+`Origins` and `Destinations` are string arrays. Check the response `Status` against
+`DistanceMatrixStatusCodes.OK`, then the per-pair `Element.Status` against
+`DistanceMatrixElementStatusCodes.OK` before reading distance/duration.
+
+#!csharp
+
+var request = new DistanceMatrixRequest
+{
+    Origins = new[] { "New York, NY" },
+    Destinations = new[] { "Philadelphia, PA" },
+    Units = DistanceMatrixUnitSystems.metric,
+};
+
+DistanceMatrixResponse response = await maps.DistanceMatrix.QueryAsync(request);
+
+if (response.Status != DistanceMatrixStatusCodes.OK)
+    throw new Exception($"Distance Matrix failed: {response.Status} {response.ErrorMessage}");
+
+var element = response.Rows.First().Elements.First();
+if (element.Status != DistanceMatrixElementStatusCodes.OK)
+    throw new Exception($"No route: {element.Status}");
+
+new
+{
+    Origin = response.OriginAddresses.First(),
+    Destination = response.DestinationAddresses.First(),
+    Distance = element.Distance.Text,
+    Duration = element.Duration.Text,
+}
+
+#!markdown
+
+## 5. A full origins × destinations matrix
+
+Pass multiple origins and destinations to get every pairing in one call. Each `Row` corresponds to an
+origin (in request order); each `Element` within it corresponds to a destination.
+
+#!csharp
+
+var origins = new[] { "Mountain View, CA", "San Jose, CA" };
+var destinations = new[] { "San Francisco, CA", "Oakland, CA" };
+
+var matrixRequest = new DistanceMatrixRequest
+{
+    Origins = origins,
+    Destinations = destinations,
+    Mode = DistanceMatrixTravelModes.driving,
+    Units = DistanceMatrixUnitSystems.imperial,
+};
+
+DistanceMatrixResponse matrix = await maps.DistanceMatrix.QueryAsync(matrixRequest);
+
+if (matrix.Status != DistanceMatrixStatusCodes.OK)
+    throw new Exception($"Distance Matrix failed: {matrix.Status} {matrix.ErrorMessage}");
+
+matrix.Rows
+    .SelectMany((row, originIndex) => row.Elements.Select((el, destIndex) => new
+    {
+        Origin = origins[originIndex],
+        Destination = destinations[destIndex],
+        Status = el.Status,
+        Distance = el.Status == DistanceMatrixElementStatusCodes.OK ? el.Distance.Text : null,
+        Duration = el.Status == DistanceMatrixElementStatusCodes.OK ? el.Duration.Text : null,
+    }))

--- a/samples/notebooks/Elevation.dib
+++ b/samples/notebooks/Elevation.dib
@@ -1,0 +1,121 @@
+#!meta
+
+{"kernelInfo":{"defaultKernelName":"csharp","items":[{"name":"csharp","languageName":"C#"}]}}
+
+#!markdown
+
+# Elevation API
+
+Look up the elevation (in meters above sea level) for one or more points on the earth's surface.
+This notebook calls [`IGoogleMapsClient.Elevation`](https://maximn.github.io/google-maps/) — values
+below sea level (e.g. ocean floor) come back negative.
+
+- Google docs: <https://developers.google.com/maps/documentation/elevation>
+- Library types: `ElevationRequest` → `ElevationResponse`
+- **Cost:** free tier — not billable in this library's test gate.
+
+**How to run:** open this file in VS Code with the
+[Polyglot Notebooks](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.dotnet-interactive-vscode)
+extension, set the `GOOGLE_API_KEY` environment variable, then run the cells top to bottom.
+
+#!markdown
+
+## 1. Reference the package and import the namespaces
+
+#!csharp
+
+#r "nuget: GoogleMapsApi, 2.4.0"
+
+using GoogleMapsApi;
+using GoogleMapsApi.Entities.Common;
+using GoogleMapsApi.Entities.Elevation.Request;
+using GoogleMapsApi.Entities.Elevation.Response;
+
+#!markdown
+
+## 2. Read your API key
+
+The notebook reads the key from the `GOOGLE_API_KEY` environment variable, matching the project's
+samples. Prefer to type it in instead? Replace the cell with
+`var apiKey = await Microsoft.DotNet.Interactive.Kernel.GetInputAsync("Google Maps API key");`.
+
+#!csharp
+
+var apiKey = Environment.GetEnvironmentVariable("GOOGLE_API_KEY");
+if (string.IsNullOrWhiteSpace(apiKey))
+    throw new InvalidOperationException("Set the GOOGLE_API_KEY environment variable before running the API cells.");
+
+#!markdown
+
+## 3. Construct the client
+
+Build one `GoogleMapsClient` over a reused `HttpClient`. Passing the key via `GoogleMapsClientOptions`
+makes it ambient, so individual requests don't repeat it.
+
+#!csharp
+
+var http = new HttpClient();
+var maps = new GoogleMapsClient(http, new GoogleMapsClientOptions { ApiKey = apiKey });
+
+#!markdown
+
+## 4. Elevation for specific locations
+
+Pass one or more `Location` values via `Locations`. Here we compare downtown Denver (the "Mile-High
+City"), the summit of Mt. Everest, and a point in the Pacific (which returns a negative value).
+
+#!csharp
+
+var request = new ElevationRequest
+{
+    Locations = new[]
+    {
+        new Location(39.7392, -104.9903),   // Denver, CO
+        new Location(27.9881, 86.9250),     // Mt. Everest summit
+        new Location(0.0, -160.0),          // open Pacific Ocean
+    },
+};
+
+ElevationResponse response = await maps.Elevation.QueryAsync(request);
+
+if (response.Status != Status.OK || response.Results is null)
+    throw new Exception($"Elevation lookup failed: {response.Status}");
+
+response.Results.Select(r => new
+{
+    Latitude = r.Location.Latitude,
+    Longitude = r.Location.Longitude,
+    ElevationMeters = Math.Round(r.Elevation, 1),
+    ResolutionMeters = Math.Round(r.Resolution, 1),
+})
+
+#!markdown
+
+## 5. Elevation sampled along a path
+
+Pass `Path` instead of `Locations` to sample elevations evenly between points — useful for hiking or
+cycling profiles. The `samples` value (number of points) is controlled by the library's path handling;
+each result is one sampled point along the route.
+
+#!csharp
+
+var pathRequest = new ElevationRequest
+{
+    Path = new[]
+    {
+        new Location(36.578581, -118.291994),  // Mt. Whitney
+        new Location(36.23998, -116.83171),    // Badwater Basin, Death Valley
+    },
+};
+
+ElevationResponse pathResponse = await maps.Elevation.QueryAsync(pathRequest);
+
+if (pathResponse.Status != Status.OK || pathResponse.Results is null)
+    throw new Exception($"Elevation path lookup failed: {pathResponse.Status}");
+
+pathResponse.Results.Select(r => new
+{
+    Latitude = Math.Round(r.Location.Latitude, 4),
+    Longitude = Math.Round(r.Location.Longitude, 4),
+    ElevationMeters = Math.Round(r.Elevation, 1),
+})

--- a/samples/notebooks/Geocoding.dib
+++ b/samples/notebooks/Geocoding.dib
@@ -1,0 +1,93 @@
+#!meta
+
+{"kernelInfo":{"defaultKernelName":"csharp","items":[{"name":"csharp","languageName":"C#"}]}}
+
+#!markdown
+
+# Geocoding API
+
+Turn a human-readable address into latitude/longitude coordinates (and back, via reverse geocoding).
+This notebook calls [`IGoogleMapsClient.Geocode`](https://maximn.github.io/google-maps/) and mirrors
+the [`Console.Geocoding`](../Console.Geocoding/) sample.
+
+- Google docs: <https://developers.google.com/maps/documentation/geocoding>
+- Library types: `GeocodingRequest` → `GeocodingResponse`
+- **Cost:** free tier — the Geocoding API is not billable in this library's test gate.
+
+**How to run:** open this file in VS Code with the
+[Polyglot Notebooks](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.dotnet-interactive-vscode)
+extension, set the `GOOGLE_API_KEY` environment variable, then run the cells top to bottom.
+
+#!markdown
+
+## 1. Reference the package and import the namespaces
+
+#!csharp
+
+#r "nuget: GoogleMapsApi, 2.4.0"
+
+using GoogleMapsApi;
+using GoogleMapsApi.Entities.Common;
+using GoogleMapsApi.Entities.Geocoding.Request;
+using GoogleMapsApi.Entities.Geocoding.Response;
+
+#!markdown
+
+## 2. Read your API key
+
+The notebook reads the key from the `GOOGLE_API_KEY` environment variable, matching the project's
+samples. Prefer to type it in instead? Replace the cell with
+`var apiKey = await Microsoft.DotNet.Interactive.Kernel.GetInputAsync("Google Maps API key");`.
+
+#!csharp
+
+var apiKey = Environment.GetEnvironmentVariable("GOOGLE_API_KEY");
+if (string.IsNullOrWhiteSpace(apiKey))
+    throw new InvalidOperationException("Set the GOOGLE_API_KEY environment variable before running the API cells.");
+
+#!markdown
+
+## 3. Construct the client
+
+Build one `GoogleMapsClient` over a reused `HttpClient`. Passing the key via `GoogleMapsClientOptions`
+makes it ambient, so individual requests don't repeat it.
+
+#!csharp
+
+var http = new HttpClient();
+var maps = new GoogleMapsClient(http, new GoogleMapsClientOptions { ApiKey = apiKey });
+
+#!markdown
+
+## 4. Geocode an address
+
+#!csharp
+
+var request = new GeocodingRequest { Address = "1600 Amphitheatre Parkway, Mountain View, CA" };
+
+GeocodingResponse response = await maps.Geocode.QueryAsync(request);
+
+if (response.Status != Status.OK || response.Results is null)
+    throw new Exception($"Geocoding failed: {response.Status}");
+
+response.Results.Select(r => new
+{
+    r.FormattedAddress,
+    Latitude = r.Geometry.Location.Latitude,
+    Longitude = r.Geometry.Location.Longitude,
+    r.PlaceId,
+})
+
+#!markdown
+
+## 5. Reverse geocode — coordinates back to an address
+
+Pass a `Location` instead of an `Address` to look up the nearest addresses for a point.
+
+#!csharp
+
+var reverse = new GeocodingRequest { Location = new Location(40.714224, -73.961452) };
+
+GeocodingResponse reverseResponse = await maps.Geocode.QueryAsync(reverse);
+
+reverseResponse.Results?.Take(3).Select(r => r.FormattedAddress)

--- a/samples/notebooks/PlacesNew.dib
+++ b/samples/notebooks/PlacesNew.dib
@@ -1,0 +1,229 @@
+#!meta
+
+{"kernelInfo":{"defaultKernelName":"csharp","items":[{"name":"csharp","languageName":"C#"}]}}
+
+#!markdown
+
+# Places API (New)
+
+Search, detail, autocomplete and photo lookups against the modern Places API (New). This notebook
+calls the `PlacesSearchText`, `PlacesSearchNearby`, `PlaceDetailsNew`, `PlacesAutocompleteNew` and
+`PlacePhoto` surfaces on [`IGoogleMapsClient`](https://maximn.github.io/google-maps/).
+
+- Google docs: <https://developers.google.com/maps/documentation/places/web-service>
+- Library types: `SearchTextRequest` → `SearchTextResponse`, `SearchNearbyRequest` → `SearchNearbyResponse`, `PlaceDetailsRequest` → `Place`, `AutocompleteRequest` → `AutocompleteResponse`, `PlacePhotoRequest` → `PlacePhotoResponse`
+- **Cost:** billable ⚠️
+
+**How to run:** open this file in VS Code with the
+[Polyglot Notebooks](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.dotnet-interactive-vscode)
+extension, set the `GOOGLE_API_KEY` environment variable, then run the cells top to bottom.
+
+#!markdown
+
+> [!WARNING]
+> **This API is billable.** Running the cells below calls a paid Google Maps API and **will incur charges** on your Google Cloud project. Only run them if you accept the cost.
+
+#!markdown
+
+## 1. Reference the package and import the namespaces
+
+#!csharp
+
+#r "nuget: GoogleMapsApi, 2.4.0"
+
+using GoogleMapsApi;
+using GoogleMapsApi.Entities.Common;
+using GoogleMapsApi.Entities.PlacesNew.Common;
+using GoogleMapsApi.Entities.PlacesNew.Request;
+using GoogleMapsApi.Entities.PlacesNew.Response;
+
+#!markdown
+
+## 2. Read your API key
+
+The notebook reads the key from the `GOOGLE_API_KEY` environment variable, matching the project's
+samples. Prefer to type it in instead? Replace the cell with
+`var apiKey = await Microsoft.DotNet.Interactive.Kernel.GetInputAsync("Google Maps API key");`.
+
+#!csharp
+
+var apiKey = Environment.GetEnvironmentVariable("GOOGLE_API_KEY");
+if (string.IsNullOrWhiteSpace(apiKey))
+    throw new InvalidOperationException("Set the GOOGLE_API_KEY environment variable before running the API cells.");
+
+#!markdown
+
+## 3. Construct the client
+
+Build one `GoogleMapsClient` over a reused `HttpClient`. Passing the key via `GoogleMapsClientOptions`
+makes it ambient, so individual requests don't repeat it.
+
+#!csharp
+
+var http = new HttpClient();
+var maps = new GoogleMapsClient(http, new GoogleMapsClientOptions { ApiKey = apiKey });
+
+#!markdown
+
+## 4. Text Search — find places from a free-text query
+
+The Places API (New) **requires a field mask**. `SearchTextRequest.FieldMask` is pre-populated with a
+sensible default (`places.id,places.displayName,...`); tighten it to cut response size and cost.
+We keep the first result's place id and photo name for the later cells.
+
+#!csharp
+
+var textRequest = new SearchTextRequest
+{
+    TextQuery = "pizza in New York",
+    MinRating = 4.0,
+};
+
+SearchTextResponse textResponse = await maps.PlacesSearchText.QueryAsync(textRequest);
+
+if (textResponse.Places is null || textResponse.Places.Count == 0)
+    throw new Exception("Text Search returned no places.");
+
+// Reuse these in later cells.
+var firstPlaceId = textResponse.Places[0].Id;
+
+textResponse.Places.Select(p => new
+{
+    Name = p.DisplayName?.Text,
+    p.FormattedAddress,
+    p.Rating,
+    p.Id,
+})
+
+#!markdown
+
+## 5. Nearby Search — places within a circle
+
+Nearby Search requires a `LocationRestriction` containing a `Circle`. Build the circle from a
+`LatLng` center plus a radius in meters, then wrap it in a `LocationRestriction`.
+
+#!csharp
+
+var nearbyRequest = new SearchNearbyRequest
+{
+    LocationRestriction = new LocationRestriction
+    {
+        Circle = new Circle
+        {
+            Center = new LatLng { Latitude = 40.748817, Longitude = -73.985428 }, // Empire State Building
+            Radius = 500,
+        },
+    },
+    IncludedTypes = new List<string> { "restaurant" },
+    MaxResultCount = 10,
+};
+
+SearchNearbyResponse nearbyResponse = await maps.PlacesSearchNearby.QueryAsync(nearbyRequest);
+
+(nearbyResponse.Places ?? new List<Place>()).Select(p => new
+{
+    Name = p.DisplayName?.Text,
+    p.FormattedAddress,
+    p.Rating,
+    PrimaryType = p.Types?.FirstOrDefault(),
+})
+
+#!markdown
+
+## 6. Place Details — full detail for one place id
+
+Place Details takes a `PlaceId` and a field mask using **top-level** paths (no `places.` prefix —
+its `DefaultFieldMask` already handles that). We reuse the id from the Text Search above.
+
+#!csharp
+
+var detailsRequest = new PlaceDetailsRequest
+{
+    // From the Text Search result above; falls back to a well-known place id (Google Sydney).
+    PlaceId = firstPlaceId ?? "ChIJN1t_tDeuEmsRUsoyG83frY4",
+};
+
+Place place = await maps.PlaceDetailsNew.QueryAsync(detailsRequest);
+
+new[]
+{
+    new
+    {
+        Name = place.DisplayName?.Text,
+        place.FormattedAddress,
+        place.Rating,
+        place.GoogleMapsUri,
+        place.Id,
+    },
+}
+
+#!markdown
+
+## 7. Autocomplete — predictions as the user types
+
+Autocomplete does **not** use a field mask. Each `Suggestion` carries either a `PlacePrediction` or a
+`QueryPrediction`; we project the place predictions.
+
+#!csharp
+
+var autocompleteRequest = new AutocompleteRequest
+{
+    Input = "1600 Amphitheatre",
+    IncludedRegionCodes = new List<string> { "US" },
+};
+
+AutocompleteResponse autocompleteResponse = await maps.PlacesAutocompleteNew.QueryAsync(autocompleteRequest);
+
+(autocompleteResponse.Suggestions ?? new List<Suggestion>())
+    .Where(s => s.PlacePrediction is not null)
+    .Select(s => new
+    {
+        Text = s.PlacePrediction!.Text?.Text,
+        MainText = s.PlacePrediction.StructuredFormat?.MainText?.Text,
+        SecondaryText = s.PlacePrediction.StructuredFormat?.SecondaryText?.Text,
+        s.PlacePrediction.PlaceId,
+    })
+
+#!markdown
+
+## 8. Place Photo — resolve a photo reference to an image URI
+
+A photo's resource name comes from a prior search's `Place.Photos[].Name`. The default field mask
+above does not request photos, so here we run a focused Text Search asking only for
+`places.photos`, take the first photo name, then resolve it. `PlacePhotoRequest` needs `PhotoName`
+plus at least one of `MaxHeightPx` / `MaxWidthPx`; the response is the resolved `PhotoUri`.
+
+#!csharp
+
+var photoSearch = new SearchTextRequest
+{
+    TextQuery = "Eiffel Tower",
+    FieldMask = "places.id,places.displayName,places.photos",
+};
+
+SearchTextResponse photoSearchResponse = await maps.PlacesSearchText.QueryAsync(photoSearch);
+
+var photoName = photoSearchResponse.Places?
+    .SelectMany(p => p.Photos ?? new List<Photo>())
+    .Select(photo => photo.Name)
+    .FirstOrDefault(name => !string.IsNullOrWhiteSpace(name));
+
+if (photoName is null)
+    throw new Exception("No photo reference found on the search results.");
+
+var photoRequest = new PlacePhotoRequest
+{
+    PhotoName = photoName,
+    MaxWidthPx = 800,
+};
+
+PlacePhotoResponse photoResponse = await maps.PlacePhoto.QueryAsync(photoRequest);
+
+new[]
+{
+    new
+    {
+        photoResponse.Name,
+        photoResponse.PhotoUri,
+    },
+}

--- a/samples/notebooks/README.md
+++ b/samples/notebooks/README.md
@@ -1,0 +1,45 @@
+# Interactive notebooks
+
+Live, runnable [Polyglot Notebooks](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.dotnet-interactive-vscode)
+(`.dib`) — one per Google Maps API surface. Each notebook references the published
+[`GoogleMapsApi`](https://www.nuget.org/packages/GoogleMapsApi) NuGet package (`#r "nuget: GoogleMapsApi, 2.4.0"`),
+so they run anywhere without building this repo. Execute the cells top to bottom to call the real API
+and see each response rendered inline — a more hands-on alternative to the README's code blocks and the
+full project [samples](../).
+
+## How to run
+
+1. Install the **Polyglot Notebooks** extension in VS Code (it pulls in the .NET Interactive kernel),
+   or use the [`dotnet repl`](https://github.com/jonsequitur/dotnet-repl) CLI.
+2. Set your key once for the session: `export GOOGLE_API_KEY=your-key` (the notebooks read it from the
+   environment, matching the other samples). Don't have one? Get it in the
+   [Google Cloud Console](https://console.cloud.google.com/) and enable the relevant API.
+3. Open a `.dib` file and run the cells in order — the package reference, key, and client are set up in
+   the first few cells and reused by the rest.
+
+## Notebooks
+
+### Free tier
+
+| Notebook | API surface | What it shows |
+| --- | --- | --- |
+| [Geocoding.dib](Geocoding.dib) | Geocoding | Address → coordinates, and reverse geocoding |
+| [Routes.dib](Routes.dib) | Routes (modern) | Compute a route with traffic-aware preference and a field mask |
+| [Directions.dib](Directions.dib) | Directions *(legacy)* | Turn-by-turn directions; legacy — prefer Routes |
+| [DistanceMatrix.dib](DistanceMatrix.dib) | Distance Matrix *(legacy)* | Travel time/distance matrix; legacy — prefer Routes |
+| [Elevation.dib](Elevation.dib) | Elevation | Elevation for points and along a path |
+| [TimeZone.dib](TimeZone.dib) | Time Zone | Time zone and UTC/DST offsets for a location |
+| [AddressValidation.dib](AddressValidation.dib) | Address Validation | Validate a postal address and read the verdict |
+| [Roads.dib](Roads.dib) | Roads | Snap to roads, nearest roads, and speed limits |
+| [StaticMaps.dib](StaticMaps.dib) | Static Maps | Build a map-image URL and render it inline |
+
+### Billable ⚠️
+
+These call paid APIs and **incur charges** on your Google Cloud project — each opens with a cost
+warning. Run only if you accept the cost.
+
+| Notebook | API surface | What it shows |
+| --- | --- | --- |
+| [PlacesNew.dib](PlacesNew.dib) | Places (New) | Text/nearby search, details, autocomplete, and photos |
+| [Solar.dib](Solar.dib) | Solar | Building insights, data layers, and a GeoTIFF download |
+| [AerialView.dib](AerialView.dib) | Aerial View | Render a flyover video and poll until it's ready |

--- a/samples/notebooks/Roads.dib
+++ b/samples/notebooks/Roads.dib
@@ -1,0 +1,155 @@
+#!meta
+
+{"kernelInfo":{"defaultKernelName":"csharp","items":[{"name":"csharp","languageName":"C#"}]}}
+
+#!markdown
+
+# Roads API
+
+Work with GPS traces against Google's road network: snap a recorded path onto roads, find the
+nearest road segments for arbitrary points, and (with the right license) look up posted speed limits.
+This notebook calls [`IGoogleMapsClient.SnapToRoads`, `.NearestRoads`, and `.SpeedLimits`](https://maximn.github.io/google-maps/).
+
+- Google docs: <https://developers.google.com/maps/documentation/roads/overview>
+- Library types: `SnapToRoadsRequest` → `SnapToRoadsResponse`, `NearestRoadsRequest` → `NearestRoadsResponse`, `SpeedLimitsRequest` → `SpeedLimitsResponse`
+- **Cost:** free tier — Snap to Roads and Nearest Roads are not billable in this library's test gate. **Speed Limits is different:** it requires a Google *Asset Tracking* license and is separately billable (see section 4).
+
+**How to run:** open this file in VS Code with the
+[Polyglot Notebooks](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.dotnet-interactive-vscode)
+extension, set the `GOOGLE_API_KEY` environment variable, then run the cells top to bottom.
+
+#!markdown
+
+## 1. Reference the package and import the namespaces
+
+#!csharp
+
+#r "nuget: GoogleMapsApi, 2.4.0"
+
+using GoogleMapsApi;
+using GoogleMapsApi.Entities.Common;
+using GoogleMapsApi.Entities.Roads.Request;
+using GoogleMapsApi.Entities.Roads.Response;
+
+#!markdown
+
+## 2. Read your API key
+
+The notebook reads the key from the `GOOGLE_API_KEY` environment variable, matching the project's
+samples. Prefer to type it in instead? Replace the cell with
+`var apiKey = await Microsoft.DotNet.Interactive.Kernel.GetInputAsync("Google Maps API key");`.
+
+#!csharp
+
+var apiKey = Environment.GetEnvironmentVariable("GOOGLE_API_KEY");
+if (string.IsNullOrWhiteSpace(apiKey))
+    throw new InvalidOperationException("Set the GOOGLE_API_KEY environment variable before running the API cells.");
+
+#!markdown
+
+## 3. Construct the client
+
+Build one `GoogleMapsClient` over a reused `HttpClient`. Passing the key via `GoogleMapsClientOptions`
+makes it ambient, so individual requests don't repeat it.
+
+#!csharp
+
+var http = new HttpClient();
+var maps = new GoogleMapsClient(http, new GoogleMapsClientOptions { ApiKey = apiKey });
+
+#!markdown
+
+## 4. Snap to Roads
+
+`SnapToRoads` takes an ordered `Path` of recorded GPS points and snaps each onto the most likely
+road segment. With `Interpolate = true` the response is filled in with extra points so it smoothly
+follows the road geometry — those interpolated points have a `null` `OriginalIndex`.
+
+The points below trace a short drive along the road network.
+
+#!csharp
+
+var roadPath = new[]
+{
+    new Location(-35.27801, 149.12958),
+    new Location(-35.28032, 149.12907),
+    new Location(-35.28099, 149.12929),
+    new Location(-35.28144, 149.12984),
+    new Location(-35.28194, 149.13003),
+};
+
+var snapRequest = new SnapToRoadsRequest { Path = roadPath, Interpolate = true };
+
+SnapToRoadsResponse snapResponse = await maps.SnapToRoads.QueryAsync(snapRequest);
+
+snapResponse.SnappedPoints?.Select(p => new
+{
+    Latitude = p.Location?.Latitude,
+    Longitude = p.Location?.Longitude,
+    p.OriginalIndex,
+    Interpolated = p.OriginalIndex is null,
+    p.PlaceId,
+})
+
+#!markdown
+
+## 5. Nearest Roads
+
+`NearestRoads` is the order-independent cousin of Snap to Roads: it returns the nearest road segment
+for each of up to 100 arbitrary `Points`. Use it for points that don't form a traveled path.
+
+#!csharp
+
+var nearestPoints = new[]
+{
+    new Location(-35.27801, 149.12958),
+    new Location(60.170880, 24.942795),
+    new Location(60.170879, 24.942796),
+};
+
+var nearestRequest = new NearestRoadsRequest { Points = nearestPoints };
+
+NearestRoadsResponse nearestResponse = await maps.NearestRoads.QueryAsync(nearestRequest);
+
+nearestResponse.SnappedPoints?.Select(p => new
+{
+    Latitude = p.Location?.Latitude,
+    Longitude = p.Location?.Longitude,
+    p.OriginalIndex,
+    p.PlaceId,
+})
+
+#!markdown
+
+## 6. Speed Limits
+
+> **Note:** the Speed Limits service is only available to customers with a Google **Asset Tracking**
+> license. Without it, Google returns an **HTTP 403** and the call below will throw — that's expected.
+> Each returned speed limit is also separately billable. The cell still shows the correct request
+> shape (supply either a `Path` or `PlaceIds`, plus optional `Units`), wrapped in `try/catch` so the
+> notebook keeps running.
+
+#!csharp
+
+var speedLimitsRequest = new SpeedLimitsRequest
+{
+    Path = roadPath,
+    Units = SpeedUnits.Kph,
+};
+
+try
+{
+    SpeedLimitsResponse speedResponse = await maps.SpeedLimits.QueryAsync(speedLimitsRequest);
+
+    speedResponse.SpeedLimits?.Select(s => new
+    {
+        s.PlaceId,
+        Limit = s.Value,
+        Units = s.Units?.ToString(),
+    })
+}
+catch (Exception ex)
+{
+    // Expected without an Asset Tracking license — Google responds with HTTP 403.
+    new[] { new { Outcome = "Speed Limits unavailable (expected without an Asset Tracking license)", Error = ex.Message } }
+}

--- a/samples/notebooks/Routes.dib
+++ b/samples/notebooks/Routes.dib
@@ -1,0 +1,117 @@
+#!meta
+
+{"kernelInfo":{"defaultKernelName":"csharp","items":[{"name":"csharp","languageName":"C#"}]}}
+
+#!markdown
+
+# Routes API
+
+Compute a route between an origin and a destination with the modern Routes API — real-time traffic,
+toll calculation, route alternatives, and a required response field mask. This notebook calls
+[`IGoogleMapsClient.Routes`](https://maximn.github.io/google-maps/) — the recommended replacement for
+the legacy Directions API.
+
+- Google docs: <https://developers.google.com/maps/documentation/routes>
+- Library types: `RoutesRequest` → `RoutesResponse`
+- **Cost:** free tier — not billable in this library's test gate.
+
+**How to run:** open this file in VS Code with the
+[Polyglot Notebooks](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.dotnet-interactive-vscode)
+extension, set the `GOOGLE_API_KEY` environment variable, then run the cells top to bottom.
+
+#!markdown
+
+## 1. Reference the package and import the namespaces
+
+#!csharp
+
+#r "nuget: GoogleMapsApi, 2.4.0"
+
+using GoogleMapsApi;
+using GoogleMapsApi.Entities.Common;
+using GoogleMapsApi.Entities.Routes.Request;
+using GoogleMapsApi.Entities.Routes.Response;
+
+#!markdown
+
+## 2. Read your API key
+
+The notebook reads the key from the `GOOGLE_API_KEY` environment variable, matching the project's
+samples. Prefer to type it in instead? Replace the cell with
+`var apiKey = await Microsoft.DotNet.Interactive.Kernel.GetInputAsync("Google Maps API key");`.
+
+#!csharp
+
+var apiKey = Environment.GetEnvironmentVariable("GOOGLE_API_KEY");
+if (string.IsNullOrWhiteSpace(apiKey))
+    throw new InvalidOperationException("Set the GOOGLE_API_KEY environment variable before running the API cells.");
+
+#!markdown
+
+## 3. Construct the client
+
+Build one `GoogleMapsClient` over a reused `HttpClient`. Passing the key via `GoogleMapsClientOptions`
+makes it ambient, so individual requests don't repeat it.
+
+#!csharp
+
+var http = new HttpClient();
+var maps = new GoogleMapsClient(http, new GoogleMapsClientOptions { ApiKey = apiKey });
+
+#!markdown
+
+## 4. Compute a route
+
+The Routes API is a `POST` call and **requires a field mask**. `RoutesRequest.FieldMask` is pre-populated
+with `RoutesRequest.DefaultFieldMask` (duration, distance, polyline, legs, warnings), so this cell relies
+on the default — tighten it to shrink the response and cost. Build origin/destination `Waypoint`s with the
+`Waypoint.FromAddress` / `Waypoint.FromCoordinates` / `Waypoint.FromPlaceId` factories.
+
+#!csharp
+
+var request = new RoutesRequest
+{
+    Origin = Waypoint.FromAddress("New York, NY"),
+    Destination = Waypoint.FromAddress("Philadelphia, PA"),
+    TravelMode = RoutesTravelMode.Drive,
+    RoutingPreference = RoutingPreference.TrafficAware,
+};
+
+RoutesResponse response = await maps.Routes.QueryAsync(request);
+
+if (response.Routes is null || response.Routes.Count == 0)
+    throw new Exception("Routes API returned no routes.");
+
+response.Routes.Select(r => new
+{
+    DistanceKm = Math.Round((r.DistanceMeters ?? 0) / 1000.0, 1),
+    DurationMinutes = Math.Round((r.DurationSeconds ?? 0) / 60.0, 1),
+    Legs = r.Legs?.Count ?? 0,
+    Warnings = r.Warnings is null ? "" : string.Join("; ", r.Warnings),
+})
+
+#!markdown
+
+## 5. Inspect the legs of the best route
+
+Each `RouteLeg` carries its own distance and parsed `DurationSeconds`. Construct waypoints from
+coordinates here (Mountain View → San Francisco) to show the `FromCoordinates` factory.
+
+#!csharp
+
+var coordRequest = new RoutesRequest
+{
+    Origin = Waypoint.FromCoordinates(37.3861, -122.0839),       // Mountain View, CA
+    Destination = Waypoint.FromCoordinates(37.7749, -122.4194),  // San Francisco, CA
+    TravelMode = RoutesTravelMode.Drive,
+};
+
+RoutesResponse coordResponse = await maps.Routes.QueryAsync(coordRequest);
+
+coordResponse.Routes?.FirstOrDefault()?.Legs?.Select((leg, i) => new
+{
+    Leg = i + 1,
+    DistanceKm = Math.Round((leg.DistanceMeters ?? 0) / 1000.0, 1),
+    DurationMinutes = Math.Round((leg.DurationSeconds ?? 0) / 60.0, 1),
+    Steps = leg.Steps?.Count ?? 0,
+})

--- a/samples/notebooks/Solar.dib
+++ b/samples/notebooks/Solar.dib
@@ -1,0 +1,162 @@
+#!meta
+
+{"kernelInfo":{"defaultKernelName":"csharp","items":[{"name":"csharp","languageName":"C#"}]}}
+
+#!markdown
+
+# Solar API
+
+Estimate a building's solar potential, list its raster data layers, then download a layer's GeoTIFF
+bytes. This notebook calls the `SolarBuildingInsights`, `SolarDataLayers` and `SolarGeoTiff` surfaces
+on [`IGoogleMapsClient`](https://maximn.github.io/google-maps/).
+
+- Google docs: <https://developers.google.com/maps/documentation/solar>
+- Library types: `BuildingInsightsRequest` → `BuildingInsightsResponse`, `DataLayersRequest` → `DataLayersResponse`, `GeoTiffRequest` → `GeoTiffResponse`
+- **Cost:** billable ⚠️
+
+**How to run:** open this file in VS Code with the
+[Polyglot Notebooks](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.dotnet-interactive-vscode)
+extension, set the `GOOGLE_API_KEY` environment variable, then run the cells top to bottom.
+
+#!markdown
+
+> [!WARNING]
+> **This API is billable.** Running the cells below calls a paid Google Maps API and **will incur charges** on your Google Cloud project. Only run them if you accept the cost.
+
+#!markdown
+
+## 1. Reference the package and import the namespaces
+
+#!csharp
+
+#r "nuget: GoogleMapsApi, 2.4.0"
+
+using GoogleMapsApi;
+using GoogleMapsApi.Entities.Common;
+using GoogleMapsApi.Entities.Solar.Request;
+using GoogleMapsApi.Entities.Solar.Response;
+
+#!markdown
+
+## 2. Read your API key
+
+The notebook reads the key from the `GOOGLE_API_KEY` environment variable, matching the project's
+samples. Prefer to type it in instead? Replace the cell with
+`var apiKey = await Microsoft.DotNet.Interactive.Kernel.GetInputAsync("Google Maps API key");`.
+
+#!csharp
+
+var apiKey = Environment.GetEnvironmentVariable("GOOGLE_API_KEY");
+if (string.IsNullOrWhiteSpace(apiKey))
+    throw new InvalidOperationException("Set the GOOGLE_API_KEY environment variable before running the API cells.");
+
+#!markdown
+
+## 3. Construct the client
+
+Build one `GoogleMapsClient` over a reused `HttpClient`. Passing the key via `GoogleMapsClientOptions`
+makes it ambient, so individual requests don't repeat it.
+
+#!csharp
+
+var http = new HttpClient();
+var maps = new GoogleMapsClient(http, new GoogleMapsClientOptions { ApiKey = apiKey });
+
+#!markdown
+
+## 4. Building Insights — solar potential for a coordinate
+
+`BuildingInsightsRequest` takes a `Latitude`/`Longitude` and an optional `RequiredQuality`. The Solar
+API finds the building closest to the point and returns its roof geometry, panel layouts and
+financials. We use a residential coordinate in California.
+
+#!csharp
+
+double latitude = 37.4450;
+double longitude = -122.1390;
+
+var insightsRequest = new BuildingInsightsRequest
+{
+    Latitude = latitude,
+    Longitude = longitude,
+    RequiredQuality = ImageryQuality.High,
+};
+
+BuildingInsightsResponse insights = await maps.SolarBuildingInsights.QueryAsync(insightsRequest);
+
+new[]
+{
+    new
+    {
+        insights.Name,
+        insights.PostalCode,
+        insights.AdministrativeArea,
+        insights.ImageryQuality,
+        MaxPanels = insights.SolarPotential?.MaxArrayPanelsCount,
+        MaxSunshineHoursPerYear = insights.SolarPotential?.MaxSunshineHoursPerYear,
+        MaxArrayAreaM2 = insights.SolarPotential?.MaxArrayAreaMeters2,
+    },
+}
+
+#!markdown
+
+## 5. Data Layers — raster layer URLs for the region
+
+`DataLayersRequest` takes the same coordinate plus a `RadiusMeters` (the API clamps to its supported
+range, up to ~100 m). The response holds URLs to each GeoTIFF layer (DSM, RGB, mask, annual/monthly
+flux, hourly shade). We keep one layer URL for the GeoTIFF download below.
+
+#!csharp
+
+var dataLayersRequest = new DataLayersRequest
+{
+    Latitude = latitude,
+    Longitude = longitude,
+    RadiusMeters = 50,
+    RequiredQuality = ImageryQuality.High,
+};
+
+DataLayersResponse dataLayers = await maps.SolarDataLayers.QueryAsync(dataLayersRequest);
+
+// Prefer the annual flux layer; fall back to DSM or RGB.
+var layerUrl = dataLayers.AnnualFluxUrl ?? dataLayers.DsmUrl ?? dataLayers.RgbUrl;
+
+if (string.IsNullOrWhiteSpace(layerUrl))
+    throw new Exception("Data Layers returned no layer URLs.");
+
+new[]
+{
+    new
+    {
+        dataLayers.ImageryQuality,
+        HasDsm = dataLayers.DsmUrl is not null,
+        HasRgb = dataLayers.RgbUrl is not null,
+        HasAnnualFlux = dataLayers.AnnualFluxUrl is not null,
+        HasMonthlyFlux = dataLayers.MonthlyFluxUrl is not null,
+        HourlyShadeMonths = dataLayers.HourlyShadeUrls?.Count ?? 0,
+    },
+}
+
+#!markdown
+
+## 6. GeoTIFF — download a layer's raw bytes
+
+`GeoTiffRequest` takes the `Url` of a data layer from the previous response. The response is **binary**
+(`Content` is a `byte[]`, plus a `ContentType`) — so we render the byte count and content type, not the
+bytes themselves.
+
+#!csharp
+
+var geoTiffRequest = new GeoTiffRequest { Url = layerUrl };
+
+GeoTiffResponse geoTiff = await maps.SolarGeoTiff.QueryAsync(geoTiffRequest);
+
+new[]
+{
+    new
+    {
+        geoTiff.ContentType,
+        ByteCount = geoTiff.Content.Length,
+        layerUrl,
+    },
+}

--- a/samples/notebooks/StaticMaps.dib
+++ b/samples/notebooks/StaticMaps.dib
@@ -1,0 +1,109 @@
+#!meta
+
+{"kernelInfo":{"defaultKernelName":"csharp","items":[{"name":"csharp","languageName":"C#"}]}}
+
+#!markdown
+
+# Static Maps API
+
+Generate a URL for a static map image — with markers, paths, and a chosen size/zoom — that you can
+drop straight into an `<img>` tag. Unlike the other APIs in this library, Static Maps does **not** go
+through `IGoogleMapsClient` / `QueryAsync`: you build the URL locally with
+[`StaticMapsEngine.GenerateStaticMapURL`](https://maximn.github.io/google-maps/) and the browser
+fetches the image. This notebook mirrors the Static Maps example in the project README.
+
+- Google docs: <https://developers.google.com/maps/documentation/maps-static>
+- Library types: `StaticMapRequest` → `StaticMapsEngine.GenerateStaticMapURL(...)` → image URL `string`
+- **Cost:** free tier — Static Maps URL generation is purely client-side; the (free) request is the image fetch your browser makes.
+
+**How to run:** open this file in VS Code with the
+[Polyglot Notebooks](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.dotnet-interactive-vscode)
+extension, set the `GOOGLE_API_KEY` environment variable, then run the cells top to bottom.
+
+#!markdown
+
+## 1. Reference the package and import the namespaces
+
+#!csharp
+
+#r "nuget: GoogleMapsApi, 2.4.0"
+
+using GoogleMapsApi.Entities.Common;
+using GoogleMapsApi.StaticMaps;
+using GoogleMapsApi.StaticMaps.Entities;
+
+#!markdown
+
+## 2. Read your API key
+
+The notebook reads the key from the `GOOGLE_API_KEY` environment variable, matching the project's
+samples. Prefer to type it in instead? Replace the cell with
+`var apiKey = await Microsoft.DotNet.Interactive.Kernel.GetInputAsync("Google Maps API key");`.
+
+Static Maps requires the key on the request itself: the engine only appends `&key=...` when
+`StaticMapRequest.ApiKey` is set, so without it the generated URL won't render an image.
+
+#!csharp
+
+var apiKey = Environment.GetEnvironmentVariable("GOOGLE_API_KEY");
+if (string.IsNullOrWhiteSpace(apiKey))
+    throw new InvalidOperationException("Set the GOOGLE_API_KEY environment variable before running the API cells.");
+
+#!markdown
+
+## 3. Construct the engine
+
+There's no HTTP client here — `StaticMapsEngine` is a tiny, stateless URL builder. Construct one and
+reuse it across requests.
+
+#!csharp
+
+var staticMapGenerator = new StaticMapsEngine();
+
+#!markdown
+
+## 4. Build the request and generate the URL
+
+`StaticMapRequest` takes a center (`Location`), a zoom level, and an `ImageSize`. Here we also overlay
+a red `Path` connecting a few points and set `ApiKey` so the URL is renderable.
+
+#!csharp
+
+var path = new Location[]
+{
+    new Location(40.737102, -73.990318),
+    new Location(40.749825, -73.987963),
+    new Location(40.752946, -73.987384),
+    new Location(40.755823, -73.986397),
+}.Cast<ILocationString>().ToList();
+
+var request = new StaticMapRequest(new Location(40.746, -73.988), 13, new ImageSize(800, 400))
+{
+    ApiKey = apiKey,
+    Pathes = new List<Path>
+    {
+        new Path
+        {
+            Style = new PathStyle { Color = "red", Weight = 4 },
+            Locations = path,
+        },
+    },
+};
+
+string url = staticMapGenerator.GenerateStaticMapURL(request);
+
+#!markdown
+
+## 5. Render the map inline
+
+Output the raw URL string so you can see exactly what was built, then render it as an inline image.
+
+#!csharp
+
+url
+
+#!csharp
+
+using Microsoft.DotNet.Interactive.Formatting;
+
+display(HTML($"<img src=\"{url}\" />"));

--- a/samples/notebooks/TimeZone.dib
+++ b/samples/notebooks/TimeZone.dib
@@ -1,0 +1,121 @@
+#!meta
+
+{"kernelInfo":{"defaultKernelName":"csharp","items":[{"name":"csharp","languageName":"C#"}]}}
+
+#!markdown
+
+# Time Zone API
+
+Resolve the time zone (IANA id, display name, and UTC/DST offsets) for a location at a given instant.
+This notebook calls [`IGoogleMapsClient.TimeZone`](https://maximn.github.io/google-maps/). The DST
+offset depends on the timestamp you pass, so the same location can return different offsets across the
+year.
+
+- Google docs: <https://developers.google.com/maps/documentation/timezone>
+- Library types: `TimeZoneRequest` → `TimeZoneResponse`
+- **Cost:** free tier — not billable in this library's test gate.
+
+**How to run:** open this file in VS Code with the
+[Polyglot Notebooks](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.dotnet-interactive-vscode)
+extension, set the `GOOGLE_API_KEY` environment variable, then run the cells top to bottom.
+
+#!markdown
+
+## 1. Reference the package and import the namespaces
+
+#!csharp
+
+#r "nuget: GoogleMapsApi, 2.4.0"
+
+using GoogleMapsApi;
+using GoogleMapsApi.Entities.Common;
+using GoogleMapsApi.Entities.TimeZone.Request;
+using GoogleMapsApi.Entities.TimeZone.Response;
+
+#!markdown
+
+## 2. Read your API key
+
+The notebook reads the key from the `GOOGLE_API_KEY` environment variable, matching the project's
+samples. Prefer to type it in instead? Replace the cell with
+`var apiKey = await Microsoft.DotNet.Interactive.Kernel.GetInputAsync("Google Maps API key");`.
+
+#!csharp
+
+var apiKey = Environment.GetEnvironmentVariable("GOOGLE_API_KEY");
+if (string.IsNullOrWhiteSpace(apiKey))
+    throw new InvalidOperationException("Set the GOOGLE_API_KEY environment variable before running the API cells.");
+
+#!markdown
+
+## 3. Construct the client
+
+Build one `GoogleMapsClient` over a reused `HttpClient`. Passing the key via `GoogleMapsClientOptions`
+makes it ambient, so individual requests don't repeat it.
+
+#!csharp
+
+var http = new HttpClient();
+var maps = new GoogleMapsClient(http, new GoogleMapsClientOptions { ApiKey = apiKey });
+
+#!markdown
+
+## 4. Time zone for a location, right now
+
+`TimeStamp` is a `DateTime` — Google uses it to decide whether daylight-saving time applies. Offsets
+are returned in seconds; we convert them to hours for readability.
+
+#!csharp
+
+var request = new TimeZoneRequest
+{
+    Location = new Location(40.714224, -73.961452),  // Brooklyn, New York
+    TimeStamp = DateTime.UtcNow,
+};
+
+TimeZoneResponse response = await maps.TimeZone.QueryAsync(request);
+
+if (response.Status != Status.OK)
+    throw new Exception($"Time zone lookup failed: {response.Status}");
+
+new[] { response }.Select(r => new
+{
+    r.TimeZoneId,
+    r.TimeZoneName,
+    RawOffsetHours = r.RawOffset / 3600,
+    DstOffsetHours = r.DstOffset / 3600,
+    TotalUtcOffsetHours = (r.RawOffset + r.DstOffset) / 3600,
+})
+
+#!markdown
+
+## 5. Compare a few locations at the same instant
+
+Reuse a single timestamp across several locations to see how their UTC offsets differ.
+
+#!csharp
+
+var instant = DateTime.UtcNow;
+
+var locations = new (string Label, Location Location)[]
+{
+    ("Sydney",  new Location(-33.8688, 151.2093)),
+    ("London",  new Location(51.5074, -0.1278)),
+    ("Denver",  new Location(39.7392, -104.9903)),
+    ("Tokyo",   new Location(35.6762, 139.6503)),
+};
+
+var rows = new List<object>();
+foreach (var (label, location) in locations)
+{
+    var tz = await maps.TimeZone.QueryAsync(new TimeZoneRequest { Location = location, TimeStamp = instant });
+    rows.Add(new
+    {
+        Place = label,
+        Status = tz.Status,
+        tz.TimeZoneId,
+        TotalUtcOffsetHours = (tz.RawOffset + tz.DstOffset) / 3600,
+    });
+}
+
+rows


### PR DESCRIPTION
## Summary

Adds live, runnable [Polyglot Notebook](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.dotnet-interactive-vscode) (`.dib`) samples — one per Google Maps API surface — as a more hands-on alternative to the README's static code blocks. Each notebook references the published `GoogleMapsApi` NuGet package and renders real API responses inline.

## Related issue

n/a

## Changes

- Add 12 `.dib` notebooks under `samples/notebooks/`, one per API surface: Geocoding, Routes, Directions, Distance Matrix, Elevation, Time Zone, Address Validation, Roads, Static Maps, plus the billable Places (New), Solar, and Aerial View.
- Each notebook references `#r "nuget: GoogleMapsApi, 2.4.0"`, reads the key from `GOOGLE_API_KEY`, constructs the client once, then calls the API and projects responses into inline tables; Static Maps renders the generated map URL as an inline image.
- Billable notebooks (Places New, Solar, Aerial View) lead with a `> [!WARNING]` cost banner; the legacy Directions and Distance Matrix notebooks point readers to the Routes notebook.
- Add `samples/notebooks/README.md` (run instructions + free/billable index) and cross-link the notebooks from the root `README.md` and `samples/README.md`.

## Test plan

- Notebooks are docs-only: no `.cs`, public-API, `.csproj`, or `CHANGELOG` changes, so the build and release flow are untouched.
- All entity/property/enum names were verified against the in-repo source.
- Manual end-to-end (requires a live key): `export GOOGLE_API_KEY=...`, open a notebook in VS Code's Polyglot Notebooks extension, and run cells top to bottom (e.g. `StaticMaps.dib` renders the map image inline).

## Checklist

- [x] `dotnet format` has been run. (n/a — no source files changed)
- [ ] `dotnet test` passes locally (with a valid `GOOGLE_API_KEY` for integration tests).
- [x] Multi-framework build passes (netstandard2.0, net8.0, net10.0). (n/a — no source files changed)
- [x] XML documentation updated if public API surface changed. (n/a — public API unchanged)
