### PR TITLE
ci: add Stryker.NET mutation testing workflow

### DIFF
--- a/.agents/build-release-ci.md
+++ b/.agents/build-release-ci.md
@@ -52,6 +52,10 @@ the default push/PR run **tests on `net10.0` only** — use `workflow_dispatch` 
 run `net8.0` or both. Uses the `GOOGLE_API_KEY` secret for live integration tests. Billable Places tests
 are gated by the `run-billable-tests` label or the dispatch input (see [`testing.md`](testing.md)).
 
+Two heavy jobs never gate PRs — both `workflow_dispatch`, and run on demand or on a schedule:
+`benchmarks.yml` (BenchmarkDotNet) and `mutation.yml` (Stryker.NET mutation testing, weekly Monday
+07:00 UTC — see [`testing.md`](testing.md)).
+
 ## Security & dependencies
 
 - `codeql.yml` — CodeQL scanning (scheduled + push/PR). `scorecard.yml` — OpenSSF Scorecard

--- a/.agents/testing.md
+++ b/.agents/testing.md
@@ -72,6 +72,28 @@ committed; until then it emits an explicit warning. A separate scheduled/dispatc
 `Integration` category live with the key + `RUN_BILLABLE_TESTS` to detect drift; the
 `run-billable-tests` PR label also triggers a live run.
 
+## Mutation testing (Stryker.NET)
+
+Line coverage proves code *ran*; mutation testing proves the assertions actually *catch*
+regressions. [Stryker.NET](https://stryker-mutator.io/docs/stryker-net/introduction/) injects faults
+into the shipped `GoogleMapsApi` library and checks the suite fails. Surviving mutants flag behavior
+no test pins down.
+
+It's slow, so it never gates PRs — `.github/workflows/mutation.yml` runs it weekly (Monday 07:00
+UTC) and on `workflow_dispatch`. The job publishes the score to the run's job summary and uploads the
+HTML report as the `mutation-report` artifact. The `break` threshold in `stryker-config.json` fails
+the job below that score. Baseline at introduction was **~46%**, so `break` is set to **40** (a little
+headroom); ratchet it up as test assertions improve rather than letting the score drift down.
+
+Run it locally (offline, from cassettes — no key, no charges):
+
+```bash
+dotnet tool restore                                  # installs pinned dotnet-stryker (.config/dotnet-tools.json)
+cd GoogleMapsApi.Test && VCR_MODE=replay dotnet stryker
+```
+
+Config lives in `GoogleMapsApi.Test/stryker-config.json` (mutates core only, target `net10.0`).
+
 ## Quota handling
 
 `Utils/AssertInconclusive` converts an `OVER_QUERY_LIMIT` response into an NUnit **inconclusive**

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-stryker": {
+      "version": "4.14.2",
+      "commands": [
+        "dotnet-stryker"
+      ]
+    }
+  }
+}

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -1,0 +1,49 @@
+name: Mutation Testing
+
+# Mutation testing is slow and CPU-heavy, so it never gates PRs — weekly + on demand only.
+on:
+  schedule:
+    - cron: '0 7 * * 1'   # Monday 07:00 UTC, offset from the other Monday jobs
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  stryker:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+    - name: Setup .NET
+      uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2  # v5.3.0
+      with:
+        dotnet-version: |
+          8.0.x
+          10.0.x
+    - name: Restore tools
+      run: dotnet tool restore
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Run Stryker
+      working-directory: GoogleMapsApi.Test
+      env:
+        VCR_MODE: replay   # offline: cassette replay, no Google quota
+      run: dotnet stryker
+    - name: Publish report to job summary
+      if: always()
+      shell: bash
+      run: |
+        report=$(find GoogleMapsApi.Test/StrykerOutput -name 'mutation-report.md' | head -n1)
+        if [ -n "$report" ]; then
+          cat "$report" >> "$GITHUB_STEP_SUMMARY"
+        else
+          echo "No Stryker markdown report produced." >> "$GITHUB_STEP_SUMMARY"
+        fi
+    - name: Upload HTML report
+      if: always()
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+      with:
+        name: mutation-report
+        path: GoogleMapsApi.Test/StrykerOutput/**/reports/mutation-report.html
+        if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -396,6 +396,9 @@ coverage*.xml
 publish/
 out/
 
+# Stryker.NET mutation testing reports
+StrykerOutput/
+
 # OS-specific
 .DS_Store
 Thumbs.db

--- a/GoogleMapsApi.Test/stryker-config.json
+++ b/GoogleMapsApi.Test/stryker-config.json
@@ -1,0 +1,18 @@
+{
+  "stryker-config": {
+    "project": "GoogleMapsApi.csproj",
+    "target-framework": "net10.0",
+    "reporters": [
+      "html",
+      "markdown",
+      "progress",
+      "cleartext"
+    ],
+    "coverage-analysis": "perTest",
+    "thresholds": {
+      "high": 80,
+      "low": 60,
+      "break": 40
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds optional Stryker.NET mutation testing as a standalone weekly (plus on-demand) CI job that never gates PRs, complementing the existing line-coverage badge by proving the test assertions actually catch regressions.

## Related issue

n/a

## Changes

- Pin `dotnet-stryker` 4.14.2 as a local tool in `.config/dotnet-tools.json` for reproducible runs.
- Add `GoogleMapsApi.Test/stryker-config.json`: mutate the core `GoogleMapsApi` library only on `net10.0`, `perTest` coverage, with a `break` threshold of 40 (baseline ~46%).
- Add `.github/workflows/mutation.yml`: runs weekly (Monday 07:00 UTC) and on `workflow_dispatch`, publishes the score to the job summary and uploads the HTML report as the `mutation-report` artifact (no secrets needed).
- Ignore `StrykerOutput/` and document local usage in `.agents/testing.md` / `.agents/build-release-ci.md`.

## Test plan

- Ran `dotnet tool restore` then `VCR_MODE=replay dotnet stryker` locally: it built, mutated the core library, ran the offline cassette-replay suite against each mutant, and produced `StrykerOutput/<ts>/reports/mutation-report.{html,md}` (baseline score 46.24%), confirming the config and workflow report/artifact paths.
- Verified the `break` gate works: a placeholder threshold of 60 correctly failed the run, so it was calibrated to 40.

## Checklist

- [ ] `dotnet format` has been run.
- [ ] `dotnet test` passes locally (with a valid `GOOGLE_API_KEY` for integration tests).
- [ ] Multi-framework build passes (netstandard2.0, net8.0, net10.0).
- [x] XML documentation updated if public API surface changed. (No public API change.)