### PR TITLE
feat: add Air Quality API (current conditions, forecast, history, heatmap tiles)

### DIFF
--- a/GoogleMapsApi.Test/AirQualityUnitTests.cs
+++ b/GoogleMapsApi.Test/AirQualityUnitTests.cs
@@ -1,0 +1,342 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using GoogleMapsApi.Entities.AirQuality.Request;
+using NUnit.Framework;
+
+namespace GoogleMapsApi.Test
+{
+    /// <summary>
+    /// Hermetic tests for the Air Quality API request/response plumbing. No live network calls — URLs are
+    /// asserted off <c>GetUri()</c>, request bodies are captured by a recording handler, and canned JSON
+    /// is fed back through a stub handler.
+    /// </summary>
+    [TestFixture]
+    public class AirQualityUnitTests
+    {
+        private const double Latitude = 37.4;
+        private const double Longitude = -122.1;
+
+        // --- URL generation ---------------------------------------------------------------
+
+        [Test]
+        public void CurrentConditions_GetUri_BuildsExpectedUrl()
+        {
+            var uri = new CurrentConditionsRequest { ApiKey = "k", Latitude = Latitude, Longitude = Longitude }.GetUri();
+
+            Assert.That(uri.Scheme, Is.EqualTo("https"));
+            Assert.That(uri.Host, Is.EqualTo("airquality.googleapis.com"));
+            Assert.That(uri.AbsolutePath, Is.EqualTo("/v1/currentConditions:lookup"));
+            Assert.That(uri.Query, Does.Contain("key=k"));
+        }
+
+        [Test]
+        public void Forecast_GetUri_UsesForecastEndpoint()
+        {
+            var uri = new ForecastRequest { ApiKey = "k", Latitude = Latitude, Longitude = Longitude }.GetUri();
+            Assert.That(uri.AbsolutePath, Is.EqualTo("/v1/forecast:lookup"));
+        }
+
+        [Test]
+        public void History_GetUri_UsesHistoryEndpoint()
+        {
+            var uri = new HistoryRequest { ApiKey = "k", Latitude = Latitude, Longitude = Longitude }.GetUri();
+            Assert.That(uri.AbsolutePath, Is.EqualTo("/v1/history:lookup"));
+        }
+
+        [Test]
+        public void HeatmapTile_GetUri_BuildsTilePathWithMapType()
+        {
+            var uri = new HeatmapTileRequest
+            {
+                ApiKey = "k",
+                MapType = AirQualityMapType.UsAqi,
+                Zoom = 4,
+                X = 3,
+                Y = 6,
+            }.GetUri();
+
+            Assert.That(uri.Host, Is.EqualTo("airquality.googleapis.com"));
+            Assert.That(uri.AbsolutePath, Is.EqualTo("/v1/mapTypes/US_AQI/heatmapTiles/4/3/6"));
+            Assert.That(uri.Query, Does.Contain("key=k"));
+        }
+
+        // --- Guard clauses ----------------------------------------------------------------
+
+        [Test]
+        public void CurrentConditions_GetUri_MissingApiKey_Throws()
+        {
+            Assert.Throws<InvalidOperationException>(
+                () => new CurrentConditionsRequest { Latitude = Latitude, Longitude = Longitude }.GetUri());
+        }
+
+        [Test]
+        public void CurrentConditions_GetUri_NonSsl_Throws()
+        {
+            Assert.Throws<ArgumentException>(
+                () => new CurrentConditionsRequest { ApiKey = "k", IsSSL = false, Latitude = Latitude, Longitude = Longitude }.GetUri());
+        }
+
+        [Test]
+        public void HeatmapTile_GetUri_ZoomOutOfRange_Throws()
+        {
+            Assert.Throws<ArgumentException>(
+                () => new HeatmapTileRequest { ApiKey = "k", MapType = AirQualityMapType.UsAqi, Zoom = 17, X = 1, Y = 1 }.GetUri());
+        }
+
+        // --- POST body serialization ------------------------------------------------------
+
+        [Test]
+        public async Task CurrentConditions_QueryAsync_PostsExpectedBody()
+        {
+            var handler = new RecordingHandler("{}");
+            using var http = new HttpClient(handler);
+            var client = new GoogleMapsClient(http, new GoogleMapsClientOptions { ApiKey = "k" });
+
+            await client.AirQualityCurrentConditions.QueryAsync(new CurrentConditionsRequest
+            {
+                Latitude = Latitude,
+                Longitude = Longitude,
+                UniversalAqi = false,
+                ExtraComputations = new() { ExtraComputation.HealthRecommendations, ExtraComputation.PollutantConcentration },
+                LanguageCode = "en",
+            });
+
+            Assert.That(handler.LastMethod, Is.EqualTo(HttpMethod.Post));
+            Assert.That(handler.LastContentType, Is.EqualTo("application/json"));
+            Assert.That(handler.LastRequestBody, Does.Contain("\"latitude\":37.4"));
+            Assert.That(handler.LastRequestBody, Does.Contain("\"longitude\":-122.1"));
+            Assert.That(handler.LastRequestBody, Does.Contain("\"universalAqi\":false"));
+            Assert.That(handler.LastRequestBody, Does.Contain("\"HEALTH_RECOMMENDATIONS\""));
+            Assert.That(handler.LastRequestBody, Does.Contain("\"POLLUTANT_CONCENTRATION\""));
+        }
+
+        [Test]
+        public async Task CurrentConditions_QueryAsync_OmitsUnsetOptionalFields()
+        {
+            var handler = new RecordingHandler("{}");
+            using var http = new HttpClient(handler);
+            var client = new GoogleMapsClient(http, new GoogleMapsClientOptions { ApiKey = "k" });
+
+            await client.AirQualityCurrentConditions.QueryAsync(
+                new CurrentConditionsRequest { Latitude = Latitude, Longitude = Longitude });
+
+            Assert.That(handler.LastRequestBody, Does.Not.Contain("extraComputations"));
+            Assert.That(handler.LastRequestBody, Does.Not.Contain("languageCode"));
+            Assert.That(handler.LastRequestBody, Does.Not.Contain("universalAqi"));
+        }
+
+        [Test]
+        public async Task Forecast_QueryAsync_SerializesPeriodAndPaging()
+        {
+            var handler = new RecordingHandler("{}");
+            using var http = new HttpClient(handler);
+            var client = new GoogleMapsClient(http, new GoogleMapsClientOptions { ApiKey = "k" });
+
+            await client.AirQualityForecast.QueryAsync(new ForecastRequest
+            {
+                Latitude = Latitude,
+                Longitude = Longitude,
+                Period = new Interval
+                {
+                    StartTime = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                    EndTime = new DateTimeOffset(2024, 1, 2, 0, 0, 0, TimeSpan.Zero),
+                },
+                PageSize = 12,
+                PageToken = "tok",
+            });
+
+            Assert.That(handler.LastRequestBody, Does.Contain("\"startTime\":\"2024-01-01T00:00:00Z\""));
+            Assert.That(handler.LastRequestBody, Does.Contain("\"endTime\":\"2024-01-02T00:00:00Z\""));
+            Assert.That(handler.LastRequestBody, Does.Contain("\"pageSize\":12"));
+            Assert.That(handler.LastRequestBody, Does.Contain("\"pageToken\":\"tok\""));
+        }
+
+        [Test]
+        public void Forecast_QueryAsync_DateTimeAndPeriodTogether_Throws()
+        {
+            var handler = new RecordingHandler("{}");
+            using var http = new HttpClient(handler);
+            var client = new GoogleMapsClient(http, new GoogleMapsClientOptions { ApiKey = "k" });
+
+            Assert.ThrowsAsync<InvalidOperationException>(async () =>
+                await client.AirQualityForecast.QueryAsync(new ForecastRequest
+                {
+                    Latitude = Latitude,
+                    Longitude = Longitude,
+                    DateTime = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                    Period = new Interval { StartTime = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero) },
+                }));
+        }
+
+        [Test]
+        public async Task History_QueryAsync_SerializesHours()
+        {
+            var handler = new RecordingHandler("{}");
+            using var http = new HttpClient(handler);
+            var client = new GoogleMapsClient(http, new GoogleMapsClientOptions { ApiKey = "k" });
+
+            await client.AirQualityHistory.QueryAsync(new HistoryRequest
+            {
+                Latitude = Latitude,
+                Longitude = Longitude,
+                Hours = 24,
+            });
+
+            Assert.That(handler.LastRequestBody, Does.Contain("\"hours\":24"));
+        }
+
+        [Test]
+        public void History_QueryAsync_MultipleRanges_Throws()
+        {
+            var handler = new RecordingHandler("{}");
+            using var http = new HttpClient(handler);
+            var client = new GoogleMapsClient(http, new GoogleMapsClientOptions { ApiKey = "k" });
+
+            Assert.ThrowsAsync<InvalidOperationException>(async () =>
+                await client.AirQualityHistory.QueryAsync(new HistoryRequest
+                {
+                    Latitude = Latitude,
+                    Longitude = Longitude,
+                    Hours = 24,
+                    DateTime = new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                }));
+        }
+
+        // --- JSON deserialization ---------------------------------------------------------
+
+        [Test]
+        public async Task CurrentConditions_QueryAsync_DeserializesNestedFields()
+        {
+            const string json = """
+            {
+              "dateTime": "2024-01-01T10:00:00Z",
+              "regionCode": "us",
+              "indexes": [
+                { "code": "uaqi", "displayName": "Universal AQI", "aqi": 63, "aqiDisplay": "63",
+                  "color": { "red": 0.2, "green": 0.8, "blue": 0.1 },
+                  "category": "Good air quality", "dominantPollutant": "pm25" }
+              ],
+              "pollutants": [
+                { "code": "pm25", "displayName": "PM2.5", "fullName": "Fine particulate matter",
+                  "concentration": { "units": "MICROGRAMS_PER_CUBIC_METER", "value": 12.5 },
+                  "additionalInfo": { "sources": "Combustion", "effects": "Respiratory" } }
+              ],
+              "healthRecommendations": { "generalPopulation": "Enjoy outdoor activities." }
+            }
+            """;
+            using var handler = new StubHandler(Encoding.UTF8.GetBytes(json), "application/json");
+            using var http = new HttpClient(handler);
+            var client = new GoogleMapsClient(http, new GoogleMapsClientOptions { ApiKey = "k" });
+
+            var response = await client.AirQualityCurrentConditions.QueryAsync(
+                new CurrentConditionsRequest { Latitude = Latitude, Longitude = Longitude });
+
+            Assert.That(response.RegionCode, Is.EqualTo("us"));
+            Assert.That(response.Indexes, Is.Not.Null.And.Count.EqualTo(1));
+            Assert.That(response.Indexes![0].Aqi, Is.EqualTo(63));
+            Assert.That(response.Indexes[0].Color!.Green, Is.EqualTo(0.8f));
+            Assert.That(response.Pollutants![0].Concentration!.Value, Is.EqualTo(12.5));
+            Assert.That(response.Pollutants[0].AdditionalInfo!.Sources, Is.EqualTo("Combustion"));
+            Assert.That(response.HealthRecommendations!.GeneralPopulation, Is.EqualTo("Enjoy outdoor activities."));
+        }
+
+        [Test]
+        public async Task Forecast_QueryAsync_DeserializesHourlyForecasts()
+        {
+            const string json = """
+            {
+              "hourlyForecasts": [
+                { "dateTime": "2024-01-01T10:00:00Z", "indexes": [ { "code": "uaqi", "aqi": 70 } ] }
+              ],
+              "regionCode": "us",
+              "nextPageToken": "next"
+            }
+            """;
+            using var handler = new StubHandler(Encoding.UTF8.GetBytes(json), "application/json");
+            using var http = new HttpClient(handler);
+            var client = new GoogleMapsClient(http, new GoogleMapsClientOptions { ApiKey = "k" });
+
+            var response = await client.AirQualityForecast.QueryAsync(
+                new ForecastRequest { Latitude = Latitude, Longitude = Longitude });
+
+            Assert.That(response.HourlyForecasts, Is.Not.Null.And.Count.EqualTo(1));
+            Assert.That(response.HourlyForecasts![0].Indexes![0].Aqi, Is.EqualTo(70));
+            Assert.That(response.NextPageToken, Is.EqualTo("next"));
+        }
+
+        // --- Binary engine path -----------------------------------------------------------
+
+        [Test]
+        public async Task HeatmapTile_QueryAsync_ReturnsRawBytesAndContentType()
+        {
+            var payload = new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A };
+            using var handler = new StubHandler(payload, "image/png");
+            using var http = new HttpClient(handler);
+            var client = new GoogleMapsClient(http, new GoogleMapsClientOptions { ApiKey = "k" });
+
+            var response = await client.AirQualityHeatmapTile.QueryAsync(new HeatmapTileRequest
+            {
+                MapType = AirQualityMapType.UaqiRedGreen,
+                Zoom = 4,
+                X = 1,
+                Y = 2,
+            });
+
+            Assert.That(response.Content, Is.EqualTo(payload));
+            Assert.That(response.ContentType, Is.EqualTo("image/png"));
+        }
+
+        private sealed class StubHandler : HttpMessageHandler
+        {
+            private readonly byte[] _body;
+            private readonly string _mediaType;
+
+            public StubHandler(byte[] body, string mediaType)
+            {
+                _body = body;
+                _mediaType = mediaType;
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var content = new ByteArrayContent(_body);
+                content.Headers.ContentType = new MediaTypeHeaderValue(_mediaType);
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = content });
+            }
+        }
+
+        private sealed class RecordingHandler : HttpMessageHandler
+        {
+            private readonly string _responseJson;
+
+            public RecordingHandler(string responseJson) => _responseJson = responseJson;
+
+            public HttpMethod? LastMethod { get; private set; }
+            public Uri? LastUri { get; private set; }
+            public string? LastRequestBody { get; private set; }
+            public string? LastContentType { get; private set; }
+
+            protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                LastMethod = request.Method;
+                LastUri = request.RequestUri;
+                if (request.Content != null)
+                {
+                    LastRequestBody = await request.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    LastContentType = request.Content.Headers.ContentType?.MediaType;
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(_responseJson, Encoding.UTF8, "application/json"),
+                };
+            }
+        }
+    }
+}

--- a/GoogleMapsApi.Test/IntegrationTests/AirQualityTests.cs
+++ b/GoogleMapsApi.Test/IntegrationTests/AirQualityTests.cs
@@ -1,0 +1,81 @@
+using System.Threading.Tasks;
+using GoogleMapsApi.Entities.AirQuality.Request;
+using GoogleMapsApi.Test.Utils;
+using NUnit.Framework;
+
+namespace GoogleMapsApi.Test.IntegrationTests
+{
+    /// <summary>
+    /// Live Air Quality API tests. The Air Quality API is billable, so in live modes these are skipped
+    /// unless <c>RUN_BILLABLE_TESTS=true</c> (with a key that has the Air Quality API enabled). Under the
+    /// default <c>VCR_MODE=replay</c> they serve committed cassettes — free and offline.
+    /// </summary>
+    [TestFixture]
+    [BillableTest]
+    public class AirQualityTests : BaseTestIntegration
+    {
+        // Mountain View, CA.
+        private const double Latitude = 37.4220;
+        private const double Longitude = -122.0841;
+
+        [Test]
+        public async Task CurrentConditions_ValidLocation_ReturnsIndexes()
+        {
+            var response = await Maps.AirQualityCurrentConditions.QueryAsync(new CurrentConditionsRequest
+            {
+                ApiKey = ApiKey,
+                Latitude = Latitude,
+                Longitude = Longitude,
+                ExtraComputations = new() { ExtraComputation.HealthRecommendations, ExtraComputation.PollutantConcentration },
+            });
+
+            Assert.That(response.RegionCode, Is.Not.Null.And.Not.Empty);
+            Assert.That(response.Indexes, Is.Not.Null.And.Not.Empty);
+            Assert.That(response.Indexes![0].Aqi, Is.GreaterThan(0));
+        }
+
+        [Test]
+        public async Task Forecast_ValidLocation_ReturnsHourlyForecasts()
+        {
+            var response = await Maps.AirQualityForecast.QueryAsync(new ForecastRequest
+            {
+                ApiKey = ApiKey,
+                Latitude = Latitude,
+                Longitude = Longitude,
+                PageSize = 6,
+            });
+
+            Assert.That(response.HourlyForecasts, Is.Not.Null.And.Not.Empty);
+            Assert.That(response.HourlyForecasts![0].Indexes, Is.Not.Null.And.Not.Empty);
+        }
+
+        [Test]
+        public async Task History_ValidLocation_ReturnsHours()
+        {
+            var response = await Maps.AirQualityHistory.QueryAsync(new HistoryRequest
+            {
+                ApiKey = ApiKey,
+                Latitude = Latitude,
+                Longitude = Longitude,
+                Hours = 6,
+            });
+
+            Assert.That(response.HoursInfo, Is.Not.Null.And.Not.Empty);
+        }
+
+        [Test]
+        public async Task HeatmapTile_ValidTile_DownloadsPngBytes()
+        {
+            var response = await Maps.AirQualityHeatmapTile.QueryAsync(new HeatmapTileRequest
+            {
+                ApiKey = ApiKey,
+                MapType = AirQualityMapType.UsAqi,
+                Zoom = 4,
+                X = 4,
+                Y = 6,
+            });
+
+            Assert.That(response.Content, Is.Not.Null.And.Not.Empty);
+        }
+    }
+}

--- a/GoogleMapsApi.Test/IntegrationTests/PollenTests.cs
+++ b/GoogleMapsApi.Test/IntegrationTests/PollenTests.cs
@@ -1,0 +1,52 @@
+using System.Threading.Tasks;
+using GoogleMapsApi.Entities.Pollen.Request;
+using GoogleMapsApi.Test.Utils;
+using NUnit.Framework;
+
+namespace GoogleMapsApi.Test.IntegrationTests
+{
+    /// <summary>
+    /// Live Pollen API tests. The Pollen API is billable, so in live modes these are skipped unless
+    /// <c>RUN_BILLABLE_TESTS=true</c> (with a key that has the Pollen API enabled). Under the default
+    /// <c>VCR_MODE=replay</c> they serve committed cassettes — free and offline.
+    /// </summary>
+    [TestFixture]
+    [BillableTest]
+    public class PollenTests : BaseTestIntegration
+    {
+        // Madrid, Spain — reliably has pollen forecast coverage.
+        private const double Latitude = 40.4168;
+        private const double Longitude = -3.7038;
+
+        [Test]
+        public async Task Forecast_ValidLocation_ReturnsDailyInfo()
+        {
+            var response = await Maps.PollenForecast.QueryAsync(new PollenForecastRequest
+            {
+                ApiKey = ApiKey,
+                Latitude = Latitude,
+                Longitude = Longitude,
+                Days = 3,
+            });
+
+            Assert.That(response.RegionCode, Is.Not.Null.And.Not.Empty);
+            Assert.That(response.DailyInfo, Is.Not.Null.And.Not.Empty);
+            Assert.That(response.DailyInfo![0].Date, Is.Not.Null);
+        }
+
+        [Test]
+        public async Task HeatmapTile_ValidTile_DownloadsPngBytes()
+        {
+            var response = await Maps.PollenHeatmapTile.QueryAsync(new PollenHeatmapTileRequest
+            {
+                ApiKey = ApiKey,
+                MapType = PollenMapType.TreeUpi,
+                Zoom = 4,
+                X = 8,
+                Y = 6,
+            });
+
+            Assert.That(response.Content, Is.Not.Null.And.Not.Empty);
+        }
+    }
+}

--- a/GoogleMapsApi.Test/PollenUnitTests.cs
+++ b/GoogleMapsApi.Test/PollenUnitTests.cs
@@ -1,0 +1,215 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using GoogleMapsApi.Entities.Pollen.Request;
+using NUnit.Framework;
+
+namespace GoogleMapsApi.Test
+{
+    /// <summary>
+    /// Hermetic tests for the Pollen API request/response plumbing. No live network calls — URLs are
+    /// asserted off <c>GetUri()</c> and canned JSON is fed back through a stub handler.
+    /// </summary>
+    [TestFixture]
+    public class PollenUnitTests
+    {
+        private const double Latitude = 37.4;
+        private const double Longitude = -122.1;
+
+        // --- URL generation ---------------------------------------------------------------
+
+        [Test]
+        public void Forecast_GetUri_BuildsExpectedUrl()
+        {
+            var uri = new PollenForecastRequest
+            {
+                ApiKey = "k",
+                Latitude = Latitude,
+                Longitude = Longitude,
+                Days = 3,
+            }.GetUri();
+
+            Assert.That(uri.Scheme, Is.EqualTo("https"));
+            Assert.That(uri.Host, Is.EqualTo("pollen.googleapis.com"));
+            Assert.That(uri.AbsolutePath, Is.EqualTo("/v1/forecast:lookup"));
+            Assert.That(uri.Query, Does.Contain("location.latitude=37.4"));
+            Assert.That(uri.Query, Does.Contain("location.longitude=-122.1"));
+            Assert.That(uri.Query, Does.Contain("days=3"));
+            Assert.That(uri.Query, Does.Contain("key=k"));
+        }
+
+        [Test]
+        public void Forecast_GetUri_AppendsOptionalParameters()
+        {
+            var uri = new PollenForecastRequest
+            {
+                ApiKey = "k",
+                Latitude = Latitude,
+                Longitude = Longitude,
+                Days = 5,
+                PageSize = 2,
+                PageToken = "tok",
+                LanguageCode = "fr",
+                PlantsDescription = false,
+            }.GetUri();
+
+            Assert.That(uri.Query, Does.Contain("pageSize=2"));
+            Assert.That(uri.Query, Does.Contain("pageToken=tok"));
+            Assert.That(uri.Query, Does.Contain("languageCode=fr"));
+            Assert.That(uri.Query, Does.Contain("plantsDescription=false"));
+        }
+
+        [Test]
+        public void Forecast_GetUri_OmitsOptionalParameters_WhenUnset()
+        {
+            var uri = new PollenForecastRequest { ApiKey = "k", Latitude = Latitude, Longitude = Longitude, Days = 1 }.GetUri();
+
+            Assert.That(uri.Query, Does.Not.Contain("pageSize"));
+            Assert.That(uri.Query, Does.Not.Contain("pageToken"));
+            Assert.That(uri.Query, Does.Not.Contain("languageCode"));
+            Assert.That(uri.Query, Does.Not.Contain("plantsDescription"));
+        }
+
+        [Test]
+        public void HeatmapTile_GetUri_BuildsTilePathWithMapType()
+        {
+            var uri = new PollenHeatmapTileRequest
+            {
+                ApiKey = "k",
+                MapType = PollenMapType.GrassUpi,
+                Zoom = 5,
+                X = 9,
+                Y = 12,
+            }.GetUri();
+
+            Assert.That(uri.Host, Is.EqualTo("pollen.googleapis.com"));
+            Assert.That(uri.AbsolutePath, Is.EqualTo("/v1/mapTypes/GRASS_UPI/heatmapTiles/5/9/12"));
+            Assert.That(uri.Query, Does.Contain("key=k"));
+        }
+
+        // --- Guard clauses ----------------------------------------------------------------
+
+        [Test]
+        public void Forecast_GetUri_MissingApiKey_Throws()
+        {
+            Assert.Throws<InvalidOperationException>(
+                () => new PollenForecastRequest { Latitude = Latitude, Longitude = Longitude, Days = 1 }.GetUri());
+        }
+
+        [Test]
+        public void Forecast_GetUri_NonSsl_Throws()
+        {
+            Assert.Throws<ArgumentException>(
+                () => new PollenForecastRequest { ApiKey = "k", IsSSL = false, Latitude = Latitude, Longitude = Longitude, Days = 1 }.GetUri());
+        }
+
+        [Test]
+        public void Forecast_GetUri_DaysOutOfRange_Throws([Values(0, 6)] int days)
+        {
+            Assert.Throws<ArgumentException>(
+                () => new PollenForecastRequest { ApiKey = "k", Latitude = Latitude, Longitude = Longitude, Days = days }.GetUri());
+        }
+
+        [Test]
+        public void HeatmapTile_GetUri_ZoomOutOfRange_Throws()
+        {
+            Assert.Throws<ArgumentException>(
+                () => new PollenHeatmapTileRequest { ApiKey = "k", MapType = PollenMapType.TreeUpi, Zoom = 17, X = 1, Y = 1 }.GetUri());
+        }
+
+        // --- JSON deserialization ---------------------------------------------------------
+
+        [Test]
+        public async Task Forecast_QueryAsync_DeserializesNestedFields()
+        {
+            const string json = """
+            {
+              "regionCode": "US",
+              "dailyInfo": [
+                {
+                  "date": { "year": 2024, "month": 4, "day": 1 },
+                  "pollenTypeInfo": [
+                    { "code": "TREE", "displayName": "Tree", "inSeason": true,
+                      "indexInfo": { "code": "UPI", "displayName": "Universal Pollen Index", "value": 3,
+                                     "category": "Moderate", "color": { "red": 1.0, "green": 0.8 } },
+                      "healthRecommendations": [ "Keep windows closed." ] }
+                  ],
+                  "plantInfo": [
+                    { "code": "BIRCH", "displayName": "Birch", "inSeason": true,
+                      "indexInfo": { "code": "UPI", "value": 4, "category": "High" },
+                      "plantDescription": { "type": "TREE", "family": "Betulaceae", "season": "Spring",
+                                            "picture": "https://example/birch.png" } }
+                  ]
+                }
+              ],
+              "nextPageToken": "next"
+            }
+            """;
+            using var handler = new StubHandler(Encoding.UTF8.GetBytes(json), "application/json");
+            using var http = new HttpClient(handler);
+            var client = new GoogleMapsClient(http, new GoogleMapsClientOptions { ApiKey = "k" });
+
+            var response = await client.PollenForecast.QueryAsync(
+                new PollenForecastRequest { Latitude = Latitude, Longitude = Longitude, Days = 1 });
+
+            Assert.That(response.RegionCode, Is.EqualTo("US"));
+            Assert.That(response.DailyInfo, Is.Not.Null.And.Count.EqualTo(1));
+
+            var day = response.DailyInfo![0];
+            Assert.That(day.Date!.Year, Is.EqualTo(2024));
+            Assert.That(day.PollenTypeInfo![0].Code, Is.EqualTo("TREE"));
+            Assert.That(day.PollenTypeInfo[0].IndexInfo!.Value, Is.EqualTo(3));
+            Assert.That(day.PollenTypeInfo[0].IndexInfo!.Color!.Red, Is.EqualTo(1.0f));
+            Assert.That(day.PollenTypeInfo[0].HealthRecommendations![0], Is.EqualTo("Keep windows closed."));
+            Assert.That(day.PlantInfo![0].Code, Is.EqualTo("BIRCH"));
+            Assert.That(day.PlantInfo[0].PlantDescription!.Family, Is.EqualTo("Betulaceae"));
+            Assert.That(response.NextPageToken, Is.EqualTo("next"));
+        }
+
+        // --- Binary engine path -----------------------------------------------------------
+
+        [Test]
+        public async Task HeatmapTile_QueryAsync_ReturnsRawBytesAndContentType()
+        {
+            var payload = new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A };
+            using var handler = new StubHandler(payload, "image/png");
+            using var http = new HttpClient(handler);
+            var client = new GoogleMapsClient(http, new GoogleMapsClientOptions { ApiKey = "k" });
+
+            var response = await client.PollenHeatmapTile.QueryAsync(new PollenHeatmapTileRequest
+            {
+                MapType = PollenMapType.WeedUpi,
+                Zoom = 4,
+                X = 1,
+                Y = 2,
+            });
+
+            Assert.That(response.Content, Is.EqualTo(payload));
+            Assert.That(response.ContentType, Is.EqualTo("image/png"));
+        }
+
+        private sealed class StubHandler : HttpMessageHandler
+        {
+            private readonly byte[] _body;
+            private readonly string _mediaType;
+
+            public StubHandler(byte[] body, string mediaType)
+            {
+                _body = body;
+                _mediaType = mediaType;
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var content = new ByteArrayContent(_body);
+                content.Headers.ContentType = new MediaTypeHeaderValue(_mediaType);
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = content });
+            }
+        }
+    }
+}

--- a/GoogleMapsApi/Entities/AirQuality/Request/AirQualityJson.cs
+++ b/GoogleMapsApi/Entities/AirQuality/Request/AirQualityJson.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using GoogleMapsApi.Engine.JsonConverters;
+
+namespace GoogleMapsApi.Entities.AirQuality.Request
+{
+    /// <summary>
+    /// Shared serialization helpers for the Air Quality POST request bodies. Internal: not part of the
+    /// public surface.
+    /// </summary>
+    internal static class AirQualityJson
+    {
+        /// <summary>Options for serializing request bodies: omit nulls and emit enums by their wire value.</summary>
+        public static readonly JsonSerializerOptions BodyOptions = BuildBodyOptions();
+
+        private static JsonSerializerOptions BuildBodyOptions()
+        {
+            var opts = new JsonSerializerOptions
+            {
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            };
+            opts.Converters.Add(new EnumMemberJsonConverterFactory());
+            return opts;
+        }
+
+        /// <summary>Formats a timestamp as the RFC3339 UTC string the Air Quality API expects.</summary>
+        public static string Rfc3339(DateTimeOffset value) =>
+            value.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture);
+    }
+}

--- a/GoogleMapsApi/Entities/AirQuality/Request/AirQualityMapType.cs
+++ b/GoogleMapsApi/Entities/AirQuality/Request/AirQualityMapType.cs
@@ -1,0 +1,38 @@
+using System.Runtime.Serialization;
+
+namespace GoogleMapsApi.Entities.AirQuality.Request
+{
+    /// <summary>
+    /// The air-quality heatmap type (index and colour scheme) for a
+    /// <see cref="HeatmapTileRequest"/>. Determines which pollutant/index the returned PNG tile renders.
+    /// </summary>
+    public enum AirQualityMapType
+    {
+        /// <summary>No map type specified. Ignored by the server if sent.</summary>
+        [EnumMember(Value = "MAP_TYPE_UNSPECIFIED")] Unspecified,
+
+        /// <summary>Universal AQI, red-green palette.</summary>
+        [EnumMember(Value = "UAQI_RED_GREEN")] UaqiRedGreen,
+
+        /// <summary>Universal AQI, indigo-Persian palette.</summary>
+        [EnumMember(Value = "UAQI_INDIGO_PERSIAN")] UaqiIndigoPersian,
+
+        /// <summary>PM2.5 concentration, indigo-Persian palette.</summary>
+        [EnumMember(Value = "PM25_INDIGO_PERSIAN")] Pm25IndigoPersian,
+
+        /// <summary>UK DEFRA Daily Air Quality Index.</summary>
+        [EnumMember(Value = "GBR_DEFRA")] GbrDefra,
+
+        /// <summary>German Federal Environment Agency (UBA) index.</summary>
+        [EnumMember(Value = "DEU_UBA")] DeuUba,
+
+        /// <summary>Environment Canada Air Quality Health Index.</summary>
+        [EnumMember(Value = "CAN_EC")] CanEc,
+
+        /// <summary>French ATMO index.</summary>
+        [EnumMember(Value = "FRA_ATMO")] FraAtmo,
+
+        /// <summary>US EPA Air Quality Index.</summary>
+        [EnumMember(Value = "US_AQI")] UsAqi,
+    }
+}

--- a/GoogleMapsApi/Entities/AirQuality/Request/ColorPalette.cs
+++ b/GoogleMapsApi/Entities/AirQuality/Request/ColorPalette.cs
@@ -1,0 +1,23 @@
+using System.Runtime.Serialization;
+
+namespace GoogleMapsApi.Entities.AirQuality.Request
+{
+    /// <summary>
+    /// Colour palette used for the Universal Air Quality Index in the response (and in heatmap tiles).
+    /// Supplied via <c>uaqiColorPalette</c>.
+    /// </summary>
+    public enum ColorPalette
+    {
+        /// <summary>No palette specified; the API picks a default.</summary>
+        [EnumMember(Value = "COLOR_PALETTE_UNSPECIFIED")] Unspecified,
+
+        /// <summary>Red-to-green palette.</summary>
+        [EnumMember(Value = "RED_GREEN")] RedGreen,
+
+        /// <summary>Indigo-to-Persian palette, dark theme.</summary>
+        [EnumMember(Value = "INDIGO_PERSIAN_DARK")] IndigoPersianDark,
+
+        /// <summary>Indigo-to-Persian palette, light theme.</summary>
+        [EnumMember(Value = "INDIGO_PERSIAN_LIGHT")] IndigoPersianLight,
+    }
+}

--- a/GoogleMapsApi/Entities/AirQuality/Request/CurrentConditionsRequest.cs
+++ b/GoogleMapsApi/Entities/AirQuality/Request/CurrentConditionsRequest.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using GoogleMapsApi.Entities.Common;
+
+namespace GoogleMapsApi.Entities.AirQuality.Request
+{
+    /// <summary>
+    /// Request for the Air Quality API <c>currentConditions:lookup</c> endpoint
+    /// (<c>POST https://airquality.googleapis.com/v1/currentConditions:lookup</c>). Returns hourly
+    /// air-quality information for a coordinate.
+    /// </summary>
+    /// <remarks>The Air Quality API is billable; calls beyond the free tier incur charges.</remarks>
+    public sealed class CurrentConditionsRequest : MapsBaseRequest
+    {
+        /// <summary>Latitude of the query point, in degrees. Required.</summary>
+        public double Latitude { get; set; }
+
+        /// <summary>Longitude of the query point, in degrees. Required.</summary>
+        public double Longitude { get; set; }
+
+        /// <summary>Optional extra computations that enrich the response (local AQIs, health advice, pollutant detail).</summary>
+        public List<ExtraComputation>? ExtraComputations { get; set; }
+
+        /// <summary>Colour palette used for the Universal AQI in the response.</summary>
+        public ColorPalette? UaqiColorPalette { get; set; }
+
+        /// <summary>Per-region overrides selecting which local AQI to report.</summary>
+        public List<CustomLocalAqi>? CustomLocalAqis { get; set; }
+
+        /// <summary>Whether to include the Universal AQI in the response. Defaults to true server-side when unset.</summary>
+        public bool? UniversalAqi { get; set; }
+
+        /// <summary>IETF BCP-47 language code for textual fields in the response (e.g. <c>"en"</c>).</summary>
+        public string? LanguageCode { get; set; }
+
+        /// <inheritdoc/>
+        public override Uri GetUri()
+        {
+            if (string.IsNullOrWhiteSpace(ApiKey))
+                throw new InvalidOperationException("ApiKey is required for the Air Quality API.");
+            if (!IsSSL)
+                throw new ArgumentException("Air Quality API requires SSL [IsSSL = true].");
+
+            return new Uri(
+                "https://airquality.googleapis.com/v1/currentConditions:lookup" +
+                $"?key={Uri.EscapeDataString(ApiKey!)}");
+        }
+
+        /// <inheritdoc/>
+        protected internal override HttpContent? GetRequestBody()
+        {
+            var payload = new Payload
+            {
+                Location = new LatLng { Latitude = Latitude, Longitude = Longitude },
+                ExtraComputations = ExtraComputations is { Count: > 0 } ? ExtraComputations : null,
+                UaqiColorPalette = UaqiColorPalette,
+                CustomLocalAqis = CustomLocalAqis is { Count: > 0 } ? CustomLocalAqis : null,
+                UniversalAqi = UniversalAqi,
+                LanguageCode = string.IsNullOrWhiteSpace(LanguageCode) ? null : LanguageCode,
+            };
+            var json = JsonSerializer.Serialize(payload, AirQualityJson.BodyOptions);
+            return new StringContent(json, Encoding.UTF8, "application/json");
+        }
+
+        private sealed class Payload
+        {
+            [JsonPropertyName("location")] public LatLng? Location { get; set; }
+            [JsonPropertyName("extraComputations")] public List<ExtraComputation>? ExtraComputations { get; set; }
+            [JsonPropertyName("uaqiColorPalette")] public ColorPalette? UaqiColorPalette { get; set; }
+            [JsonPropertyName("customLocalAqis")] public List<CustomLocalAqi>? CustomLocalAqis { get; set; }
+            [JsonPropertyName("universalAqi")] public bool? UniversalAqi { get; set; }
+            [JsonPropertyName("languageCode")] public string? LanguageCode { get; set; }
+        }
+    }
+}

--- a/GoogleMapsApi/Entities/AirQuality/Request/CustomLocalAqi.cs
+++ b/GoogleMapsApi/Entities/AirQuality/Request/CustomLocalAqi.cs
@@ -1,0 +1,19 @@
+using System.Text.Json.Serialization;
+
+namespace GoogleMapsApi.Entities.AirQuality.Request
+{
+    /// <summary>
+    /// Pairs a country/region with the local Air Quality Index to report for it, overriding the API's
+    /// default index for that region. Supplied via <c>customLocalAqis</c>.
+    /// </summary>
+    public sealed class CustomLocalAqi
+    {
+        /// <summary>The country/region this override applies to (ISO 3166-1 alpha-2 code).</summary>
+        [JsonPropertyName("regionCode")]
+        public string? RegionCode { get; set; }
+
+        /// <summary>The AQI to use for the region (e.g. <c>"usa_epa"</c>).</summary>
+        [JsonPropertyName("aqi")]
+        public string? Aqi { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/AirQuality/Request/ExtraComputation.cs
+++ b/GoogleMapsApi/Entities/AirQuality/Request/ExtraComputation.cs
@@ -1,0 +1,30 @@
+using System.Runtime.Serialization;
+
+namespace GoogleMapsApi.Entities.AirQuality.Request
+{
+    /// <summary>
+    /// Optional additional computations the Air Quality API can run for a request, each enriching the
+    /// response with extra data (local AQIs, health advice, pollutant detail). Supplied via
+    /// <c>extraComputations</c>.
+    /// </summary>
+    public enum ExtraComputation
+    {
+        /// <summary>No extra computation. Ignored by the server if sent.</summary>
+        [EnumMember(Value = "EXTRA_COMPUTATION_UNSPECIFIED")] Unspecified,
+
+        /// <summary>Include the local (national) Air Quality Index for the requested location.</summary>
+        [EnumMember(Value = "LOCAL_AQI")] LocalAqi,
+
+        /// <summary>Include health recommendations for the general population and at-risk groups.</summary>
+        [EnumMember(Value = "HEALTH_RECOMMENDATIONS")] HealthRecommendations,
+
+        /// <summary>Include supplementary sources/effects information for each pollutant.</summary>
+        [EnumMember(Value = "POLLUTANT_ADDITIONAL_INFO")] PollutantAdditionalInfo,
+
+        /// <summary>Include concentrations of the dominant pollutants identified by the indexes.</summary>
+        [EnumMember(Value = "DOMINANT_POLLUTANT_CONCENTRATION")] DominantPollutantConcentration,
+
+        /// <summary>Include concentrations of every pollutant measured by the indexes.</summary>
+        [EnumMember(Value = "POLLUTANT_CONCENTRATION")] PollutantConcentration,
+    }
+}

--- a/GoogleMapsApi/Entities/AirQuality/Request/ForecastRequest.cs
+++ b/GoogleMapsApi/Entities/AirQuality/Request/ForecastRequest.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using GoogleMapsApi.Entities.Common;
+
+namespace GoogleMapsApi.Entities.AirQuality.Request
+{
+    /// <summary>
+    /// Request for the Air Quality API <c>forecast:lookup</c> endpoint
+    /// (<c>POST https://airquality.googleapis.com/v1/forecast:lookup</c>). Returns projected hourly
+    /// air-quality data for a coordinate over a time range.
+    /// </summary>
+    /// <remarks>
+    /// Specify the time range with either <see cref="DateTime"/> (a single hour) or <see cref="Period"/>
+    /// (a range) — not both. The Air Quality API is billable; calls beyond the free tier incur charges.
+    /// </remarks>
+    public sealed class ForecastRequest : MapsBaseRequest
+    {
+        /// <summary>Latitude of the query point, in degrees. Required.</summary>
+        public double Latitude { get; set; }
+
+        /// <summary>Longitude of the query point, in degrees. Required.</summary>
+        public double Longitude { get; set; }
+
+        /// <summary>A single hour to forecast (rounded down to the hour). Mutually exclusive with <see cref="Period"/>.</summary>
+        public DateTimeOffset? DateTime { get; set; }
+
+        /// <summary>A time range to forecast. Mutually exclusive with <see cref="DateTime"/>.</summary>
+        public Interval? Period { get; set; }
+
+        /// <summary>Maximum number of hourly records per page. Defaults to 24 server-side when unset.</summary>
+        public int? PageSize { get; set; }
+
+        /// <summary>Page token from a previous response's <c>NextPageToken</c> to fetch the next page.</summary>
+        public string? PageToken { get; set; }
+
+        /// <summary>Optional extra computations that enrich the response (local AQIs, health advice, pollutant detail).</summary>
+        public List<ExtraComputation>? ExtraComputations { get; set; }
+
+        /// <summary>Colour palette used for the Universal AQI in the response.</summary>
+        public ColorPalette? UaqiColorPalette { get; set; }
+
+        /// <summary>Per-region overrides selecting which local AQI to report.</summary>
+        public List<CustomLocalAqi>? CustomLocalAqis { get; set; }
+
+        /// <summary>Whether to include the Universal AQI in the response. Defaults to true server-side when unset.</summary>
+        public bool? UniversalAqi { get; set; }
+
+        /// <summary>IETF BCP-47 language code for textual fields in the response (e.g. <c>"en"</c>).</summary>
+        public string? LanguageCode { get; set; }
+
+        /// <inheritdoc/>
+        public override Uri GetUri()
+        {
+            if (string.IsNullOrWhiteSpace(ApiKey))
+                throw new InvalidOperationException("ApiKey is required for the Air Quality API.");
+            if (!IsSSL)
+                throw new ArgumentException("Air Quality API requires SSL [IsSSL = true].");
+
+            return new Uri(
+                "https://airquality.googleapis.com/v1/forecast:lookup" +
+                $"?key={Uri.EscapeDataString(ApiKey!)}");
+        }
+
+        /// <inheritdoc/>
+        protected internal override HttpContent? GetRequestBody()
+        {
+            if (DateTime.HasValue && Period != null)
+                throw new InvalidOperationException("DateTime and Period are mutually exclusive on a forecast request.");
+
+            var payload = new Payload
+            {
+                Location = new LatLng { Latitude = Latitude, Longitude = Longitude },
+                DateTime = DateTime.HasValue ? AirQualityJson.Rfc3339(DateTime.Value) : null,
+                Period = Period == null ? null : new IntervalPayload
+                {
+                    StartTime = Period.StartTime.HasValue ? AirQualityJson.Rfc3339(Period.StartTime.Value) : null,
+                    EndTime = Period.EndTime.HasValue ? AirQualityJson.Rfc3339(Period.EndTime.Value) : null,
+                },
+                PageSize = PageSize,
+                PageToken = string.IsNullOrWhiteSpace(PageToken) ? null : PageToken,
+                ExtraComputations = ExtraComputations is { Count: > 0 } ? ExtraComputations : null,
+                UaqiColorPalette = UaqiColorPalette,
+                CustomLocalAqis = CustomLocalAqis is { Count: > 0 } ? CustomLocalAqis : null,
+                UniversalAqi = UniversalAqi,
+                LanguageCode = string.IsNullOrWhiteSpace(LanguageCode) ? null : LanguageCode,
+            };
+            var json = JsonSerializer.Serialize(payload, AirQualityJson.BodyOptions);
+            return new StringContent(json, Encoding.UTF8, "application/json");
+        }
+
+        private sealed class Payload
+        {
+            [JsonPropertyName("location")] public LatLng? Location { get; set; }
+            [JsonPropertyName("dateTime")] public string? DateTime { get; set; }
+            [JsonPropertyName("period")] public IntervalPayload? Period { get; set; }
+            [JsonPropertyName("pageSize")] public int? PageSize { get; set; }
+            [JsonPropertyName("pageToken")] public string? PageToken { get; set; }
+            [JsonPropertyName("extraComputations")] public List<ExtraComputation>? ExtraComputations { get; set; }
+            [JsonPropertyName("uaqiColorPalette")] public ColorPalette? UaqiColorPalette { get; set; }
+            [JsonPropertyName("customLocalAqis")] public List<CustomLocalAqi>? CustomLocalAqis { get; set; }
+            [JsonPropertyName("universalAqi")] public bool? UniversalAqi { get; set; }
+            [JsonPropertyName("languageCode")] public string? LanguageCode { get; set; }
+        }
+
+        private sealed class IntervalPayload
+        {
+            [JsonPropertyName("startTime")] public string? StartTime { get; set; }
+            [JsonPropertyName("endTime")] public string? EndTime { get; set; }
+        }
+    }
+}

--- a/GoogleMapsApi/Entities/AirQuality/Request/HeatmapTileRequest.cs
+++ b/GoogleMapsApi/Entities/AirQuality/Request/HeatmapTileRequest.cs
@@ -1,0 +1,49 @@
+using System;
+using GoogleMapsApi.Engine;
+using GoogleMapsApi.Entities.Common;
+
+namespace GoogleMapsApi.Entities.AirQuality.Request
+{
+    /// <summary>
+    /// Request for the Air Quality API heatmap-tile endpoint
+    /// (<c>GET https://airquality.googleapis.com/v1/mapTypes/{mapType}/heatmapTiles/{zoom}/{x}/{y}</c>).
+    /// Downloads a single 256×256 PNG map tile for the chosen air-quality index. The response is binary,
+    /// not JSON.
+    /// </summary>
+    /// <remarks>
+    /// Tile coordinates follow the standard Web Mercator scheme: <see cref="X"/> and <see cref="Y"/> are
+    /// in the range <c>[0, 2^zoom)</c>. The Air Quality API is billable; calls beyond the free tier incur charges.
+    /// </remarks>
+    public sealed class HeatmapTileRequest : MapsBaseRequest
+    {
+        /// <summary>Which air-quality index and colour scheme the tile renders. Required.</summary>
+        public AirQualityMapType MapType { get; set; }
+
+        /// <summary>Zoom level, in the range [0, 16]; 0 is the whole world in one tile.</summary>
+        public int Zoom { get; set; }
+
+        /// <summary>The tile's east-west index, in the range [0, 2^zoom).</summary>
+        public int X { get; set; }
+
+        /// <summary>The tile's north-south index, in the range [0, 2^zoom).</summary>
+        public int Y { get; set; }
+
+        /// <inheritdoc/>
+        public override Uri GetUri()
+        {
+            if (string.IsNullOrWhiteSpace(ApiKey))
+                throw new InvalidOperationException("ApiKey is required for the Air Quality API.");
+            if (!IsSSL)
+                throw new ArgumentException("Air Quality API requires SSL [IsSSL = true].");
+            if (Zoom < 0 || Zoom > 16)
+                throw new ArgumentException("Zoom must be in the range [0, 16].", nameof(Zoom));
+            if (X < 0 || Y < 0)
+                throw new ArgumentException("Tile coordinates X and Y must be non-negative.");
+
+            return new Uri(
+                "https://airquality.googleapis.com/v1/mapTypes/" +
+                $"{EnumMemberHelper.GetValue(MapType)}/heatmapTiles/{Zoom}/{X}/{Y}" +
+                $"?key={Uri.EscapeDataString(ApiKey!)}");
+        }
+    }
+}

--- a/GoogleMapsApi/Entities/AirQuality/Request/HistoryRequest.cs
+++ b/GoogleMapsApi/Entities/AirQuality/Request/HistoryRequest.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using GoogleMapsApi.Entities.Common;
+
+namespace GoogleMapsApi.Entities.AirQuality.Request
+{
+    /// <summary>
+    /// Request for the Air Quality API <c>history:lookup</c> endpoint
+    /// (<c>POST https://airquality.googleapis.com/v1/history:lookup</c>). Returns past hourly
+    /// air-quality records for a coordinate.
+    /// </summary>
+    /// <remarks>
+    /// Specify the time range with exactly one of <see cref="DateTime"/> (a single hour),
+    /// <see cref="Hours"/> (the most recent N hours) or <see cref="Period"/> (an explicit range).
+    /// The Air Quality API is billable; calls beyond the free tier incur charges.
+    /// </remarks>
+    public sealed class HistoryRequest : MapsBaseRequest
+    {
+        /// <summary>Latitude of the query point, in degrees. Required.</summary>
+        public double Latitude { get; set; }
+
+        /// <summary>Longitude of the query point, in degrees. Required.</summary>
+        public double Longitude { get; set; }
+
+        /// <summary>A single past hour to look up. Mutually exclusive with <see cref="Hours"/> and <see cref="Period"/>.</summary>
+        public DateTimeOffset? DateTime { get; set; }
+
+        /// <summary>The most recent number of hours to return. Mutually exclusive with <see cref="DateTime"/> and <see cref="Period"/>.</summary>
+        public int? Hours { get; set; }
+
+        /// <summary>An explicit past time range. Mutually exclusive with <see cref="DateTime"/> and <see cref="Hours"/>.</summary>
+        public Interval? Period { get; set; }
+
+        /// <summary>Maximum number of hourly records per page. Defaults to 72 server-side when unset.</summary>
+        public int? PageSize { get; set; }
+
+        /// <summary>Page token from a previous response's <c>NextPageToken</c> to fetch the next page.</summary>
+        public string? PageToken { get; set; }
+
+        /// <summary>Optional extra computations that enrich the response (local AQIs, health advice, pollutant detail).</summary>
+        public List<ExtraComputation>? ExtraComputations { get; set; }
+
+        /// <summary>Colour palette used for the Universal AQI in the response.</summary>
+        public ColorPalette? UaqiColorPalette { get; set; }
+
+        /// <summary>Per-region overrides selecting which local AQI to report.</summary>
+        public List<CustomLocalAqi>? CustomLocalAqis { get; set; }
+
+        /// <summary>Whether to include the Universal AQI in the response. Defaults to true server-side when unset.</summary>
+        public bool? UniversalAqi { get; set; }
+
+        /// <summary>IETF BCP-47 language code for textual fields in the response (e.g. <c>"en"</c>).</summary>
+        public string? LanguageCode { get; set; }
+
+        /// <inheritdoc/>
+        public override Uri GetUri()
+        {
+            if (string.IsNullOrWhiteSpace(ApiKey))
+                throw new InvalidOperationException("ApiKey is required for the Air Quality API.");
+            if (!IsSSL)
+                throw new ArgumentException("Air Quality API requires SSL [IsSSL = true].");
+
+            return new Uri(
+                "https://airquality.googleapis.com/v1/history:lookup" +
+                $"?key={Uri.EscapeDataString(ApiKey!)}");
+        }
+
+        /// <inheritdoc/>
+        protected internal override HttpContent? GetRequestBody()
+        {
+            var rangeCount = (DateTime.HasValue ? 1 : 0) + (Hours.HasValue ? 1 : 0) + (Period != null ? 1 : 0);
+            if (rangeCount > 1)
+                throw new InvalidOperationException("Specify only one of DateTime, Hours or Period on a history request.");
+
+            var payload = new Payload
+            {
+                Location = new LatLng { Latitude = Latitude, Longitude = Longitude },
+                DateTime = DateTime.HasValue ? AirQualityJson.Rfc3339(DateTime.Value) : null,
+                Hours = Hours,
+                Period = Period == null ? null : new IntervalPayload
+                {
+                    StartTime = Period.StartTime.HasValue ? AirQualityJson.Rfc3339(Period.StartTime.Value) : null,
+                    EndTime = Period.EndTime.HasValue ? AirQualityJson.Rfc3339(Period.EndTime.Value) : null,
+                },
+                PageSize = PageSize,
+                PageToken = string.IsNullOrWhiteSpace(PageToken) ? null : PageToken,
+                ExtraComputations = ExtraComputations is { Count: > 0 } ? ExtraComputations : null,
+                UaqiColorPalette = UaqiColorPalette,
+                CustomLocalAqis = CustomLocalAqis is { Count: > 0 } ? CustomLocalAqis : null,
+                UniversalAqi = UniversalAqi,
+                LanguageCode = string.IsNullOrWhiteSpace(LanguageCode) ? null : LanguageCode,
+            };
+            var json = JsonSerializer.Serialize(payload, AirQualityJson.BodyOptions);
+            return new StringContent(json, Encoding.UTF8, "application/json");
+        }
+
+        private sealed class Payload
+        {
+            [JsonPropertyName("location")] public LatLng? Location { get; set; }
+            [JsonPropertyName("dateTime")] public string? DateTime { get; set; }
+            [JsonPropertyName("hours")] public int? Hours { get; set; }
+            [JsonPropertyName("period")] public IntervalPayload? Period { get; set; }
+            [JsonPropertyName("pageSize")] public int? PageSize { get; set; }
+            [JsonPropertyName("pageToken")] public string? PageToken { get; set; }
+            [JsonPropertyName("extraComputations")] public List<ExtraComputation>? ExtraComputations { get; set; }
+            [JsonPropertyName("uaqiColorPalette")] public ColorPalette? UaqiColorPalette { get; set; }
+            [JsonPropertyName("customLocalAqis")] public List<CustomLocalAqi>? CustomLocalAqis { get; set; }
+            [JsonPropertyName("universalAqi")] public bool? UniversalAqi { get; set; }
+            [JsonPropertyName("languageCode")] public string? LanguageCode { get; set; }
+        }
+
+        private sealed class IntervalPayload
+        {
+            [JsonPropertyName("startTime")] public string? StartTime { get; set; }
+            [JsonPropertyName("endTime")] public string? EndTime { get; set; }
+        }
+    }
+}

--- a/GoogleMapsApi/Entities/AirQuality/Request/Interval.cs
+++ b/GoogleMapsApi/Entities/AirQuality/Request/Interval.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace GoogleMapsApi.Entities.AirQuality.Request
+{
+    /// <summary>
+    /// A half-open-to-inclusive time range for <see cref="ForecastRequest.Period"/> and
+    /// <see cref="HistoryRequest.Period"/>. Both bounds are sent to the API as RFC3339 UTC timestamps.
+    /// </summary>
+    public sealed class Interval
+    {
+        /// <summary>Start of the range.</summary>
+        public DateTimeOffset? StartTime { get; set; }
+
+        /// <summary>End of the range (inclusive).</summary>
+        public DateTimeOffset? EndTime { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/AirQuality/Request/LatLng.cs
+++ b/GoogleMapsApi/Entities/AirQuality/Request/LatLng.cs
@@ -1,0 +1,16 @@
+using System.Text.Json.Serialization;
+
+namespace GoogleMapsApi.Entities.AirQuality.Request
+{
+    /// <summary>A WGS84 latitude/longitude coordinate sent in the request body (mirrors <c>google.type.LatLng</c>).</summary>
+    public sealed class LatLng
+    {
+        /// <summary>Latitude in degrees, in the range [-90, 90].</summary>
+        [JsonPropertyName("latitude")]
+        public double Latitude { get; set; }
+
+        /// <summary>Longitude in degrees, in the range [-180, 180].</summary>
+        [JsonPropertyName("longitude")]
+        public double Longitude { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/AirQuality/Response/AdditionalInfo.cs
+++ b/GoogleMapsApi/Entities/AirQuality/Response/AdditionalInfo.cs
@@ -1,0 +1,16 @@
+using System.Text.Json.Serialization;
+
+namespace GoogleMapsApi.Entities.AirQuality.Response
+{
+    /// <summary>Supplementary information about a pollutant (returned with <c>POLLUTANT_ADDITIONAL_INFO</c>).</summary>
+    public sealed class AdditionalInfo
+    {
+        /// <summary>Text describing the pollutant's main emission sources.</summary>
+        [JsonPropertyName("sources")]
+        public string? Sources { get; set; }
+
+        /// <summary>Text describing the pollutant's main health effects.</summary>
+        [JsonPropertyName("effects")]
+        public string? Effects { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/AirQuality/Response/AirQualityIndex.cs
+++ b/GoogleMapsApi/Entities/AirQuality/Response/AirQualityIndex.cs
@@ -1,0 +1,36 @@
+using System.Text.Json.Serialization;
+
+namespace GoogleMapsApi.Entities.AirQuality.Response
+{
+    /// <summary>A single air-quality index value (e.g. the Universal AQI or a local/national index).</summary>
+    public sealed class AirQualityIndex
+    {
+        /// <summary>The index's code (e.g. <c>"uaqi"</c>, <c>"usa_epa"</c>).</summary>
+        [JsonPropertyName("code")]
+        public string? Code { get; set; }
+
+        /// <summary>Human-readable index name (e.g. <c>"Universal AQI"</c>).</summary>
+        [JsonPropertyName("displayName")]
+        public string? DisplayName { get; set; }
+
+        /// <summary>The numeric index score.</summary>
+        [JsonPropertyName("aqi")]
+        public int Aqi { get; set; }
+
+        /// <summary>The index score as it should be displayed.</summary>
+        [JsonPropertyName("aqiDisplay")]
+        public string? AqiDisplay { get; set; }
+
+        /// <summary>The colour associated with the score, for rendering.</summary>
+        [JsonPropertyName("color")]
+        public Color? Color { get; set; }
+
+        /// <summary>Textual classification of the score (e.g. <c>"Good air quality"</c>).</summary>
+        [JsonPropertyName("category")]
+        public string? Category { get; set; }
+
+        /// <summary>Code of the pollutant dominating this index (e.g. <c>"pm25"</c>).</summary>
+        [JsonPropertyName("dominantPollutant")]
+        public string? DominantPollutant { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/AirQuality/Response/Color.cs
+++ b/GoogleMapsApi/Entities/AirQuality/Response/Color.cs
@@ -1,0 +1,24 @@
+using System.Text.Json.Serialization;
+
+namespace GoogleMapsApi.Entities.AirQuality.Response
+{
+    /// <summary>An RGBA colour with components in the range [0, 1] (mirrors <c>google.type.Color</c>).</summary>
+    public sealed class Color
+    {
+        /// <summary>Red component, in the range [0, 1].</summary>
+        [JsonPropertyName("red")]
+        public float? Red { get; set; }
+
+        /// <summary>Green component, in the range [0, 1].</summary>
+        [JsonPropertyName("green")]
+        public float? Green { get; set; }
+
+        /// <summary>Blue component, in the range [0, 1].</summary>
+        [JsonPropertyName("blue")]
+        public float? Blue { get; set; }
+
+        /// <summary>Alpha (opacity), in the range [0, 1]. Often omitted, meaning fully opaque.</summary>
+        [JsonPropertyName("alpha")]
+        public float? Alpha { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/AirQuality/Response/Concentration.cs
+++ b/GoogleMapsApi/Entities/AirQuality/Response/Concentration.cs
@@ -1,0 +1,16 @@
+using System.Text.Json.Serialization;
+
+namespace GoogleMapsApi.Entities.AirQuality.Response
+{
+    /// <summary>A pollutant concentration measurement.</summary>
+    public sealed class Concentration
+    {
+        /// <summary>Unit the <see cref="Value"/> is expressed in (e.g. <c>"PARTS_PER_BILLION"</c>).</summary>
+        [JsonPropertyName("units")]
+        public string? Units { get; set; }
+
+        /// <summary>The measured concentration value.</summary>
+        [JsonPropertyName("value")]
+        public double Value { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/AirQuality/Response/CurrentConditionsResponse.cs
+++ b/GoogleMapsApi/Entities/AirQuality/Response/CurrentConditionsResponse.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using GoogleMapsApi.Entities.AirQuality.Request;
+using GoogleMapsApi.Entities.Common;
+
+namespace GoogleMapsApi.Entities.AirQuality.Response
+{
+    /// <summary>Response from the Air Quality API <c>currentConditions:lookup</c> endpoint.</summary>
+    public sealed class CurrentConditionsResponse : IResponseFor<CurrentConditionsRequest>
+    {
+        /// <summary>The hour (rounded down) the conditions apply to.</summary>
+        [JsonPropertyName("dateTime")]
+        public DateTimeOffset? DateTime { get; set; }
+
+        /// <summary>Region code (ISO 3166-1 alpha-2) of the location.</summary>
+        [JsonPropertyName("regionCode")]
+        public string? RegionCode { get; set; }
+
+        /// <summary>The air-quality indexes for the location.</summary>
+        [JsonPropertyName("indexes")]
+        public List<AirQualityIndex>? Indexes { get; set; }
+
+        /// <summary>Per-pollutant data (when requested via extra computations).</summary>
+        [JsonPropertyName("pollutants")]
+        public List<Pollutant>? Pollutants { get; set; }
+
+        /// <summary>Health recommendations (when requested via the <c>HEALTH_RECOMMENDATIONS</c> computation).</summary>
+        [JsonPropertyName("healthRecommendations")]
+        public HealthRecommendations? HealthRecommendations { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/AirQuality/Response/ForecastResponse.cs
+++ b/GoogleMapsApi/Entities/AirQuality/Response/ForecastResponse.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using GoogleMapsApi.Entities.AirQuality.Request;
+using GoogleMapsApi.Entities.Common;
+
+namespace GoogleMapsApi.Entities.AirQuality.Response
+{
+    /// <summary>Response from the Air Quality API <c>forecast:lookup</c> endpoint.</summary>
+    public sealed class ForecastResponse : IResponseFor<ForecastRequest>
+    {
+        /// <summary>The forecast hours requested, one entry per hour.</summary>
+        [JsonPropertyName("hourlyForecasts")]
+        public List<HourlyForecast>? HourlyForecasts { get; set; }
+
+        /// <summary>Region code (ISO 3166-1 alpha-2) of the location.</summary>
+        [JsonPropertyName("regionCode")]
+        public string? RegionCode { get; set; }
+
+        /// <summary>Token to pass as <c>PageToken</c> on a follow-up request to fetch the next page, if any.</summary>
+        [JsonPropertyName("nextPageToken")]
+        public string? NextPageToken { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/AirQuality/Response/HealthRecommendations.cs
+++ b/GoogleMapsApi/Entities/AirQuality/Response/HealthRecommendations.cs
@@ -1,0 +1,39 @@
+using System.Text.Json.Serialization;
+
+namespace GoogleMapsApi.Entities.AirQuality.Response
+{
+    /// <summary>
+    /// Health advice tailored to the current conditions for the general population and at-risk groups
+    /// (returned with the <c>HEALTH_RECOMMENDATIONS</c> extra computation).
+    /// </summary>
+    public sealed class HealthRecommendations
+    {
+        /// <summary>Advice for the general population.</summary>
+        [JsonPropertyName("generalPopulation")]
+        public string? GeneralPopulation { get; set; }
+
+        /// <summary>Advice for elderly people.</summary>
+        [JsonPropertyName("elderly")]
+        public string? Elderly { get; set; }
+
+        /// <summary>Advice for people with lung disease.</summary>
+        [JsonPropertyName("lungDiseasePopulation")]
+        public string? LungDiseasePopulation { get; set; }
+
+        /// <summary>Advice for people with heart disease.</summary>
+        [JsonPropertyName("heartDiseasePopulation")]
+        public string? HeartDiseasePopulation { get; set; }
+
+        /// <summary>Advice for athletes / people exercising outdoors.</summary>
+        [JsonPropertyName("athletes")]
+        public string? Athletes { get; set; }
+
+        /// <summary>Advice for pregnant women.</summary>
+        [JsonPropertyName("pregnantWomen")]
+        public string? PregnantWomen { get; set; }
+
+        /// <summary>Advice for children.</summary>
+        [JsonPropertyName("children")]
+        public string? Children { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/AirQuality/Response/HeatmapTileResponse.cs
+++ b/GoogleMapsApi/Entities/AirQuality/Response/HeatmapTileResponse.cs
@@ -1,0 +1,19 @@
+using System;
+using GoogleMapsApi.Entities.AirQuality.Request;
+using GoogleMapsApi.Entities.Common;
+
+namespace GoogleMapsApi.Entities.AirQuality.Response
+{
+    /// <summary>
+    /// Response from the Air Quality API heatmap-tile endpoint — the raw PNG bytes of a map tile.
+    /// Being binary, this is populated directly by the engine rather than from JSON.
+    /// </summary>
+    public sealed class HeatmapTileResponse : IResponseFor<HeatmapTileRequest>, IBinaryResponse
+    {
+        /// <summary>The raw PNG bytes of the tile.</summary>
+        public byte[] Content { get; set; } = Array.Empty<byte>();
+
+        /// <summary>The response media type (typically <c>image/png</c>).</summary>
+        public string? ContentType { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/AirQuality/Response/HistoryResponse.cs
+++ b/GoogleMapsApi/Entities/AirQuality/Response/HistoryResponse.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using GoogleMapsApi.Entities.AirQuality.Request;
+using GoogleMapsApi.Entities.Common;
+
+namespace GoogleMapsApi.Entities.AirQuality.Response
+{
+    /// <summary>Response from the Air Quality API <c>history:lookup</c> endpoint.</summary>
+    public sealed class HistoryResponse : IResponseFor<HistoryRequest>
+    {
+        /// <summary>The past hours requested, one entry per hour.</summary>
+        [JsonPropertyName("hoursInfo")]
+        public List<HourlyForecast>? HoursInfo { get; set; }
+
+        /// <summary>Region code (ISO 3166-1 alpha-2) of the location.</summary>
+        [JsonPropertyName("regionCode")]
+        public string? RegionCode { get; set; }
+
+        /// <summary>Token to pass as <c>PageToken</c> on a follow-up request to fetch the next page, if any.</summary>
+        [JsonPropertyName("nextPageToken")]
+        public string? NextPageToken { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/AirQuality/Response/HourlyForecast.cs
+++ b/GoogleMapsApi/Entities/AirQuality/Response/HourlyForecast.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace GoogleMapsApi.Entities.AirQuality.Response
+{
+    /// <summary>Air-quality data for a single hour, used by the forecast and history responses.</summary>
+    public sealed class HourlyForecast
+    {
+        /// <summary>The hour (rounded down) these values apply to.</summary>
+        [JsonPropertyName("dateTime")]
+        public DateTimeOffset? DateTime { get; set; }
+
+        /// <summary>The air-quality indexes for this hour.</summary>
+        [JsonPropertyName("indexes")]
+        public List<AirQualityIndex>? Indexes { get; set; }
+
+        /// <summary>Per-pollutant data for this hour (when requested via extra computations).</summary>
+        [JsonPropertyName("pollutants")]
+        public List<Pollutant>? Pollutants { get; set; }
+
+        /// <summary>Health recommendations for this hour (when requested via extra computations).</summary>
+        [JsonPropertyName("healthRecommendations")]
+        public HealthRecommendations? HealthRecommendations { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/AirQuality/Response/Pollutant.cs
+++ b/GoogleMapsApi/Entities/AirQuality/Response/Pollutant.cs
@@ -1,0 +1,28 @@
+using System.Text.Json.Serialization;
+
+namespace GoogleMapsApi.Entities.AirQuality.Response
+{
+    /// <summary>Data for a single pollutant (returned with the pollutant-concentration extra computations).</summary>
+    public sealed class Pollutant
+    {
+        /// <summary>The pollutant's code (e.g. <c>"pm25"</c>, <c>"no2"</c>).</summary>
+        [JsonPropertyName("code")]
+        public string? Code { get; set; }
+
+        /// <summary>The pollutant's short display name (e.g. <c>"PM2.5"</c>).</summary>
+        [JsonPropertyName("displayName")]
+        public string? DisplayName { get; set; }
+
+        /// <summary>The pollutant's full name (e.g. <c>"Fine particulate matter (&lt;2.5µm)"</c>).</summary>
+        [JsonPropertyName("fullName")]
+        public string? FullName { get; set; }
+
+        /// <summary>The measured concentration.</summary>
+        [JsonPropertyName("concentration")]
+        public Concentration? Concentration { get; set; }
+
+        /// <summary>Supplementary sources/effects information for this pollutant.</summary>
+        [JsonPropertyName("additionalInfo")]
+        public AdditionalInfo? AdditionalInfo { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/Pollen/Request/PollenForecastRequest.cs
+++ b/GoogleMapsApi/Entities/Pollen/Request/PollenForecastRequest.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Globalization;
+using GoogleMapsApi.Engine;
+using GoogleMapsApi.Entities.Common;
+
+namespace GoogleMapsApi.Entities.Pollen.Request
+{
+    /// <summary>
+    /// Request for the Google Pollen API <c>forecast:lookup</c> endpoint
+    /// (<c>GET https://pollen.googleapis.com/v1/forecast:lookup</c>). Returns up to five days of daily
+    /// pollen information (types and plants) for a coordinate.
+    /// </summary>
+    /// <remarks>The Pollen API is billable; calls beyond the free tier incur charges.</remarks>
+    public sealed class PollenForecastRequest : MapsBaseRequest
+    {
+        /// <summary>Latitude of the query point, in degrees. Required.</summary>
+        public double Latitude { get; set; }
+
+        /// <summary>Longitude of the query point, in degrees. Required.</summary>
+        public double Longitude { get; set; }
+
+        /// <summary>Number of forecast days to return, in the range [1, 5]. Required.</summary>
+        public int Days { get; set; }
+
+        /// <summary>Maximum number of daily records per page. Defaults to the number of days when unset.</summary>
+        public int? PageSize { get; set; }
+
+        /// <summary>Page token from a previous response's <c>NextPageToken</c> to fetch the next page.</summary>
+        public string? PageToken { get; set; }
+
+        /// <summary>IETF BCP-47 language code for textual fields in the response (e.g. <c>"en"</c>).</summary>
+        public string? LanguageCode { get; set; }
+
+        /// <summary>
+        /// Whether to include the detailed <c>PlantDescription</c> for each plant. Defaults to true
+        /// server-side when unset; set false to reduce the response size.
+        /// </summary>
+        public bool? PlantsDescription { get; set; }
+
+        /// <inheritdoc/>
+        public override Uri GetUri()
+        {
+            if (string.IsNullOrWhiteSpace(ApiKey))
+                throw new InvalidOperationException("ApiKey is required for the Pollen API.");
+            if (!IsSSL)
+                throw new ArgumentException("Pollen API requires SSL [IsSSL = true].");
+            if (Days < 1 || Days > 5)
+                throw new ArgumentException("Days must be in the range [1, 5].", nameof(Days));
+
+            var url =
+                "https://pollen.googleapis.com/v1/forecast:lookup" +
+                $"?location.latitude={CoordinateFormatter.Format(Latitude)}" +
+                $"&location.longitude={CoordinateFormatter.Format(Longitude)}" +
+                $"&days={Days.ToString(CultureInfo.InvariantCulture)}" +
+                $"&key={Uri.EscapeDataString(ApiKey!)}";
+
+            if (PageSize.HasValue)
+                url += $"&pageSize={PageSize.Value.ToString(CultureInfo.InvariantCulture)}";
+            if (!string.IsNullOrWhiteSpace(PageToken))
+                url += $"&pageToken={Uri.EscapeDataString(PageToken!)}";
+            if (!string.IsNullOrWhiteSpace(LanguageCode))
+                url += $"&languageCode={Uri.EscapeDataString(LanguageCode!)}";
+            if (PlantsDescription.HasValue)
+                url += $"&plantsDescription={(PlantsDescription.Value ? "true" : "false")}";
+
+            return new Uri(url);
+        }
+    }
+}

--- a/GoogleMapsApi/Entities/Pollen/Request/PollenHeatmapTileRequest.cs
+++ b/GoogleMapsApi/Entities/Pollen/Request/PollenHeatmapTileRequest.cs
@@ -1,0 +1,48 @@
+using System;
+using GoogleMapsApi.Engine;
+using GoogleMapsApi.Entities.Common;
+
+namespace GoogleMapsApi.Entities.Pollen.Request
+{
+    /// <summary>
+    /// Request for the Pollen API heatmap-tile endpoint
+    /// (<c>GET https://pollen.googleapis.com/v1/mapTypes/{mapType}/heatmapTiles/{zoom}/{x}/{y}</c>).
+    /// Downloads a single PNG map tile for the chosen pollen index. The response is binary, not JSON.
+    /// </summary>
+    /// <remarks>
+    /// Tile coordinates follow the standard Web Mercator scheme: <see cref="X"/> and <see cref="Y"/> are
+    /// in the range <c>[0, 2^zoom)</c>. The Pollen API is billable; calls beyond the free tier incur charges.
+    /// </remarks>
+    public sealed class PollenHeatmapTileRequest : MapsBaseRequest
+    {
+        /// <summary>Which pollen index the tile renders. Required.</summary>
+        public PollenMapType MapType { get; set; }
+
+        /// <summary>Zoom level, in the range [0, 16]; 0 is the whole world in one tile.</summary>
+        public int Zoom { get; set; }
+
+        /// <summary>The tile's east-west index, in the range [0, 2^zoom).</summary>
+        public int X { get; set; }
+
+        /// <summary>The tile's north-south index, in the range [0, 2^zoom).</summary>
+        public int Y { get; set; }
+
+        /// <inheritdoc/>
+        public override Uri GetUri()
+        {
+            if (string.IsNullOrWhiteSpace(ApiKey))
+                throw new InvalidOperationException("ApiKey is required for the Pollen API.");
+            if (!IsSSL)
+                throw new ArgumentException("Pollen API requires SSL [IsSSL = true].");
+            if (Zoom < 0 || Zoom > 16)
+                throw new ArgumentException("Zoom must be in the range [0, 16].", nameof(Zoom));
+            if (X < 0 || Y < 0)
+                throw new ArgumentException("Tile coordinates X and Y must be non-negative.");
+
+            return new Uri(
+                "https://pollen.googleapis.com/v1/mapTypes/" +
+                $"{EnumMemberHelper.GetValue(MapType)}/heatmapTiles/{Zoom}/{X}/{Y}" +
+                $"?key={Uri.EscapeDataString(ApiKey!)}");
+        }
+    }
+}

--- a/GoogleMapsApi/Entities/Pollen/Request/PollenMapType.cs
+++ b/GoogleMapsApi/Entities/Pollen/Request/PollenMapType.cs
@@ -1,0 +1,23 @@
+using System.Runtime.Serialization;
+
+namespace GoogleMapsApi.Entities.Pollen.Request
+{
+    /// <summary>
+    /// The pollen heatmap type (which pollen the tile renders) for a
+    /// <see cref="PollenHeatmapTileRequest"/>. Each maps the Universal Pollen Index for one pollen type.
+    /// </summary>
+    public enum PollenMapType
+    {
+        /// <summary>No map type specified. Ignored by the server if sent.</summary>
+        [EnumMember(Value = "MAP_TYPE_UNSPECIFIED")] Unspecified,
+
+        /// <summary>Tree pollen, Universal Pollen Index.</summary>
+        [EnumMember(Value = "TREE_UPI")] TreeUpi,
+
+        /// <summary>Grass pollen, Universal Pollen Index.</summary>
+        [EnumMember(Value = "GRASS_UPI")] GrassUpi,
+
+        /// <summary>Weed pollen, Universal Pollen Index.</summary>
+        [EnumMember(Value = "WEED_UPI")] WeedUpi,
+    }
+}

--- a/GoogleMapsApi/Entities/Pollen/Response/Color.cs
+++ b/GoogleMapsApi/Entities/Pollen/Response/Color.cs
@@ -1,0 +1,24 @@
+using System.Text.Json.Serialization;
+
+namespace GoogleMapsApi.Entities.Pollen.Response
+{
+    /// <summary>An RGBA colour with components in the range [0, 1] (mirrors <c>google.type.Color</c>).</summary>
+    public sealed class Color
+    {
+        /// <summary>Red component, in the range [0, 1].</summary>
+        [JsonPropertyName("red")]
+        public float? Red { get; set; }
+
+        /// <summary>Green component, in the range [0, 1].</summary>
+        [JsonPropertyName("green")]
+        public float? Green { get; set; }
+
+        /// <summary>Blue component, in the range [0, 1].</summary>
+        [JsonPropertyName("blue")]
+        public float? Blue { get; set; }
+
+        /// <summary>Alpha (opacity), in the range [0, 1]. Often omitted, meaning fully opaque.</summary>
+        [JsonPropertyName("alpha")]
+        public float? Alpha { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/Pollen/Response/Date.cs
+++ b/GoogleMapsApi/Entities/Pollen/Response/Date.cs
@@ -1,0 +1,20 @@
+using System.Text.Json.Serialization;
+
+namespace GoogleMapsApi.Entities.Pollen.Response
+{
+    /// <summary>A calendar date with no time zone (mirrors <c>google.type.Date</c>).</summary>
+    public sealed class Date
+    {
+        /// <summary>Year of the date.</summary>
+        [JsonPropertyName("year")]
+        public int Year { get; set; }
+
+        /// <summary>Month of the date, 1-12.</summary>
+        [JsonPropertyName("month")]
+        public int Month { get; set; }
+
+        /// <summary>Day of the month, 1-31.</summary>
+        [JsonPropertyName("day")]
+        public int Day { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/Pollen/Response/DayInfo.cs
+++ b/GoogleMapsApi/Entities/Pollen/Response/DayInfo.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace GoogleMapsApi.Entities.Pollen.Response
+{
+    /// <summary>Pollen forecast for a single day.</summary>
+    public sealed class DayInfo
+    {
+        /// <summary>The date this forecast applies to.</summary>
+        [JsonPropertyName("date")]
+        public Date? Date { get; set; }
+
+        /// <summary>Per-pollen-type information (up to three: grass, tree, weed).</summary>
+        [JsonPropertyName("pollenTypeInfo")]
+        public List<PollenTypeInfo>? PollenTypeInfo { get; set; }
+
+        /// <summary>Per-plant information (up to fifteen species).</summary>
+        [JsonPropertyName("plantInfo")]
+        public List<PlantInfo>? PlantInfo { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/Pollen/Response/IndexInfo.cs
+++ b/GoogleMapsApi/Entities/Pollen/Response/IndexInfo.cs
@@ -1,0 +1,32 @@
+using System.Text.Json.Serialization;
+
+namespace GoogleMapsApi.Entities.Pollen.Response
+{
+    /// <summary>A pollen index value (the Universal Pollen Index) for a pollen type or plant.</summary>
+    public sealed class IndexInfo
+    {
+        /// <summary>The index's code (e.g. <c>"UPI"</c>).</summary>
+        [JsonPropertyName("code")]
+        public string? Code { get; set; }
+
+        /// <summary>Human-readable index name (e.g. <c>"Universal Pollen Index"</c>).</summary>
+        [JsonPropertyName("displayName")]
+        public string? DisplayName { get; set; }
+
+        /// <summary>The index value, on a 0-5 scale.</summary>
+        [JsonPropertyName("value")]
+        public int Value { get; set; }
+
+        /// <summary>Textual classification of the value (e.g. <c>"Low"</c>, <c>"High"</c>).</summary>
+        [JsonPropertyName("category")]
+        public string? Category { get; set; }
+
+        /// <summary>A human-readable explanation of the index value.</summary>
+        [JsonPropertyName("indexDescription")]
+        public string? IndexDescription { get; set; }
+
+        /// <summary>The colour associated with the value, for rendering.</summary>
+        [JsonPropertyName("color")]
+        public Color? Color { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/Pollen/Response/PlantDescription.cs
+++ b/GoogleMapsApi/Entities/Pollen/Response/PlantDescription.cs
@@ -1,0 +1,40 @@
+using System.Text.Json.Serialization;
+
+namespace GoogleMapsApi.Entities.Pollen.Response
+{
+    /// <summary>Descriptive information about a plant that produces pollen.</summary>
+    public sealed class PlantDescription
+    {
+        /// <summary>The pollen type this plant belongs to (<c>"GRASS"</c>, <c>"TREE"</c> or <c>"WEED"</c>).</summary>
+        [JsonPropertyName("type")]
+        public string? Type { get; set; }
+
+        /// <summary>The plant's botanical family (e.g. <c>"Betulaceae"</c>).</summary>
+        [JsonPropertyName("family")]
+        public string? Family { get; set; }
+
+        /// <summary>The seasons in which the plant typically pollinates.</summary>
+        [JsonPropertyName("season")]
+        public string? Season { get; set; }
+
+        /// <summary>Colours that help identify the plant.</summary>
+        [JsonPropertyName("specialColors")]
+        public string? SpecialColors { get; set; }
+
+        /// <summary>Shapes that help identify the plant.</summary>
+        [JsonPropertyName("specialShapes")]
+        public string? SpecialShapes { get; set; }
+
+        /// <summary>Information about cross-reaction with other allergens.</summary>
+        [JsonPropertyName("crossReaction")]
+        public string? CrossReaction { get; set; }
+
+        /// <summary>URL of a representative picture of the plant.</summary>
+        [JsonPropertyName("picture")]
+        public string? Picture { get; set; }
+
+        /// <summary>URL of a close-up picture of the plant.</summary>
+        [JsonPropertyName("pictureCloseup")]
+        public string? PictureCloseup { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/Pollen/Response/PlantInfo.cs
+++ b/GoogleMapsApi/Entities/Pollen/Response/PlantInfo.cs
@@ -1,0 +1,28 @@
+using System.Text.Json.Serialization;
+
+namespace GoogleMapsApi.Entities.Pollen.Response
+{
+    /// <summary>Pollen information for one specific plant species on a given day.</summary>
+    public sealed class PlantInfo
+    {
+        /// <summary>The plant's code (e.g. <c>"BIRCH"</c>, <c>"OAK"</c>, <c>"RAGWEED"</c>).</summary>
+        [JsonPropertyName("code")]
+        public string? Code { get; set; }
+
+        /// <summary>Human-readable plant name (e.g. <c>"Birch"</c>).</summary>
+        [JsonPropertyName("displayName")]
+        public string? DisplayName { get; set; }
+
+        /// <summary>Whether the plant is in season on this day.</summary>
+        [JsonPropertyName("inSeason")]
+        public bool? InSeason { get; set; }
+
+        /// <summary>The pollen index for this plant. Absent when no data is available.</summary>
+        [JsonPropertyName("indexInfo")]
+        public IndexInfo? IndexInfo { get; set; }
+
+        /// <summary>Descriptive detail about the plant. Absent when <c>PlantsDescription</c> was disabled.</summary>
+        [JsonPropertyName("plantDescription")]
+        public PlantDescription? PlantDescription { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/Pollen/Response/PollenForecastResponse.cs
+++ b/GoogleMapsApi/Entities/Pollen/Response/PollenForecastResponse.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using GoogleMapsApi.Entities.Common;
+using GoogleMapsApi.Entities.Pollen.Request;
+
+namespace GoogleMapsApi.Entities.Pollen.Response
+{
+    /// <summary>Response from the Pollen API <c>forecast:lookup</c> endpoint.</summary>
+    public sealed class PollenForecastResponse : IResponseFor<PollenForecastRequest>
+    {
+        /// <summary>Region code (ISO 3166-1 alpha-2) of the location.</summary>
+        [JsonPropertyName("regionCode")]
+        public string? RegionCode { get; set; }
+
+        /// <summary>The daily forecasts, one entry per requested day.</summary>
+        [JsonPropertyName("dailyInfo")]
+        public List<DayInfo>? DailyInfo { get; set; }
+
+        /// <summary>Token to pass as <c>PageToken</c> on a follow-up request to fetch the next page, if any.</summary>
+        [JsonPropertyName("nextPageToken")]
+        public string? NextPageToken { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/Pollen/Response/PollenHeatmapTileResponse.cs
+++ b/GoogleMapsApi/Entities/Pollen/Response/PollenHeatmapTileResponse.cs
@@ -1,0 +1,19 @@
+using System;
+using GoogleMapsApi.Entities.Common;
+using GoogleMapsApi.Entities.Pollen.Request;
+
+namespace GoogleMapsApi.Entities.Pollen.Response
+{
+    /// <summary>
+    /// Response from the Pollen API heatmap-tile endpoint — the raw PNG bytes of a map tile.
+    /// Being binary, this is populated directly by the engine rather than from JSON.
+    /// </summary>
+    public sealed class PollenHeatmapTileResponse : IResponseFor<PollenHeatmapTileRequest>, IBinaryResponse
+    {
+        /// <summary>The raw PNG bytes of the tile.</summary>
+        public byte[] Content { get; set; } = Array.Empty<byte>();
+
+        /// <summary>The response media type (typically <c>image/png</c>).</summary>
+        public string? ContentType { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/Pollen/Response/PollenTypeInfo.cs
+++ b/GoogleMapsApi/Entities/Pollen/Response/PollenTypeInfo.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace GoogleMapsApi.Entities.Pollen.Response
+{
+    /// <summary>Pollen information for one pollen type (grass, tree or weed) on a given day.</summary>
+    public sealed class PollenTypeInfo
+    {
+        /// <summary>The pollen type code (<c>"GRASS"</c>, <c>"TREE"</c> or <c>"WEED"</c>).</summary>
+        [JsonPropertyName("code")]
+        public string? Code { get; set; }
+
+        /// <summary>Human-readable pollen type name (e.g. <c>"Grass"</c>).</summary>
+        [JsonPropertyName("displayName")]
+        public string? DisplayName { get; set; }
+
+        /// <summary>Whether the pollen type is in season on this day.</summary>
+        [JsonPropertyName("inSeason")]
+        public bool? InSeason { get; set; }
+
+        /// <summary>The pollen index for this type. Absent when no data is available.</summary>
+        [JsonPropertyName("indexInfo")]
+        public IndexInfo? IndexInfo { get; set; }
+
+        /// <summary>Health recommendations related to this pollen type.</summary>
+        [JsonPropertyName("healthRecommendations")]
+        public List<string>? HealthRecommendations { get; set; }
+    }
+}

--- a/GoogleMapsApi/GoogleMapsClient.cs
+++ b/GoogleMapsApi/GoogleMapsClient.cs
@@ -19,6 +19,8 @@ using GoogleMapsApi.Entities.Routes.Request;
 using GoogleMapsApi.Entities.Routes.Response;
 using GoogleMapsApi.Entities.PlacesNew.Request;
 using GoogleMapsApi.Entities.PlacesNew.Response;
+using GoogleMapsApi.Entities.Pollen.Request;
+using GoogleMapsApi.Entities.Pollen.Response;
 using GoogleMapsApi.Entities.Solar.Request;
 using GoogleMapsApi.Entities.Solar.Response;
 using GoogleMapsApi.Entities.TimeZone.Request;
@@ -76,6 +78,8 @@ namespace GoogleMapsApi
             AirQualityForecast = new HttpClientEngineFacade<ForecastRequest, ForecastResponse>(httpClient, options);
             AirQualityHistory = new HttpClientEngineFacade<HistoryRequest, HistoryResponse>(httpClient, options);
             AirQualityHeatmapTile = new HttpClientEngineFacade<HeatmapTileRequest, HeatmapTileResponse>(httpClient, options);
+            PollenForecast = new HttpClientEngineFacade<PollenForecastRequest, PollenForecastResponse>(httpClient, options);
+            PollenHeatmapTile = new HttpClientEngineFacade<PollenHeatmapTileRequest, PollenHeatmapTileResponse>(httpClient, options);
             AerialView = new AerialViewApi(httpClient, options);
         }
 
@@ -144,6 +148,12 @@ namespace GoogleMapsApi
 
         /// <inheritdoc/>
         public IEngineFacade<HeatmapTileRequest, HeatmapTileResponse> AirQualityHeatmapTile { get; }
+
+        /// <inheritdoc/>
+        public IEngineFacade<PollenForecastRequest, PollenForecastResponse> PollenForecast { get; }
+
+        /// <inheritdoc/>
+        public IEngineFacade<PollenHeatmapTileRequest, PollenHeatmapTileResponse> PollenHeatmapTile { get; }
 
         /// <inheritdoc/>
         public IAerialViewApi AerialView { get; }

--- a/GoogleMapsApi/GoogleMapsClient.cs
+++ b/GoogleMapsApi/GoogleMapsClient.cs
@@ -3,6 +3,8 @@ using GoogleMapsApi.Entities.AddressValidation.Request;
 using GoogleMapsApi.Entities.AddressValidation.Response;
 using GoogleMapsApi.Entities.AerialView.Request;
 using GoogleMapsApi.Entities.AerialView.Response;
+using GoogleMapsApi.Entities.AirQuality.Request;
+using GoogleMapsApi.Entities.AirQuality.Response;
 using GoogleMapsApi.Entities.Directions.Request;
 using GoogleMapsApi.Entities.Directions.Response;
 using GoogleMapsApi.Entities.DistanceMatrix.Request;
@@ -70,6 +72,10 @@ namespace GoogleMapsApi
             SolarBuildingInsights = new HttpClientEngineFacade<BuildingInsightsRequest, BuildingInsightsResponse>(httpClient, options);
             SolarDataLayers = new HttpClientEngineFacade<DataLayersRequest, DataLayersResponse>(httpClient, options);
             SolarGeoTiff = new HttpClientEngineFacade<GeoTiffRequest, GeoTiffResponse>(httpClient, options);
+            AirQualityCurrentConditions = new HttpClientEngineFacade<CurrentConditionsRequest, CurrentConditionsResponse>(httpClient, options);
+            AirQualityForecast = new HttpClientEngineFacade<ForecastRequest, ForecastResponse>(httpClient, options);
+            AirQualityHistory = new HttpClientEngineFacade<HistoryRequest, HistoryResponse>(httpClient, options);
+            AirQualityHeatmapTile = new HttpClientEngineFacade<HeatmapTileRequest, HeatmapTileResponse>(httpClient, options);
             AerialView = new AerialViewApi(httpClient, options);
         }
 
@@ -126,6 +132,18 @@ namespace GoogleMapsApi
 
         /// <inheritdoc/>
         public IEngineFacade<GeoTiffRequest, GeoTiffResponse> SolarGeoTiff { get; }
+
+        /// <inheritdoc/>
+        public IEngineFacade<CurrentConditionsRequest, CurrentConditionsResponse> AirQualityCurrentConditions { get; }
+
+        /// <inheritdoc/>
+        public IEngineFacade<ForecastRequest, ForecastResponse> AirQualityForecast { get; }
+
+        /// <inheritdoc/>
+        public IEngineFacade<HistoryRequest, HistoryResponse> AirQualityHistory { get; }
+
+        /// <inheritdoc/>
+        public IEngineFacade<HeatmapTileRequest, HeatmapTileResponse> AirQualityHeatmapTile { get; }
 
         /// <inheritdoc/>
         public IAerialViewApi AerialView { get; }

--- a/GoogleMapsApi/IGoogleMapsClient.cs
+++ b/GoogleMapsApi/IGoogleMapsClient.cs
@@ -16,6 +16,8 @@ using GoogleMapsApi.Entities.Routes.Request;
 using GoogleMapsApi.Entities.Routes.Response;
 using GoogleMapsApi.Entities.PlacesNew.Request;
 using GoogleMapsApi.Entities.PlacesNew.Response;
+using GoogleMapsApi.Entities.Pollen.Request;
+using GoogleMapsApi.Entities.Pollen.Response;
 using GoogleMapsApi.Entities.Solar.Request;
 using GoogleMapsApi.Entities.Solar.Response;
 using GoogleMapsApi.Entities.TimeZone.Request;
@@ -101,6 +103,12 @@ namespace GoogleMapsApi
 
         /// <summary>Download an air-quality heatmap map tile as raw PNG bytes via the Air Quality API (billable).</summary>
         IEngineFacade<HeatmapTileRequest, HeatmapTileResponse> AirQualityHeatmapTile { get; }
+
+        /// <summary>Get a multi-day pollen forecast (types and plants) for a coordinate via the Pollen API (billable).</summary>
+        IEngineFacade<PollenForecastRequest, PollenForecastResponse> PollenForecast { get; }
+
+        /// <summary>Download a pollen heatmap map tile as raw PNG bytes via the Pollen API (billable).</summary>
+        IEngineFacade<PollenHeatmapTileRequest, PollenHeatmapTileResponse> PollenHeatmapTile { get; }
 
         /// <summary>Render and look up cinematic flyover videos via the Aerial View API.</summary>
         IAerialViewApi AerialView { get; }

--- a/GoogleMapsApi/IGoogleMapsClient.cs
+++ b/GoogleMapsApi/IGoogleMapsClient.cs
@@ -1,5 +1,7 @@
 using GoogleMapsApi.Entities.AddressValidation.Request;
 using GoogleMapsApi.Entities.AddressValidation.Response;
+using GoogleMapsApi.Entities.AirQuality.Request;
+using GoogleMapsApi.Entities.AirQuality.Response;
 using GoogleMapsApi.Entities.Directions.Request;
 using GoogleMapsApi.Entities.Directions.Response;
 using GoogleMapsApi.Entities.DistanceMatrix.Request;
@@ -87,6 +89,18 @@ namespace GoogleMapsApi
 
         /// <summary>Download a Solar API data layer as raw GeoTIFF bytes (billable).</summary>
         IEngineFacade<GeoTiffRequest, GeoTiffResponse> SolarGeoTiff { get; }
+
+        /// <summary>Get current hourly air-quality conditions for a coordinate via the Air Quality API (billable).</summary>
+        IEngineFacade<CurrentConditionsRequest, CurrentConditionsResponse> AirQualityCurrentConditions { get; }
+
+        /// <summary>Get an hourly air-quality forecast for a coordinate via the Air Quality API (billable).</summary>
+        IEngineFacade<ForecastRequest, ForecastResponse> AirQualityForecast { get; }
+
+        /// <summary>Get past hourly air-quality records for a coordinate via the Air Quality API (billable).</summary>
+        IEngineFacade<HistoryRequest, HistoryResponse> AirQualityHistory { get; }
+
+        /// <summary>Download an air-quality heatmap map tile as raw PNG bytes via the Air Quality API (billable).</summary>
+        IEngineFacade<HeatmapTileRequest, HeatmapTileResponse> AirQualityHeatmapTile { get; }
 
         /// <summary>Render and look up cinematic flyover videos via the Aerial View API.</summary>
         IAerialViewApi AerialView { get; }

--- a/GoogleMapsApi/PublicAPI.Unshipped.txt
+++ b/GoogleMapsApi/PublicAPI.Unshipped.txt
@@ -442,3 +442,241 @@ override GoogleMapsApi.Entities.Solar.Request.DataLayersRequest.GetUri() -> Syst
 override GoogleMapsApi.Entities.Solar.Request.GeoTiffRequest.GetUri() -> System.Uri!
 override GoogleMapsApi.Entities.AerialView.Request.LookupVideoRequest.GetUri() -> System.Uri!
 override GoogleMapsApi.Entities.AerialView.Request.RenderVideoRequest.GetUri() -> System.Uri!
+GoogleMapsApi.Entities.AirQuality.Request.AirQualityMapType
+GoogleMapsApi.Entities.AirQuality.Request.AirQualityMapType.CanEc = 6 -> GoogleMapsApi.Entities.AirQuality.Request.AirQualityMapType
+GoogleMapsApi.Entities.AirQuality.Request.AirQualityMapType.DeuUba = 5 -> GoogleMapsApi.Entities.AirQuality.Request.AirQualityMapType
+GoogleMapsApi.Entities.AirQuality.Request.AirQualityMapType.FraAtmo = 7 -> GoogleMapsApi.Entities.AirQuality.Request.AirQualityMapType
+GoogleMapsApi.Entities.AirQuality.Request.AirQualityMapType.GbrDefra = 4 -> GoogleMapsApi.Entities.AirQuality.Request.AirQualityMapType
+GoogleMapsApi.Entities.AirQuality.Request.AirQualityMapType.Pm25IndigoPersian = 3 -> GoogleMapsApi.Entities.AirQuality.Request.AirQualityMapType
+GoogleMapsApi.Entities.AirQuality.Request.AirQualityMapType.UaqiIndigoPersian = 2 -> GoogleMapsApi.Entities.AirQuality.Request.AirQualityMapType
+GoogleMapsApi.Entities.AirQuality.Request.AirQualityMapType.UaqiRedGreen = 1 -> GoogleMapsApi.Entities.AirQuality.Request.AirQualityMapType
+GoogleMapsApi.Entities.AirQuality.Request.AirQualityMapType.Unspecified = 0 -> GoogleMapsApi.Entities.AirQuality.Request.AirQualityMapType
+GoogleMapsApi.Entities.AirQuality.Request.AirQualityMapType.UsAqi = 8 -> GoogleMapsApi.Entities.AirQuality.Request.AirQualityMapType
+GoogleMapsApi.Entities.AirQuality.Request.ColorPalette
+GoogleMapsApi.Entities.AirQuality.Request.ColorPalette.IndigoPersianDark = 2 -> GoogleMapsApi.Entities.AirQuality.Request.ColorPalette
+GoogleMapsApi.Entities.AirQuality.Request.ColorPalette.IndigoPersianLight = 3 -> GoogleMapsApi.Entities.AirQuality.Request.ColorPalette
+GoogleMapsApi.Entities.AirQuality.Request.ColorPalette.RedGreen = 1 -> GoogleMapsApi.Entities.AirQuality.Request.ColorPalette
+GoogleMapsApi.Entities.AirQuality.Request.ColorPalette.Unspecified = 0 -> GoogleMapsApi.Entities.AirQuality.Request.ColorPalette
+GoogleMapsApi.Entities.AirQuality.Request.CurrentConditionsRequest
+GoogleMapsApi.Entities.AirQuality.Request.CurrentConditionsRequest.CurrentConditionsRequest() -> void
+GoogleMapsApi.Entities.AirQuality.Request.CurrentConditionsRequest.CustomLocalAqis.get -> System.Collections.Generic.List<GoogleMapsApi.Entities.AirQuality.Request.CustomLocalAqi!>?
+GoogleMapsApi.Entities.AirQuality.Request.CurrentConditionsRequest.CustomLocalAqis.set -> void
+GoogleMapsApi.Entities.AirQuality.Request.CurrentConditionsRequest.ExtraComputations.get -> System.Collections.Generic.List<GoogleMapsApi.Entities.AirQuality.Request.ExtraComputation>?
+GoogleMapsApi.Entities.AirQuality.Request.CurrentConditionsRequest.ExtraComputations.set -> void
+GoogleMapsApi.Entities.AirQuality.Request.CurrentConditionsRequest.LanguageCode.get -> string?
+GoogleMapsApi.Entities.AirQuality.Request.CurrentConditionsRequest.LanguageCode.set -> void
+GoogleMapsApi.Entities.AirQuality.Request.CurrentConditionsRequest.Latitude.get -> double
+GoogleMapsApi.Entities.AirQuality.Request.CurrentConditionsRequest.Latitude.set -> void
+GoogleMapsApi.Entities.AirQuality.Request.CurrentConditionsRequest.Longitude.get -> double
+GoogleMapsApi.Entities.AirQuality.Request.CurrentConditionsRequest.Longitude.set -> void
+GoogleMapsApi.Entities.AirQuality.Request.CurrentConditionsRequest.UaqiColorPalette.get -> GoogleMapsApi.Entities.AirQuality.Request.ColorPalette?
+GoogleMapsApi.Entities.AirQuality.Request.CurrentConditionsRequest.UaqiColorPalette.set -> void
+GoogleMapsApi.Entities.AirQuality.Request.CurrentConditionsRequest.UniversalAqi.get -> bool?
+GoogleMapsApi.Entities.AirQuality.Request.CurrentConditionsRequest.UniversalAqi.set -> void
+GoogleMapsApi.Entities.AirQuality.Request.CustomLocalAqi
+GoogleMapsApi.Entities.AirQuality.Request.CustomLocalAqi.Aqi.get -> string?
+GoogleMapsApi.Entities.AirQuality.Request.CustomLocalAqi.Aqi.set -> void
+GoogleMapsApi.Entities.AirQuality.Request.CustomLocalAqi.CustomLocalAqi() -> void
+GoogleMapsApi.Entities.AirQuality.Request.CustomLocalAqi.RegionCode.get -> string?
+GoogleMapsApi.Entities.AirQuality.Request.CustomLocalAqi.RegionCode.set -> void
+GoogleMapsApi.Entities.AirQuality.Request.ExtraComputation
+GoogleMapsApi.Entities.AirQuality.Request.ExtraComputation.DominantPollutantConcentration = 4 -> GoogleMapsApi.Entities.AirQuality.Request.ExtraComputation
+GoogleMapsApi.Entities.AirQuality.Request.ExtraComputation.HealthRecommendations = 2 -> GoogleMapsApi.Entities.AirQuality.Request.ExtraComputation
+GoogleMapsApi.Entities.AirQuality.Request.ExtraComputation.LocalAqi = 1 -> GoogleMapsApi.Entities.AirQuality.Request.ExtraComputation
+GoogleMapsApi.Entities.AirQuality.Request.ExtraComputation.PollutantAdditionalInfo = 3 -> GoogleMapsApi.Entities.AirQuality.Request.ExtraComputation
+GoogleMapsApi.Entities.AirQuality.Request.ExtraComputation.PollutantConcentration = 5 -> GoogleMapsApi.Entities.AirQuality.Request.ExtraComputation
+GoogleMapsApi.Entities.AirQuality.Request.ExtraComputation.Unspecified = 0 -> GoogleMapsApi.Entities.AirQuality.Request.ExtraComputation
+GoogleMapsApi.Entities.AirQuality.Request.ForecastRequest
+GoogleMapsApi.Entities.AirQuality.Request.ForecastRequest.CustomLocalAqis.get -> System.Collections.Generic.List<GoogleMapsApi.Entities.AirQuality.Request.CustomLocalAqi!>?
+GoogleMapsApi.Entities.AirQuality.Request.ForecastRequest.CustomLocalAqis.set -> void
+GoogleMapsApi.Entities.AirQuality.Request.ForecastRequest.DateTime.get -> System.DateTimeOffset?
+GoogleMapsApi.Entities.AirQuality.Request.ForecastRequest.DateTime.set -> void
+GoogleMapsApi.Entities.AirQuality.Request.ForecastRequest.ExtraComputations.get -> System.Collections.Generic.List<GoogleMapsApi.Entities.AirQuality.Request.ExtraComputation>?
+GoogleMapsApi.Entities.AirQuality.Request.ForecastRequest.ExtraComputations.set -> void
+GoogleMapsApi.Entities.AirQuality.Request.ForecastRequest.ForecastRequest() -> void
+GoogleMapsApi.Entities.AirQuality.Request.ForecastRequest.LanguageCode.get -> string?
+GoogleMapsApi.Entities.AirQuality.Request.ForecastRequest.LanguageCode.set -> void
+GoogleMapsApi.Entities.AirQuality.Request.ForecastRequest.Latitude.get -> double
+GoogleMapsApi.Entities.AirQuality.Request.ForecastRequest.Latitude.set -> void
+GoogleMapsApi.Entities.AirQuality.Request.ForecastRequest.Longitude.get -> double
+GoogleMapsApi.Entities.AirQuality.Request.ForecastRequest.Longitude.set -> void
+GoogleMapsApi.Entities.AirQuality.Request.ForecastRequest.PageSize.get -> int?
+GoogleMapsApi.Entities.AirQuality.Request.ForecastRequest.PageSize.set -> void
+GoogleMapsApi.Entities.AirQuality.Request.ForecastRequest.PageToken.get -> string?
+GoogleMapsApi.Entities.AirQuality.Request.ForecastRequest.PageToken.set -> void
+GoogleMapsApi.Entities.AirQuality.Request.ForecastRequest.Period.get -> GoogleMapsApi.Entities.AirQuality.Request.Interval?
+GoogleMapsApi.Entities.AirQuality.Request.ForecastRequest.Period.set -> void
+GoogleMapsApi.Entities.AirQuality.Request.ForecastRequest.UaqiColorPalette.get -> GoogleMapsApi.Entities.AirQuality.Request.ColorPalette?
+GoogleMapsApi.Entities.AirQuality.Request.ForecastRequest.UaqiColorPalette.set -> void
+GoogleMapsApi.Entities.AirQuality.Request.ForecastRequest.UniversalAqi.get -> bool?
+GoogleMapsApi.Entities.AirQuality.Request.ForecastRequest.UniversalAqi.set -> void
+GoogleMapsApi.Entities.AirQuality.Request.HeatmapTileRequest
+GoogleMapsApi.Entities.AirQuality.Request.HeatmapTileRequest.HeatmapTileRequest() -> void
+GoogleMapsApi.Entities.AirQuality.Request.HeatmapTileRequest.MapType.get -> GoogleMapsApi.Entities.AirQuality.Request.AirQualityMapType
+GoogleMapsApi.Entities.AirQuality.Request.HeatmapTileRequest.MapType.set -> void
+GoogleMapsApi.Entities.AirQuality.Request.HeatmapTileRequest.X.get -> int
+GoogleMapsApi.Entities.AirQuality.Request.HeatmapTileRequest.X.set -> void
+GoogleMapsApi.Entities.AirQuality.Request.HeatmapTileRequest.Y.get -> int
+GoogleMapsApi.Entities.AirQuality.Request.HeatmapTileRequest.Y.set -> void
+GoogleMapsApi.Entities.AirQuality.Request.HeatmapTileRequest.Zoom.get -> int
+GoogleMapsApi.Entities.AirQuality.Request.HeatmapTileRequest.Zoom.set -> void
+GoogleMapsApi.Entities.AirQuality.Request.HistoryRequest
+GoogleMapsApi.Entities.AirQuality.Request.HistoryRequest.CustomLocalAqis.get -> System.Collections.Generic.List<GoogleMapsApi.Entities.AirQuality.Request.CustomLocalAqi!>?
+GoogleMapsApi.Entities.AirQuality.Request.HistoryRequest.CustomLocalAqis.set -> void
+GoogleMapsApi.Entities.AirQuality.Request.HistoryRequest.DateTime.get -> System.DateTimeOffset?
+GoogleMapsApi.Entities.AirQuality.Request.HistoryRequest.DateTime.set -> void
+GoogleMapsApi.Entities.AirQuality.Request.HistoryRequest.ExtraComputations.get -> System.Collections.Generic.List<GoogleMapsApi.Entities.AirQuality.Request.ExtraComputation>?
+GoogleMapsApi.Entities.AirQuality.Request.HistoryRequest.ExtraComputations.set -> void
+GoogleMapsApi.Entities.AirQuality.Request.HistoryRequest.HistoryRequest() -> void
+GoogleMapsApi.Entities.AirQuality.Request.HistoryRequest.Hours.get -> int?
+GoogleMapsApi.Entities.AirQuality.Request.HistoryRequest.Hours.set -> void
+GoogleMapsApi.Entities.AirQuality.Request.HistoryRequest.LanguageCode.get -> string?
+GoogleMapsApi.Entities.AirQuality.Request.HistoryRequest.LanguageCode.set -> void
+GoogleMapsApi.Entities.AirQuality.Request.HistoryRequest.Latitude.get -> double
+GoogleMapsApi.Entities.AirQuality.Request.HistoryRequest.Latitude.set -> void
+GoogleMapsApi.Entities.AirQuality.Request.HistoryRequest.Longitude.get -> double
+GoogleMapsApi.Entities.AirQuality.Request.HistoryRequest.Longitude.set -> void
+GoogleMapsApi.Entities.AirQuality.Request.HistoryRequest.PageSize.get -> int?
+GoogleMapsApi.Entities.AirQuality.Request.HistoryRequest.PageSize.set -> void
+GoogleMapsApi.Entities.AirQuality.Request.HistoryRequest.PageToken.get -> string?
+GoogleMapsApi.Entities.AirQuality.Request.HistoryRequest.PageToken.set -> void
+GoogleMapsApi.Entities.AirQuality.Request.HistoryRequest.Period.get -> GoogleMapsApi.Entities.AirQuality.Request.Interval?
+GoogleMapsApi.Entities.AirQuality.Request.HistoryRequest.Period.set -> void
+GoogleMapsApi.Entities.AirQuality.Request.HistoryRequest.UaqiColorPalette.get -> GoogleMapsApi.Entities.AirQuality.Request.ColorPalette?
+GoogleMapsApi.Entities.AirQuality.Request.HistoryRequest.UaqiColorPalette.set -> void
+GoogleMapsApi.Entities.AirQuality.Request.HistoryRequest.UniversalAqi.get -> bool?
+GoogleMapsApi.Entities.AirQuality.Request.HistoryRequest.UniversalAqi.set -> void
+GoogleMapsApi.Entities.AirQuality.Request.Interval
+GoogleMapsApi.Entities.AirQuality.Request.Interval.EndTime.get -> System.DateTimeOffset?
+GoogleMapsApi.Entities.AirQuality.Request.Interval.EndTime.set -> void
+GoogleMapsApi.Entities.AirQuality.Request.Interval.Interval() -> void
+GoogleMapsApi.Entities.AirQuality.Request.Interval.StartTime.get -> System.DateTimeOffset?
+GoogleMapsApi.Entities.AirQuality.Request.Interval.StartTime.set -> void
+GoogleMapsApi.Entities.AirQuality.Request.LatLng
+GoogleMapsApi.Entities.AirQuality.Request.LatLng.LatLng() -> void
+GoogleMapsApi.Entities.AirQuality.Request.LatLng.Latitude.get -> double
+GoogleMapsApi.Entities.AirQuality.Request.LatLng.Latitude.set -> void
+GoogleMapsApi.Entities.AirQuality.Request.LatLng.Longitude.get -> double
+GoogleMapsApi.Entities.AirQuality.Request.LatLng.Longitude.set -> void
+GoogleMapsApi.Entities.AirQuality.Response.AdditionalInfo
+GoogleMapsApi.Entities.AirQuality.Response.AdditionalInfo.AdditionalInfo() -> void
+GoogleMapsApi.Entities.AirQuality.Response.AdditionalInfo.Effects.get -> string?
+GoogleMapsApi.Entities.AirQuality.Response.AdditionalInfo.Effects.set -> void
+GoogleMapsApi.Entities.AirQuality.Response.AdditionalInfo.Sources.get -> string?
+GoogleMapsApi.Entities.AirQuality.Response.AdditionalInfo.Sources.set -> void
+GoogleMapsApi.Entities.AirQuality.Response.AirQualityIndex
+GoogleMapsApi.Entities.AirQuality.Response.AirQualityIndex.AirQualityIndex() -> void
+GoogleMapsApi.Entities.AirQuality.Response.AirQualityIndex.Aqi.get -> int
+GoogleMapsApi.Entities.AirQuality.Response.AirQualityIndex.Aqi.set -> void
+GoogleMapsApi.Entities.AirQuality.Response.AirQualityIndex.AqiDisplay.get -> string?
+GoogleMapsApi.Entities.AirQuality.Response.AirQualityIndex.AqiDisplay.set -> void
+GoogleMapsApi.Entities.AirQuality.Response.AirQualityIndex.Category.get -> string?
+GoogleMapsApi.Entities.AirQuality.Response.AirQualityIndex.Category.set -> void
+GoogleMapsApi.Entities.AirQuality.Response.AirQualityIndex.Code.get -> string?
+GoogleMapsApi.Entities.AirQuality.Response.AirQualityIndex.Code.set -> void
+GoogleMapsApi.Entities.AirQuality.Response.AirQualityIndex.Color.get -> GoogleMapsApi.Entities.AirQuality.Response.Color?
+GoogleMapsApi.Entities.AirQuality.Response.AirQualityIndex.Color.set -> void
+GoogleMapsApi.Entities.AirQuality.Response.AirQualityIndex.DisplayName.get -> string?
+GoogleMapsApi.Entities.AirQuality.Response.AirQualityIndex.DisplayName.set -> void
+GoogleMapsApi.Entities.AirQuality.Response.AirQualityIndex.DominantPollutant.get -> string?
+GoogleMapsApi.Entities.AirQuality.Response.AirQualityIndex.DominantPollutant.set -> void
+GoogleMapsApi.Entities.AirQuality.Response.Color
+GoogleMapsApi.Entities.AirQuality.Response.Color.Alpha.get -> float?
+GoogleMapsApi.Entities.AirQuality.Response.Color.Alpha.set -> void
+GoogleMapsApi.Entities.AirQuality.Response.Color.Blue.get -> float?
+GoogleMapsApi.Entities.AirQuality.Response.Color.Blue.set -> void
+GoogleMapsApi.Entities.AirQuality.Response.Color.Color() -> void
+GoogleMapsApi.Entities.AirQuality.Response.Color.Green.get -> float?
+GoogleMapsApi.Entities.AirQuality.Response.Color.Green.set -> void
+GoogleMapsApi.Entities.AirQuality.Response.Color.Red.get -> float?
+GoogleMapsApi.Entities.AirQuality.Response.Color.Red.set -> void
+GoogleMapsApi.Entities.AirQuality.Response.Concentration
+GoogleMapsApi.Entities.AirQuality.Response.Concentration.Concentration() -> void
+GoogleMapsApi.Entities.AirQuality.Response.Concentration.Units.get -> string?
+GoogleMapsApi.Entities.AirQuality.Response.Concentration.Units.set -> void
+GoogleMapsApi.Entities.AirQuality.Response.Concentration.Value.get -> double
+GoogleMapsApi.Entities.AirQuality.Response.Concentration.Value.set -> void
+GoogleMapsApi.Entities.AirQuality.Response.CurrentConditionsResponse
+GoogleMapsApi.Entities.AirQuality.Response.CurrentConditionsResponse.CurrentConditionsResponse() -> void
+GoogleMapsApi.Entities.AirQuality.Response.CurrentConditionsResponse.DateTime.get -> System.DateTimeOffset?
+GoogleMapsApi.Entities.AirQuality.Response.CurrentConditionsResponse.DateTime.set -> void
+GoogleMapsApi.Entities.AirQuality.Response.CurrentConditionsResponse.HealthRecommendations.get -> GoogleMapsApi.Entities.AirQuality.Response.HealthRecommendations?
+GoogleMapsApi.Entities.AirQuality.Response.CurrentConditionsResponse.HealthRecommendations.set -> void
+GoogleMapsApi.Entities.AirQuality.Response.CurrentConditionsResponse.Indexes.get -> System.Collections.Generic.List<GoogleMapsApi.Entities.AirQuality.Response.AirQualityIndex!>?
+GoogleMapsApi.Entities.AirQuality.Response.CurrentConditionsResponse.Indexes.set -> void
+GoogleMapsApi.Entities.AirQuality.Response.CurrentConditionsResponse.Pollutants.get -> System.Collections.Generic.List<GoogleMapsApi.Entities.AirQuality.Response.Pollutant!>?
+GoogleMapsApi.Entities.AirQuality.Response.CurrentConditionsResponse.Pollutants.set -> void
+GoogleMapsApi.Entities.AirQuality.Response.CurrentConditionsResponse.RegionCode.get -> string?
+GoogleMapsApi.Entities.AirQuality.Response.CurrentConditionsResponse.RegionCode.set -> void
+GoogleMapsApi.Entities.AirQuality.Response.ForecastResponse
+GoogleMapsApi.Entities.AirQuality.Response.ForecastResponse.ForecastResponse() -> void
+GoogleMapsApi.Entities.AirQuality.Response.ForecastResponse.HourlyForecasts.get -> System.Collections.Generic.List<GoogleMapsApi.Entities.AirQuality.Response.HourlyForecast!>?
+GoogleMapsApi.Entities.AirQuality.Response.ForecastResponse.HourlyForecasts.set -> void
+GoogleMapsApi.Entities.AirQuality.Response.ForecastResponse.NextPageToken.get -> string?
+GoogleMapsApi.Entities.AirQuality.Response.ForecastResponse.NextPageToken.set -> void
+GoogleMapsApi.Entities.AirQuality.Response.ForecastResponse.RegionCode.get -> string?
+GoogleMapsApi.Entities.AirQuality.Response.ForecastResponse.RegionCode.set -> void
+GoogleMapsApi.Entities.AirQuality.Response.HealthRecommendations
+GoogleMapsApi.Entities.AirQuality.Response.HealthRecommendations.Athletes.get -> string?
+GoogleMapsApi.Entities.AirQuality.Response.HealthRecommendations.Athletes.set -> void
+GoogleMapsApi.Entities.AirQuality.Response.HealthRecommendations.Children.get -> string?
+GoogleMapsApi.Entities.AirQuality.Response.HealthRecommendations.Children.set -> void
+GoogleMapsApi.Entities.AirQuality.Response.HealthRecommendations.Elderly.get -> string?
+GoogleMapsApi.Entities.AirQuality.Response.HealthRecommendations.Elderly.set -> void
+GoogleMapsApi.Entities.AirQuality.Response.HealthRecommendations.GeneralPopulation.get -> string?
+GoogleMapsApi.Entities.AirQuality.Response.HealthRecommendations.GeneralPopulation.set -> void
+GoogleMapsApi.Entities.AirQuality.Response.HealthRecommendations.HealthRecommendations() -> void
+GoogleMapsApi.Entities.AirQuality.Response.HealthRecommendations.HeartDiseasePopulation.get -> string?
+GoogleMapsApi.Entities.AirQuality.Response.HealthRecommendations.HeartDiseasePopulation.set -> void
+GoogleMapsApi.Entities.AirQuality.Response.HealthRecommendations.LungDiseasePopulation.get -> string?
+GoogleMapsApi.Entities.AirQuality.Response.HealthRecommendations.LungDiseasePopulation.set -> void
+GoogleMapsApi.Entities.AirQuality.Response.HealthRecommendations.PregnantWomen.get -> string?
+GoogleMapsApi.Entities.AirQuality.Response.HealthRecommendations.PregnantWomen.set -> void
+GoogleMapsApi.Entities.AirQuality.Response.HeatmapTileResponse
+GoogleMapsApi.Entities.AirQuality.Response.HeatmapTileResponse.Content.get -> byte[]!
+GoogleMapsApi.Entities.AirQuality.Response.HeatmapTileResponse.Content.set -> void
+GoogleMapsApi.Entities.AirQuality.Response.HeatmapTileResponse.ContentType.get -> string?
+GoogleMapsApi.Entities.AirQuality.Response.HeatmapTileResponse.ContentType.set -> void
+GoogleMapsApi.Entities.AirQuality.Response.HeatmapTileResponse.HeatmapTileResponse() -> void
+GoogleMapsApi.Entities.AirQuality.Response.HistoryResponse
+GoogleMapsApi.Entities.AirQuality.Response.HistoryResponse.HistoryResponse() -> void
+GoogleMapsApi.Entities.AirQuality.Response.HistoryResponse.HoursInfo.get -> System.Collections.Generic.List<GoogleMapsApi.Entities.AirQuality.Response.HourlyForecast!>?
+GoogleMapsApi.Entities.AirQuality.Response.HistoryResponse.HoursInfo.set -> void
+GoogleMapsApi.Entities.AirQuality.Response.HistoryResponse.NextPageToken.get -> string?
+GoogleMapsApi.Entities.AirQuality.Response.HistoryResponse.NextPageToken.set -> void
+GoogleMapsApi.Entities.AirQuality.Response.HistoryResponse.RegionCode.get -> string?
+GoogleMapsApi.Entities.AirQuality.Response.HistoryResponse.RegionCode.set -> void
+GoogleMapsApi.Entities.AirQuality.Response.HourlyForecast
+GoogleMapsApi.Entities.AirQuality.Response.HourlyForecast.DateTime.get -> System.DateTimeOffset?
+GoogleMapsApi.Entities.AirQuality.Response.HourlyForecast.DateTime.set -> void
+GoogleMapsApi.Entities.AirQuality.Response.HourlyForecast.HealthRecommendations.get -> GoogleMapsApi.Entities.AirQuality.Response.HealthRecommendations?
+GoogleMapsApi.Entities.AirQuality.Response.HourlyForecast.HealthRecommendations.set -> void
+GoogleMapsApi.Entities.AirQuality.Response.HourlyForecast.HourlyForecast() -> void
+GoogleMapsApi.Entities.AirQuality.Response.HourlyForecast.Indexes.get -> System.Collections.Generic.List<GoogleMapsApi.Entities.AirQuality.Response.AirQualityIndex!>?
+GoogleMapsApi.Entities.AirQuality.Response.HourlyForecast.Indexes.set -> void
+GoogleMapsApi.Entities.AirQuality.Response.HourlyForecast.Pollutants.get -> System.Collections.Generic.List<GoogleMapsApi.Entities.AirQuality.Response.Pollutant!>?
+GoogleMapsApi.Entities.AirQuality.Response.HourlyForecast.Pollutants.set -> void
+GoogleMapsApi.Entities.AirQuality.Response.Pollutant
+GoogleMapsApi.Entities.AirQuality.Response.Pollutant.AdditionalInfo.get -> GoogleMapsApi.Entities.AirQuality.Response.AdditionalInfo?
+GoogleMapsApi.Entities.AirQuality.Response.Pollutant.AdditionalInfo.set -> void
+GoogleMapsApi.Entities.AirQuality.Response.Pollutant.Code.get -> string?
+GoogleMapsApi.Entities.AirQuality.Response.Pollutant.Code.set -> void
+GoogleMapsApi.Entities.AirQuality.Response.Pollutant.Concentration.get -> GoogleMapsApi.Entities.AirQuality.Response.Concentration?
+GoogleMapsApi.Entities.AirQuality.Response.Pollutant.Concentration.set -> void
+GoogleMapsApi.Entities.AirQuality.Response.Pollutant.DisplayName.get -> string?
+GoogleMapsApi.Entities.AirQuality.Response.Pollutant.DisplayName.set -> void
+GoogleMapsApi.Entities.AirQuality.Response.Pollutant.FullName.get -> string?
+GoogleMapsApi.Entities.AirQuality.Response.Pollutant.FullName.set -> void
+GoogleMapsApi.Entities.AirQuality.Response.Pollutant.Pollutant() -> void
+GoogleMapsApi.GoogleMapsClient.AirQualityCurrentConditions.get -> GoogleMapsApi.IEngineFacade<GoogleMapsApi.Entities.AirQuality.Request.CurrentConditionsRequest!, GoogleMapsApi.Entities.AirQuality.Response.CurrentConditionsResponse!>!
+GoogleMapsApi.GoogleMapsClient.AirQualityForecast.get -> GoogleMapsApi.IEngineFacade<GoogleMapsApi.Entities.AirQuality.Request.ForecastRequest!, GoogleMapsApi.Entities.AirQuality.Response.ForecastResponse!>!
+GoogleMapsApi.GoogleMapsClient.AirQualityHeatmapTile.get -> GoogleMapsApi.IEngineFacade<GoogleMapsApi.Entities.AirQuality.Request.HeatmapTileRequest!, GoogleMapsApi.Entities.AirQuality.Response.HeatmapTileResponse!>!
+GoogleMapsApi.GoogleMapsClient.AirQualityHistory.get -> GoogleMapsApi.IEngineFacade<GoogleMapsApi.Entities.AirQuality.Request.HistoryRequest!, GoogleMapsApi.Entities.AirQuality.Response.HistoryResponse!>!
+GoogleMapsApi.IGoogleMapsClient.AirQualityCurrentConditions.get -> GoogleMapsApi.IEngineFacade<GoogleMapsApi.Entities.AirQuality.Request.CurrentConditionsRequest!, GoogleMapsApi.Entities.AirQuality.Response.CurrentConditionsResponse!>!
+GoogleMapsApi.IGoogleMapsClient.AirQualityForecast.get -> GoogleMapsApi.IEngineFacade<GoogleMapsApi.Entities.AirQuality.Request.ForecastRequest!, GoogleMapsApi.Entities.AirQuality.Response.ForecastResponse!>!
+GoogleMapsApi.IGoogleMapsClient.AirQualityHeatmapTile.get -> GoogleMapsApi.IEngineFacade<GoogleMapsApi.Entities.AirQuality.Request.HeatmapTileRequest!, GoogleMapsApi.Entities.AirQuality.Response.HeatmapTileResponse!>!
+GoogleMapsApi.IGoogleMapsClient.AirQualityHistory.get -> GoogleMapsApi.IEngineFacade<GoogleMapsApi.Entities.AirQuality.Request.HistoryRequest!, GoogleMapsApi.Entities.AirQuality.Response.HistoryResponse!>!
+override GoogleMapsApi.Entities.AirQuality.Request.CurrentConditionsRequest.GetUri() -> System.Uri!
+override GoogleMapsApi.Entities.AirQuality.Request.ForecastRequest.GetUri() -> System.Uri!
+override GoogleMapsApi.Entities.AirQuality.Request.HeatmapTileRequest.GetUri() -> System.Uri!
+override GoogleMapsApi.Entities.AirQuality.Request.HistoryRequest.GetUri() -> System.Uri!

--- a/GoogleMapsApi/PublicAPI.Unshipped.txt
+++ b/GoogleMapsApi/PublicAPI.Unshipped.txt
@@ -680,3 +680,136 @@ override GoogleMapsApi.Entities.AirQuality.Request.CurrentConditionsRequest.GetU
 override GoogleMapsApi.Entities.AirQuality.Request.ForecastRequest.GetUri() -> System.Uri!
 override GoogleMapsApi.Entities.AirQuality.Request.HeatmapTileRequest.GetUri() -> System.Uri!
 override GoogleMapsApi.Entities.AirQuality.Request.HistoryRequest.GetUri() -> System.Uri!
+GoogleMapsApi.Entities.Pollen.Request.PollenForecastRequest
+GoogleMapsApi.Entities.Pollen.Request.PollenForecastRequest.Days.get -> int
+GoogleMapsApi.Entities.Pollen.Request.PollenForecastRequest.Days.set -> void
+GoogleMapsApi.Entities.Pollen.Request.PollenForecastRequest.LanguageCode.get -> string?
+GoogleMapsApi.Entities.Pollen.Request.PollenForecastRequest.LanguageCode.set -> void
+GoogleMapsApi.Entities.Pollen.Request.PollenForecastRequest.Latitude.get -> double
+GoogleMapsApi.Entities.Pollen.Request.PollenForecastRequest.Latitude.set -> void
+GoogleMapsApi.Entities.Pollen.Request.PollenForecastRequest.Longitude.get -> double
+GoogleMapsApi.Entities.Pollen.Request.PollenForecastRequest.Longitude.set -> void
+GoogleMapsApi.Entities.Pollen.Request.PollenForecastRequest.PageSize.get -> int?
+GoogleMapsApi.Entities.Pollen.Request.PollenForecastRequest.PageSize.set -> void
+GoogleMapsApi.Entities.Pollen.Request.PollenForecastRequest.PageToken.get -> string?
+GoogleMapsApi.Entities.Pollen.Request.PollenForecastRequest.PageToken.set -> void
+GoogleMapsApi.Entities.Pollen.Request.PollenForecastRequest.PlantsDescription.get -> bool?
+GoogleMapsApi.Entities.Pollen.Request.PollenForecastRequest.PlantsDescription.set -> void
+GoogleMapsApi.Entities.Pollen.Request.PollenForecastRequest.PollenForecastRequest() -> void
+GoogleMapsApi.Entities.Pollen.Request.PollenHeatmapTileRequest
+GoogleMapsApi.Entities.Pollen.Request.PollenHeatmapTileRequest.MapType.get -> GoogleMapsApi.Entities.Pollen.Request.PollenMapType
+GoogleMapsApi.Entities.Pollen.Request.PollenHeatmapTileRequest.MapType.set -> void
+GoogleMapsApi.Entities.Pollen.Request.PollenHeatmapTileRequest.PollenHeatmapTileRequest() -> void
+GoogleMapsApi.Entities.Pollen.Request.PollenHeatmapTileRequest.X.get -> int
+GoogleMapsApi.Entities.Pollen.Request.PollenHeatmapTileRequest.X.set -> void
+GoogleMapsApi.Entities.Pollen.Request.PollenHeatmapTileRequest.Y.get -> int
+GoogleMapsApi.Entities.Pollen.Request.PollenHeatmapTileRequest.Y.set -> void
+GoogleMapsApi.Entities.Pollen.Request.PollenHeatmapTileRequest.Zoom.get -> int
+GoogleMapsApi.Entities.Pollen.Request.PollenHeatmapTileRequest.Zoom.set -> void
+GoogleMapsApi.Entities.Pollen.Request.PollenMapType
+GoogleMapsApi.Entities.Pollen.Request.PollenMapType.GrassUpi = 2 -> GoogleMapsApi.Entities.Pollen.Request.PollenMapType
+GoogleMapsApi.Entities.Pollen.Request.PollenMapType.TreeUpi = 1 -> GoogleMapsApi.Entities.Pollen.Request.PollenMapType
+GoogleMapsApi.Entities.Pollen.Request.PollenMapType.Unspecified = 0 -> GoogleMapsApi.Entities.Pollen.Request.PollenMapType
+GoogleMapsApi.Entities.Pollen.Request.PollenMapType.WeedUpi = 3 -> GoogleMapsApi.Entities.Pollen.Request.PollenMapType
+GoogleMapsApi.Entities.Pollen.Response.Color
+GoogleMapsApi.Entities.Pollen.Response.Color.Alpha.get -> float?
+GoogleMapsApi.Entities.Pollen.Response.Color.Alpha.set -> void
+GoogleMapsApi.Entities.Pollen.Response.Color.Blue.get -> float?
+GoogleMapsApi.Entities.Pollen.Response.Color.Blue.set -> void
+GoogleMapsApi.Entities.Pollen.Response.Color.Color() -> void
+GoogleMapsApi.Entities.Pollen.Response.Color.Green.get -> float?
+GoogleMapsApi.Entities.Pollen.Response.Color.Green.set -> void
+GoogleMapsApi.Entities.Pollen.Response.Color.Red.get -> float?
+GoogleMapsApi.Entities.Pollen.Response.Color.Red.set -> void
+GoogleMapsApi.Entities.Pollen.Response.Date
+GoogleMapsApi.Entities.Pollen.Response.Date.Date() -> void
+GoogleMapsApi.Entities.Pollen.Response.Date.Day.get -> int
+GoogleMapsApi.Entities.Pollen.Response.Date.Day.set -> void
+GoogleMapsApi.Entities.Pollen.Response.Date.Month.get -> int
+GoogleMapsApi.Entities.Pollen.Response.Date.Month.set -> void
+GoogleMapsApi.Entities.Pollen.Response.Date.Year.get -> int
+GoogleMapsApi.Entities.Pollen.Response.Date.Year.set -> void
+GoogleMapsApi.Entities.Pollen.Response.DayInfo
+GoogleMapsApi.Entities.Pollen.Response.DayInfo.Date.get -> GoogleMapsApi.Entities.Pollen.Response.Date?
+GoogleMapsApi.Entities.Pollen.Response.DayInfo.Date.set -> void
+GoogleMapsApi.Entities.Pollen.Response.DayInfo.DayInfo() -> void
+GoogleMapsApi.Entities.Pollen.Response.DayInfo.PlantInfo.get -> System.Collections.Generic.List<GoogleMapsApi.Entities.Pollen.Response.PlantInfo!>?
+GoogleMapsApi.Entities.Pollen.Response.DayInfo.PlantInfo.set -> void
+GoogleMapsApi.Entities.Pollen.Response.DayInfo.PollenTypeInfo.get -> System.Collections.Generic.List<GoogleMapsApi.Entities.Pollen.Response.PollenTypeInfo!>?
+GoogleMapsApi.Entities.Pollen.Response.DayInfo.PollenTypeInfo.set -> void
+GoogleMapsApi.Entities.Pollen.Response.IndexInfo
+GoogleMapsApi.Entities.Pollen.Response.IndexInfo.Category.get -> string?
+GoogleMapsApi.Entities.Pollen.Response.IndexInfo.Category.set -> void
+GoogleMapsApi.Entities.Pollen.Response.IndexInfo.Code.get -> string?
+GoogleMapsApi.Entities.Pollen.Response.IndexInfo.Code.set -> void
+GoogleMapsApi.Entities.Pollen.Response.IndexInfo.Color.get -> GoogleMapsApi.Entities.Pollen.Response.Color?
+GoogleMapsApi.Entities.Pollen.Response.IndexInfo.Color.set -> void
+GoogleMapsApi.Entities.Pollen.Response.IndexInfo.DisplayName.get -> string?
+GoogleMapsApi.Entities.Pollen.Response.IndexInfo.DisplayName.set -> void
+GoogleMapsApi.Entities.Pollen.Response.IndexInfo.IndexDescription.get -> string?
+GoogleMapsApi.Entities.Pollen.Response.IndexInfo.IndexDescription.set -> void
+GoogleMapsApi.Entities.Pollen.Response.IndexInfo.IndexInfo() -> void
+GoogleMapsApi.Entities.Pollen.Response.IndexInfo.Value.get -> int
+GoogleMapsApi.Entities.Pollen.Response.IndexInfo.Value.set -> void
+GoogleMapsApi.Entities.Pollen.Response.PlantDescription
+GoogleMapsApi.Entities.Pollen.Response.PlantDescription.CrossReaction.get -> string?
+GoogleMapsApi.Entities.Pollen.Response.PlantDescription.CrossReaction.set -> void
+GoogleMapsApi.Entities.Pollen.Response.PlantDescription.Family.get -> string?
+GoogleMapsApi.Entities.Pollen.Response.PlantDescription.Family.set -> void
+GoogleMapsApi.Entities.Pollen.Response.PlantDescription.Picture.get -> string?
+GoogleMapsApi.Entities.Pollen.Response.PlantDescription.Picture.set -> void
+GoogleMapsApi.Entities.Pollen.Response.PlantDescription.PictureCloseup.get -> string?
+GoogleMapsApi.Entities.Pollen.Response.PlantDescription.PictureCloseup.set -> void
+GoogleMapsApi.Entities.Pollen.Response.PlantDescription.PlantDescription() -> void
+GoogleMapsApi.Entities.Pollen.Response.PlantDescription.Season.get -> string?
+GoogleMapsApi.Entities.Pollen.Response.PlantDescription.Season.set -> void
+GoogleMapsApi.Entities.Pollen.Response.PlantDescription.SpecialColors.get -> string?
+GoogleMapsApi.Entities.Pollen.Response.PlantDescription.SpecialColors.set -> void
+GoogleMapsApi.Entities.Pollen.Response.PlantDescription.SpecialShapes.get -> string?
+GoogleMapsApi.Entities.Pollen.Response.PlantDescription.SpecialShapes.set -> void
+GoogleMapsApi.Entities.Pollen.Response.PlantDescription.Type.get -> string?
+GoogleMapsApi.Entities.Pollen.Response.PlantDescription.Type.set -> void
+GoogleMapsApi.Entities.Pollen.Response.PlantInfo
+GoogleMapsApi.Entities.Pollen.Response.PlantInfo.Code.get -> string?
+GoogleMapsApi.Entities.Pollen.Response.PlantInfo.Code.set -> void
+GoogleMapsApi.Entities.Pollen.Response.PlantInfo.DisplayName.get -> string?
+GoogleMapsApi.Entities.Pollen.Response.PlantInfo.DisplayName.set -> void
+GoogleMapsApi.Entities.Pollen.Response.PlantInfo.InSeason.get -> bool?
+GoogleMapsApi.Entities.Pollen.Response.PlantInfo.InSeason.set -> void
+GoogleMapsApi.Entities.Pollen.Response.PlantInfo.IndexInfo.get -> GoogleMapsApi.Entities.Pollen.Response.IndexInfo?
+GoogleMapsApi.Entities.Pollen.Response.PlantInfo.IndexInfo.set -> void
+GoogleMapsApi.Entities.Pollen.Response.PlantInfo.PlantDescription.get -> GoogleMapsApi.Entities.Pollen.Response.PlantDescription?
+GoogleMapsApi.Entities.Pollen.Response.PlantInfo.PlantDescription.set -> void
+GoogleMapsApi.Entities.Pollen.Response.PlantInfo.PlantInfo() -> void
+GoogleMapsApi.Entities.Pollen.Response.PollenForecastResponse
+GoogleMapsApi.Entities.Pollen.Response.PollenForecastResponse.DailyInfo.get -> System.Collections.Generic.List<GoogleMapsApi.Entities.Pollen.Response.DayInfo!>?
+GoogleMapsApi.Entities.Pollen.Response.PollenForecastResponse.DailyInfo.set -> void
+GoogleMapsApi.Entities.Pollen.Response.PollenForecastResponse.NextPageToken.get -> string?
+GoogleMapsApi.Entities.Pollen.Response.PollenForecastResponse.NextPageToken.set -> void
+GoogleMapsApi.Entities.Pollen.Response.PollenForecastResponse.PollenForecastResponse() -> void
+GoogleMapsApi.Entities.Pollen.Response.PollenForecastResponse.RegionCode.get -> string?
+GoogleMapsApi.Entities.Pollen.Response.PollenForecastResponse.RegionCode.set -> void
+GoogleMapsApi.Entities.Pollen.Response.PollenHeatmapTileResponse
+GoogleMapsApi.Entities.Pollen.Response.PollenHeatmapTileResponse.Content.get -> byte[]!
+GoogleMapsApi.Entities.Pollen.Response.PollenHeatmapTileResponse.Content.set -> void
+GoogleMapsApi.Entities.Pollen.Response.PollenHeatmapTileResponse.ContentType.get -> string?
+GoogleMapsApi.Entities.Pollen.Response.PollenHeatmapTileResponse.ContentType.set -> void
+GoogleMapsApi.Entities.Pollen.Response.PollenHeatmapTileResponse.PollenHeatmapTileResponse() -> void
+GoogleMapsApi.Entities.Pollen.Response.PollenTypeInfo
+GoogleMapsApi.Entities.Pollen.Response.PollenTypeInfo.Code.get -> string?
+GoogleMapsApi.Entities.Pollen.Response.PollenTypeInfo.Code.set -> void
+GoogleMapsApi.Entities.Pollen.Response.PollenTypeInfo.DisplayName.get -> string?
+GoogleMapsApi.Entities.Pollen.Response.PollenTypeInfo.DisplayName.set -> void
+GoogleMapsApi.Entities.Pollen.Response.PollenTypeInfo.HealthRecommendations.get -> System.Collections.Generic.List<string!>?
+GoogleMapsApi.Entities.Pollen.Response.PollenTypeInfo.HealthRecommendations.set -> void
+GoogleMapsApi.Entities.Pollen.Response.PollenTypeInfo.InSeason.get -> bool?
+GoogleMapsApi.Entities.Pollen.Response.PollenTypeInfo.InSeason.set -> void
+GoogleMapsApi.Entities.Pollen.Response.PollenTypeInfo.IndexInfo.get -> GoogleMapsApi.Entities.Pollen.Response.IndexInfo?
+GoogleMapsApi.Entities.Pollen.Response.PollenTypeInfo.IndexInfo.set -> void
+GoogleMapsApi.Entities.Pollen.Response.PollenTypeInfo.PollenTypeInfo() -> void
+GoogleMapsApi.GoogleMapsClient.PollenForecast.get -> GoogleMapsApi.IEngineFacade<GoogleMapsApi.Entities.Pollen.Request.PollenForecastRequest!, GoogleMapsApi.Entities.Pollen.Response.PollenForecastResponse!>!
+GoogleMapsApi.GoogleMapsClient.PollenHeatmapTile.get -> GoogleMapsApi.IEngineFacade<GoogleMapsApi.Entities.Pollen.Request.PollenHeatmapTileRequest!, GoogleMapsApi.Entities.Pollen.Response.PollenHeatmapTileResponse!>!
+GoogleMapsApi.IGoogleMapsClient.PollenForecast.get -> GoogleMapsApi.IEngineFacade<GoogleMapsApi.Entities.Pollen.Request.PollenForecastRequest!, GoogleMapsApi.Entities.Pollen.Response.PollenForecastResponse!>!
+GoogleMapsApi.IGoogleMapsClient.PollenHeatmapTile.get -> GoogleMapsApi.IEngineFacade<GoogleMapsApi.Entities.Pollen.Request.PollenHeatmapTileRequest!, GoogleMapsApi.Entities.Pollen.Response.PollenHeatmapTileResponse!>!
+override GoogleMapsApi.Entities.Pollen.Request.PollenForecastRequest.GetUri() -> System.Uri!
+override GoogleMapsApi.Entities.Pollen.Request.PollenHeatmapTileRequest.GetUri() -> System.Uri!

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Release history: see [CHANGELOG.md](CHANGELOG.md).
 
 # GoogleMapsApi
 
-A friendly, strongly-typed .NET wrapper for the Google Maps Web Services APIs — Geocoding, Routes, Directions, Distance Matrix, Elevation, Time Zone, Places, Address Validation, Solar, Aerial View, Air Quality, and Static Maps. Multi-framework (net10.0, net8.0, netstandard2.0 — the latter still covers .NET Framework 4.6.1+), async-first, and battle-tested with **2M+ downloads** on NuGet.
+A friendly, strongly-typed .NET wrapper for the Google Maps Web Services APIs — Geocoding, Routes, Directions, Distance Matrix, Elevation, Time Zone, Places, Address Validation, Solar, Aerial View, Air Quality, Pollen, and Static Maps. Multi-framework (net10.0, net8.0, netstandard2.0 — the latter still covers .NET Framework 4.6.1+), async-first, and battle-tested with **2M+ downloads** on NuGet.
 
 ## Supported APIs
 
@@ -30,6 +30,7 @@ A friendly, strongly-typed .NET wrapper for the Google Maps Web Services APIs �
 | [Solar](https://developers.google.com/maps/documentation/solar) | Building solar potential, roof geometry, panel layouts, financial analyses, and raster data layers (billable) |
 | [Aerial View](https://developers.google.com/maps/documentation/aerial-view) | Render and look up cinematic flyover videos for US addresses |
 | [Air Quality](https://developers.google.com/maps/documentation/air-quality) | Current conditions, hourly forecast and history, plus heatmap tiles, for a coordinate (billable) |
+| [Pollen](https://developers.google.com/maps/documentation/pollen) | Up to 5 days of daily pollen forecast (types and plants) plus heatmap tiles, for a coordinate (billable) |
 | [Static Maps](https://developers.google.com/maps/documentation/maps-static) | Generate URLs for static map images with markers, paths, and styles |
 
 ## Why this vs Google's official packages
@@ -276,6 +277,38 @@ var tile = await maps.AirQualityHeatmapTile.QueryAsync(new HeatmapTileRequest
     Y = 6,
 });
 await File.WriteAllBytesAsync("aqi-tile.png", tile.Content);
+```
+
+### Pollen API (daily forecast + heatmap tiles)
+
+The [Pollen API](https://developers.google.com/maps/documentation/pollen) returns up to five days of daily pollen information — index values, in-season flags and descriptions for pollen types (grass, tree, weed) and individual plants — plus PNG heatmap tiles. It is a **billable** API, so calls beyond the free tier incur charges.
+
+``` C#
+using GoogleMapsApi;
+using GoogleMapsApi.Entities.Pollen.Request;
+
+using var http = new HttpClient();
+var maps = new GoogleMapsClient(http, new GoogleMapsClientOptions { ApiKey = "your-google-maps-api-key" });
+
+// Five-day pollen forecast.
+var forecast = await maps.PollenForecast.QueryAsync(new PollenForecastRequest
+{
+    Latitude = 40.4168,
+    Longitude = -3.7038,
+    Days = 5,
+});
+foreach (var type in forecast.DailyInfo![0].PollenTypeInfo!)
+    Console.WriteLine($"{type.DisplayName}: {type.IndexInfo?.Category}");
+
+// A pollen heatmap tile as raw PNG bytes.
+var tile = await maps.PollenHeatmapTile.QueryAsync(new PollenHeatmapTileRequest
+{
+    MapType = PollenMapType.TreeUpi,
+    Zoom = 4,
+    X = 8,
+    Y = 6,
+});
+await File.WriteAllBytesAsync("pollen-tile.png", tile.Content);
 ```
 
 ### Instance-based client (`IHttpClientFactory`-friendly)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Release history: see [CHANGELOG.md](CHANGELOG.md).
 
 # GoogleMapsApi
 
-A friendly, strongly-typed .NET wrapper for the Google Maps Web Services APIs — Geocoding, Routes, Directions, Distance Matrix, Elevation, Time Zone, Places, Address Validation, Solar, Aerial View, and Static Maps. Multi-framework (net10.0, net8.0, netstandard2.0 — the latter still covers .NET Framework 4.6.1+), async-first, and battle-tested with **2M+ downloads** on NuGet.
+A friendly, strongly-typed .NET wrapper for the Google Maps Web Services APIs — Geocoding, Routes, Directions, Distance Matrix, Elevation, Time Zone, Places, Address Validation, Solar, Aerial View, Air Quality, and Static Maps. Multi-framework (net10.0, net8.0, netstandard2.0 — the latter still covers .NET Framework 4.6.1+), async-first, and battle-tested with **2M+ downloads** on NuGet.
 
 ## Supported APIs
 
@@ -29,6 +29,7 @@ A friendly, strongly-typed .NET wrapper for the Google Maps Web Services APIs �
 | [Address Validation](https://developers.google.com/maps/documentation/address-validation) | Validate a postal address with component-level confirmation; USPS CASS for US/PR |
 | [Solar](https://developers.google.com/maps/documentation/solar) | Building solar potential, roof geometry, panel layouts, financial analyses, and raster data layers (billable) |
 | [Aerial View](https://developers.google.com/maps/documentation/aerial-view) | Render and look up cinematic flyover videos for US addresses |
+| [Air Quality](https://developers.google.com/maps/documentation/air-quality) | Current conditions, hourly forecast and history, plus heatmap tiles, for a coordinate (billable) |
 | [Static Maps](https://developers.google.com/maps/documentation/maps-static) | Generate URLs for static map images with markers, paths, and styles |
 
 ## Why this vs Google's official packages
@@ -239,6 +240,43 @@ if (video.State == VideoState.Active && video.TryGetUris(MediaFormat.Mp4High, ou
 ```
 
 > A looked-up video that does not exist (or has no 3D imagery available) returns HTTP 404, surfaced as an `HttpRequestException`. A still-rendering video is **not** an error — it returns `State == VideoState.Processing`.
+
+### Air Quality API (current conditions, forecast, history, heatmap tiles)
+
+The [Air Quality API](https://developers.google.com/maps/documentation/air-quality) reports air-quality indexes, pollutant concentrations and health recommendations for a coordinate — as current conditions, an hourly forecast, or hourly history — plus PNG heatmap tiles. Opt into the richer fields with `ExtraComputations`. It is a **billable** API, so calls beyond the free tier incur charges.
+
+``` C#
+using GoogleMapsApi;
+using GoogleMapsApi.Entities.AirQuality.Request;
+
+using var http = new HttpClient();
+var maps = new GoogleMapsClient(http, new GoogleMapsClientOptions { ApiKey = "your-google-maps-api-key" });
+
+// Current conditions, with health advice and pollutant concentrations.
+var current = await maps.AirQualityCurrentConditions.QueryAsync(new CurrentConditionsRequest
+{
+    Latitude = 37.4220,
+    Longitude = -122.0841,
+    ExtraComputations = new() { ExtraComputation.HealthRecommendations, ExtraComputation.PollutantConcentration },
+});
+Console.WriteLine($"{current.Indexes![0].DisplayName}: {current.Indexes[0].Aqi} ({current.Indexes[0].Category})");
+
+// Hourly forecast (paged), and a heatmap tile as raw PNG bytes.
+var forecast = await maps.AirQualityForecast.QueryAsync(new ForecastRequest
+{
+    Latitude = 37.4220,
+    Longitude = -122.0841,
+    PageSize = 6,
+});
+var tile = await maps.AirQualityHeatmapTile.QueryAsync(new HeatmapTileRequest
+{
+    MapType = AirQualityMapType.UsAqi,
+    Zoom = 4,
+    X = 4,
+    Y = 6,
+});
+await File.WriteAllBytesAsync("aqi-tile.png", tile.Content);
+```
 
 ### Instance-based client (`IHttpClientFactory`-friendly)
 


### PR DESCRIPTION
Expose the Google Air Quality API on GoogleMapsClient/IGoogleMapsClient:
- AirQualityCurrentConditions  (POST currentConditions:lookup)
- AirQualityForecast           (POST forecast:lookup, hourly, paged)
- AirQualityHistory            (POST history:lookup, hourly, paged)
- AirQualityHeatmapTile        (GET heatmap PNG map tiles, binary)

Adds request/response entities, hermetic unit tests, and live
[BillableTest] integration tests. DI registration and OpenTelemetry
tracing pick up the new endpoints automatically.

