### PR TITLE
feat: add Pollen API (daily forecast + heatmap tiles)

### DIFF
--- a/GoogleMapsApi.Test/IntegrationTests/PollenTests.cs
+++ b/GoogleMapsApi.Test/IntegrationTests/PollenTests.cs
@@ -1,0 +1,52 @@
+using System.Threading.Tasks;
+using GoogleMapsApi.Entities.Pollen.Request;
+using GoogleMapsApi.Test.Utils;
+using NUnit.Framework;
+
+namespace GoogleMapsApi.Test.IntegrationTests
+{
+    /// <summary>
+    /// Live Pollen API tests. The Pollen API is billable, so in live modes these are skipped unless
+    /// <c>RUN_BILLABLE_TESTS=true</c> (with a key that has the Pollen API enabled). Under the default
+    /// <c>VCR_MODE=replay</c> they serve committed cassettes — free and offline.
+    /// </summary>
+    [TestFixture]
+    [BillableTest]
+    public class PollenTests : BaseTestIntegration
+    {
+        // Madrid, Spain — reliably has pollen forecast coverage.
+        private const double Latitude = 40.4168;
+        private const double Longitude = -3.7038;
+
+        [Test]
+        public async Task Forecast_ValidLocation_ReturnsDailyInfo()
+        {
+            var response = await Maps.PollenForecast.QueryAsync(new PollenForecastRequest
+            {
+                ApiKey = ApiKey,
+                Latitude = Latitude,
+                Longitude = Longitude,
+                Days = 3,
+            });
+
+            Assert.That(response.RegionCode, Is.Not.Null.And.Not.Empty);
+            Assert.That(response.DailyInfo, Is.Not.Null.And.Not.Empty);
+            Assert.That(response.DailyInfo![0].Date, Is.Not.Null);
+        }
+
+        [Test]
+        public async Task HeatmapTile_ValidTile_DownloadsPngBytes()
+        {
+            var response = await Maps.PollenHeatmapTile.QueryAsync(new PollenHeatmapTileRequest
+            {
+                ApiKey = ApiKey,
+                MapType = PollenMapType.TreeUpi,
+                Zoom = 4,
+                X = 8,
+                Y = 6,
+            });
+
+            Assert.That(response.Content, Is.Not.Null.And.Not.Empty);
+        }
+    }
+}

--- a/GoogleMapsApi.Test/PollenUnitTests.cs
+++ b/GoogleMapsApi.Test/PollenUnitTests.cs
@@ -1,0 +1,215 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using GoogleMapsApi.Entities.Pollen.Request;
+using NUnit.Framework;
+
+namespace GoogleMapsApi.Test
+{
+    /// <summary>
+    /// Hermetic tests for the Pollen API request/response plumbing. No live network calls — URLs are
+    /// asserted off <c>GetUri()</c> and canned JSON is fed back through a stub handler.
+    /// </summary>
+    [TestFixture]
+    public class PollenUnitTests
+    {
+        private const double Latitude = 37.4;
+        private const double Longitude = -122.1;
+
+        // --- URL generation ---------------------------------------------------------------
+
+        [Test]
+        public void Forecast_GetUri_BuildsExpectedUrl()
+        {
+            var uri = new PollenForecastRequest
+            {
+                ApiKey = "k",
+                Latitude = Latitude,
+                Longitude = Longitude,
+                Days = 3,
+            }.GetUri();
+
+            Assert.That(uri.Scheme, Is.EqualTo("https"));
+            Assert.That(uri.Host, Is.EqualTo("pollen.googleapis.com"));
+            Assert.That(uri.AbsolutePath, Is.EqualTo("/v1/forecast:lookup"));
+            Assert.That(uri.Query, Does.Contain("location.latitude=37.4"));
+            Assert.That(uri.Query, Does.Contain("location.longitude=-122.1"));
+            Assert.That(uri.Query, Does.Contain("days=3"));
+            Assert.That(uri.Query, Does.Contain("key=k"));
+        }
+
+        [Test]
+        public void Forecast_GetUri_AppendsOptionalParameters()
+        {
+            var uri = new PollenForecastRequest
+            {
+                ApiKey = "k",
+                Latitude = Latitude,
+                Longitude = Longitude,
+                Days = 5,
+                PageSize = 2,
+                PageToken = "tok",
+                LanguageCode = "fr",
+                PlantsDescription = false,
+            }.GetUri();
+
+            Assert.That(uri.Query, Does.Contain("pageSize=2"));
+            Assert.That(uri.Query, Does.Contain("pageToken=tok"));
+            Assert.That(uri.Query, Does.Contain("languageCode=fr"));
+            Assert.That(uri.Query, Does.Contain("plantsDescription=false"));
+        }
+
+        [Test]
+        public void Forecast_GetUri_OmitsOptionalParameters_WhenUnset()
+        {
+            var uri = new PollenForecastRequest { ApiKey = "k", Latitude = Latitude, Longitude = Longitude, Days = 1 }.GetUri();
+
+            Assert.That(uri.Query, Does.Not.Contain("pageSize"));
+            Assert.That(uri.Query, Does.Not.Contain("pageToken"));
+            Assert.That(uri.Query, Does.Not.Contain("languageCode"));
+            Assert.That(uri.Query, Does.Not.Contain("plantsDescription"));
+        }
+
+        [Test]
+        public void HeatmapTile_GetUri_BuildsTilePathWithMapType()
+        {
+            var uri = new PollenHeatmapTileRequest
+            {
+                ApiKey = "k",
+                MapType = PollenMapType.GrassUpi,
+                Zoom = 5,
+                X = 9,
+                Y = 12,
+            }.GetUri();
+
+            Assert.That(uri.Host, Is.EqualTo("pollen.googleapis.com"));
+            Assert.That(uri.AbsolutePath, Is.EqualTo("/v1/mapTypes/GRASS_UPI/heatmapTiles/5/9/12"));
+            Assert.That(uri.Query, Does.Contain("key=k"));
+        }
+
+        // --- Guard clauses ----------------------------------------------------------------
+
+        [Test]
+        public void Forecast_GetUri_MissingApiKey_Throws()
+        {
+            Assert.Throws<InvalidOperationException>(
+                () => new PollenForecastRequest { Latitude = Latitude, Longitude = Longitude, Days = 1 }.GetUri());
+        }
+
+        [Test]
+        public void Forecast_GetUri_NonSsl_Throws()
+        {
+            Assert.Throws<ArgumentException>(
+                () => new PollenForecastRequest { ApiKey = "k", IsSSL = false, Latitude = Latitude, Longitude = Longitude, Days = 1 }.GetUri());
+        }
+
+        [Test]
+        public void Forecast_GetUri_DaysOutOfRange_Throws([Values(0, 6)] int days)
+        {
+            Assert.Throws<ArgumentException>(
+                () => new PollenForecastRequest { ApiKey = "k", Latitude = Latitude, Longitude = Longitude, Days = days }.GetUri());
+        }
+
+        [Test]
+        public void HeatmapTile_GetUri_ZoomOutOfRange_Throws()
+        {
+            Assert.Throws<ArgumentException>(
+                () => new PollenHeatmapTileRequest { ApiKey = "k", MapType = PollenMapType.TreeUpi, Zoom = 17, X = 1, Y = 1 }.GetUri());
+        }
+
+        // --- JSON deserialization ---------------------------------------------------------
+
+        [Test]
+        public async Task Forecast_QueryAsync_DeserializesNestedFields()
+        {
+            const string json = """
+            {
+              "regionCode": "US",
+              "dailyInfo": [
+                {
+                  "date": { "year": 2024, "month": 4, "day": 1 },
+                  "pollenTypeInfo": [
+                    { "code": "TREE", "displayName": "Tree", "inSeason": true,
+                      "indexInfo": { "code": "UPI", "displayName": "Universal Pollen Index", "value": 3,
+                                     "category": "Moderate", "color": { "red": 1.0, "green": 0.8 } },
+                      "healthRecommendations": [ "Keep windows closed." ] }
+                  ],
+                  "plantInfo": [
+                    { "code": "BIRCH", "displayName": "Birch", "inSeason": true,
+                      "indexInfo": { "code": "UPI", "value": 4, "category": "High" },
+                      "plantDescription": { "type": "TREE", "family": "Betulaceae", "season": "Spring",
+                                            "picture": "https://example/birch.png" } }
+                  ]
+                }
+              ],
+              "nextPageToken": "next"
+            }
+            """;
+            using var handler = new StubHandler(Encoding.UTF8.GetBytes(json), "application/json");
+            using var http = new HttpClient(handler);
+            var client = new GoogleMapsClient(http, new GoogleMapsClientOptions { ApiKey = "k" });
+
+            var response = await client.PollenForecast.QueryAsync(
+                new PollenForecastRequest { Latitude = Latitude, Longitude = Longitude, Days = 1 });
+
+            Assert.That(response.RegionCode, Is.EqualTo("US"));
+            Assert.That(response.DailyInfo, Is.Not.Null.And.Count.EqualTo(1));
+
+            var day = response.DailyInfo![0];
+            Assert.That(day.Date!.Year, Is.EqualTo(2024));
+            Assert.That(day.PollenTypeInfo![0].Code, Is.EqualTo("TREE"));
+            Assert.That(day.PollenTypeInfo[0].IndexInfo!.Value, Is.EqualTo(3));
+            Assert.That(day.PollenTypeInfo[0].IndexInfo!.Color!.Red, Is.EqualTo(1.0f));
+            Assert.That(day.PollenTypeInfo[0].HealthRecommendations![0], Is.EqualTo("Keep windows closed."));
+            Assert.That(day.PlantInfo![0].Code, Is.EqualTo("BIRCH"));
+            Assert.That(day.PlantInfo[0].PlantDescription!.Family, Is.EqualTo("Betulaceae"));
+            Assert.That(response.NextPageToken, Is.EqualTo("next"));
+        }
+
+        // --- Binary engine path -----------------------------------------------------------
+
+        [Test]
+        public async Task HeatmapTile_QueryAsync_ReturnsRawBytesAndContentType()
+        {
+            var payload = new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A };
+            using var handler = new StubHandler(payload, "image/png");
+            using var http = new HttpClient(handler);
+            var client = new GoogleMapsClient(http, new GoogleMapsClientOptions { ApiKey = "k" });
+
+            var response = await client.PollenHeatmapTile.QueryAsync(new PollenHeatmapTileRequest
+            {
+                MapType = PollenMapType.WeedUpi,
+                Zoom = 4,
+                X = 1,
+                Y = 2,
+            });
+
+            Assert.That(response.Content, Is.EqualTo(payload));
+            Assert.That(response.ContentType, Is.EqualTo("image/png"));
+        }
+
+        private sealed class StubHandler : HttpMessageHandler
+        {
+            private readonly byte[] _body;
+            private readonly string _mediaType;
+
+            public StubHandler(byte[] body, string mediaType)
+            {
+                _body = body;
+                _mediaType = mediaType;
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var content = new ByteArrayContent(_body);
+                content.Headers.ContentType = new MediaTypeHeaderValue(_mediaType);
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = content });
+            }
+        }
+    }
+}

--- a/GoogleMapsApi/Entities/Pollen/Request/PollenForecastRequest.cs
+++ b/GoogleMapsApi/Entities/Pollen/Request/PollenForecastRequest.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Globalization;
+using GoogleMapsApi.Engine;
+using GoogleMapsApi.Entities.Common;
+
+namespace GoogleMapsApi.Entities.Pollen.Request
+{
+    /// <summary>
+    /// Request for the Google Pollen API <c>forecast:lookup</c> endpoint
+    /// (<c>GET https://pollen.googleapis.com/v1/forecast:lookup</c>). Returns up to five days of daily
+    /// pollen information (types and plants) for a coordinate.
+    /// </summary>
+    /// <remarks>The Pollen API is billable; calls beyond the free tier incur charges.</remarks>
+    public sealed class PollenForecastRequest : MapsBaseRequest
+    {
+        /// <summary>Latitude of the query point, in degrees. Required.</summary>
+        public double Latitude { get; set; }
+
+        /// <summary>Longitude of the query point, in degrees. Required.</summary>
+        public double Longitude { get; set; }
+
+        /// <summary>Number of forecast days to return, in the range [1, 5]. Required.</summary>
+        public int Days { get; set; }
+
+        /// <summary>Maximum number of daily records per page. Defaults to the number of days when unset.</summary>
+        public int? PageSize { get; set; }
+
+        /// <summary>Page token from a previous response's <c>NextPageToken</c> to fetch the next page.</summary>
+        public string? PageToken { get; set; }
+
+        /// <summary>IETF BCP-47 language code for textual fields in the response (e.g. <c>"en"</c>).</summary>
+        public string? LanguageCode { get; set; }
+
+        /// <summary>
+        /// Whether to include the detailed <c>PlantDescription</c> for each plant. Defaults to true
+        /// server-side when unset; set false to reduce the response size.
+        /// </summary>
+        public bool? PlantsDescription { get; set; }
+
+        /// <inheritdoc/>
+        public override Uri GetUri()
+        {
+            if (string.IsNullOrWhiteSpace(ApiKey))
+                throw new InvalidOperationException("ApiKey is required for the Pollen API.");
+            if (!IsSSL)
+                throw new ArgumentException("Pollen API requires SSL [IsSSL = true].");
+            if (Days < 1 || Days > 5)
+                throw new ArgumentException("Days must be in the range [1, 5].", nameof(Days));
+
+            var url =
+                "https://pollen.googleapis.com/v1/forecast:lookup" +
+                $"?location.latitude={CoordinateFormatter.Format(Latitude)}" +
+                $"&location.longitude={CoordinateFormatter.Format(Longitude)}" +
+                $"&days={Days.ToString(CultureInfo.InvariantCulture)}" +
+                $"&key={Uri.EscapeDataString(ApiKey!)}";
+
+            if (PageSize.HasValue)
+                url += $"&pageSize={PageSize.Value.ToString(CultureInfo.InvariantCulture)}";
+            if (!string.IsNullOrWhiteSpace(PageToken))
+                url += $"&pageToken={Uri.EscapeDataString(PageToken!)}";
+            if (!string.IsNullOrWhiteSpace(LanguageCode))
+                url += $"&languageCode={Uri.EscapeDataString(LanguageCode!)}";
+            if (PlantsDescription.HasValue)
+                url += $"&plantsDescription={(PlantsDescription.Value ? "true" : "false")}";
+
+            return new Uri(url);
+        }
+    }
+}

--- a/GoogleMapsApi/Entities/Pollen/Request/PollenHeatmapTileRequest.cs
+++ b/GoogleMapsApi/Entities/Pollen/Request/PollenHeatmapTileRequest.cs
@@ -1,0 +1,48 @@
+using System;
+using GoogleMapsApi.Engine;
+using GoogleMapsApi.Entities.Common;
+
+namespace GoogleMapsApi.Entities.Pollen.Request
+{
+    /// <summary>
+    /// Request for the Pollen API heatmap-tile endpoint
+    /// (<c>GET https://pollen.googleapis.com/v1/mapTypes/{mapType}/heatmapTiles/{zoom}/{x}/{y}</c>).
+    /// Downloads a single PNG map tile for the chosen pollen index. The response is binary, not JSON.
+    /// </summary>
+    /// <remarks>
+    /// Tile coordinates follow the standard Web Mercator scheme: <see cref="X"/> and <see cref="Y"/> are
+    /// in the range <c>[0, 2^zoom)</c>. The Pollen API is billable; calls beyond the free tier incur charges.
+    /// </remarks>
+    public sealed class PollenHeatmapTileRequest : MapsBaseRequest
+    {
+        /// <summary>Which pollen index the tile renders. Required.</summary>
+        public PollenMapType MapType { get; set; }
+
+        /// <summary>Zoom level, in the range [0, 16]; 0 is the whole world in one tile.</summary>
+        public int Zoom { get; set; }
+
+        /// <summary>The tile's east-west index, in the range [0, 2^zoom).</summary>
+        public int X { get; set; }
+
+        /// <summary>The tile's north-south index, in the range [0, 2^zoom).</summary>
+        public int Y { get; set; }
+
+        /// <inheritdoc/>
+        public override Uri GetUri()
+        {
+            if (string.IsNullOrWhiteSpace(ApiKey))
+                throw new InvalidOperationException("ApiKey is required for the Pollen API.");
+            if (!IsSSL)
+                throw new ArgumentException("Pollen API requires SSL [IsSSL = true].");
+            if (Zoom < 0 || Zoom > 16)
+                throw new ArgumentException("Zoom must be in the range [0, 16].", nameof(Zoom));
+            if (X < 0 || Y < 0)
+                throw new ArgumentException("Tile coordinates X and Y must be non-negative.");
+
+            return new Uri(
+                "https://pollen.googleapis.com/v1/mapTypes/" +
+                $"{EnumMemberHelper.GetValue(MapType)}/heatmapTiles/{Zoom}/{X}/{Y}" +
+                $"?key={Uri.EscapeDataString(ApiKey!)}");
+        }
+    }
+}

--- a/GoogleMapsApi/Entities/Pollen/Request/PollenMapType.cs
+++ b/GoogleMapsApi/Entities/Pollen/Request/PollenMapType.cs
@@ -1,0 +1,23 @@
+using System.Runtime.Serialization;
+
+namespace GoogleMapsApi.Entities.Pollen.Request
+{
+    /// <summary>
+    /// The pollen heatmap type (which pollen the tile renders) for a
+    /// <see cref="PollenHeatmapTileRequest"/>. Each maps the Universal Pollen Index for one pollen type.
+    /// </summary>
+    public enum PollenMapType
+    {
+        /// <summary>No map type specified. Ignored by the server if sent.</summary>
+        [EnumMember(Value = "MAP_TYPE_UNSPECIFIED")] Unspecified,
+
+        /// <summary>Tree pollen, Universal Pollen Index.</summary>
+        [EnumMember(Value = "TREE_UPI")] TreeUpi,
+
+        /// <summary>Grass pollen, Universal Pollen Index.</summary>
+        [EnumMember(Value = "GRASS_UPI")] GrassUpi,
+
+        /// <summary>Weed pollen, Universal Pollen Index.</summary>
+        [EnumMember(Value = "WEED_UPI")] WeedUpi,
+    }
+}

--- a/GoogleMapsApi/Entities/Pollen/Response/Color.cs
+++ b/GoogleMapsApi/Entities/Pollen/Response/Color.cs
@@ -1,0 +1,24 @@
+using System.Text.Json.Serialization;
+
+namespace GoogleMapsApi.Entities.Pollen.Response
+{
+    /// <summary>An RGBA colour with components in the range [0, 1] (mirrors <c>google.type.Color</c>).</summary>
+    public sealed class Color
+    {
+        /// <summary>Red component, in the range [0, 1].</summary>
+        [JsonPropertyName("red")]
+        public float? Red { get; set; }
+
+        /// <summary>Green component, in the range [0, 1].</summary>
+        [JsonPropertyName("green")]
+        public float? Green { get; set; }
+
+        /// <summary>Blue component, in the range [0, 1].</summary>
+        [JsonPropertyName("blue")]
+        public float? Blue { get; set; }
+
+        /// <summary>Alpha (opacity), in the range [0, 1]. Often omitted, meaning fully opaque.</summary>
+        [JsonPropertyName("alpha")]
+        public float? Alpha { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/Pollen/Response/Date.cs
+++ b/GoogleMapsApi/Entities/Pollen/Response/Date.cs
@@ -1,0 +1,20 @@
+using System.Text.Json.Serialization;
+
+namespace GoogleMapsApi.Entities.Pollen.Response
+{
+    /// <summary>A calendar date with no time zone (mirrors <c>google.type.Date</c>).</summary>
+    public sealed class Date
+    {
+        /// <summary>Year of the date.</summary>
+        [JsonPropertyName("year")]
+        public int Year { get; set; }
+
+        /// <summary>Month of the date, 1-12.</summary>
+        [JsonPropertyName("month")]
+        public int Month { get; set; }
+
+        /// <summary>Day of the month, 1-31.</summary>
+        [JsonPropertyName("day")]
+        public int Day { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/Pollen/Response/DayInfo.cs
+++ b/GoogleMapsApi/Entities/Pollen/Response/DayInfo.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace GoogleMapsApi.Entities.Pollen.Response
+{
+    /// <summary>Pollen forecast for a single day.</summary>
+    public sealed class DayInfo
+    {
+        /// <summary>The date this forecast applies to.</summary>
+        [JsonPropertyName("date")]
+        public Date? Date { get; set; }
+
+        /// <summary>Per-pollen-type information (up to three: grass, tree, weed).</summary>
+        [JsonPropertyName("pollenTypeInfo")]
+        public List<PollenTypeInfo>? PollenTypeInfo { get; set; }
+
+        /// <summary>Per-plant information (up to fifteen species).</summary>
+        [JsonPropertyName("plantInfo")]
+        public List<PlantInfo>? PlantInfo { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/Pollen/Response/IndexInfo.cs
+++ b/GoogleMapsApi/Entities/Pollen/Response/IndexInfo.cs
@@ -1,0 +1,32 @@
+using System.Text.Json.Serialization;
+
+namespace GoogleMapsApi.Entities.Pollen.Response
+{
+    /// <summary>A pollen index value (the Universal Pollen Index) for a pollen type or plant.</summary>
+    public sealed class IndexInfo
+    {
+        /// <summary>The index's code (e.g. <c>"UPI"</c>).</summary>
+        [JsonPropertyName("code")]
+        public string? Code { get; set; }
+
+        /// <summary>Human-readable index name (e.g. <c>"Universal Pollen Index"</c>).</summary>
+        [JsonPropertyName("displayName")]
+        public string? DisplayName { get; set; }
+
+        /// <summary>The index value, on a 0-5 scale.</summary>
+        [JsonPropertyName("value")]
+        public int Value { get; set; }
+
+        /// <summary>Textual classification of the value (e.g. <c>"Low"</c>, <c>"High"</c>).</summary>
+        [JsonPropertyName("category")]
+        public string? Category { get; set; }
+
+        /// <summary>A human-readable explanation of the index value.</summary>
+        [JsonPropertyName("indexDescription")]
+        public string? IndexDescription { get; set; }
+
+        /// <summary>The colour associated with the value, for rendering.</summary>
+        [JsonPropertyName("color")]
+        public Color? Color { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/Pollen/Response/PlantDescription.cs
+++ b/GoogleMapsApi/Entities/Pollen/Response/PlantDescription.cs
@@ -1,0 +1,40 @@
+using System.Text.Json.Serialization;
+
+namespace GoogleMapsApi.Entities.Pollen.Response
+{
+    /// <summary>Descriptive information about a plant that produces pollen.</summary>
+    public sealed class PlantDescription
+    {
+        /// <summary>The pollen type this plant belongs to (<c>"GRASS"</c>, <c>"TREE"</c> or <c>"WEED"</c>).</summary>
+        [JsonPropertyName("type")]
+        public string? Type { get; set; }
+
+        /// <summary>The plant's botanical family (e.g. <c>"Betulaceae"</c>).</summary>
+        [JsonPropertyName("family")]
+        public string? Family { get; set; }
+
+        /// <summary>The seasons in which the plant typically pollinates.</summary>
+        [JsonPropertyName("season")]
+        public string? Season { get; set; }
+
+        /// <summary>Colours that help identify the plant.</summary>
+        [JsonPropertyName("specialColors")]
+        public string? SpecialColors { get; set; }
+
+        /// <summary>Shapes that help identify the plant.</summary>
+        [JsonPropertyName("specialShapes")]
+        public string? SpecialShapes { get; set; }
+
+        /// <summary>Information about cross-reaction with other allergens.</summary>
+        [JsonPropertyName("crossReaction")]
+        public string? CrossReaction { get; set; }
+
+        /// <summary>URL of a representative picture of the plant.</summary>
+        [JsonPropertyName("picture")]
+        public string? Picture { get; set; }
+
+        /// <summary>URL of a close-up picture of the plant.</summary>
+        [JsonPropertyName("pictureCloseup")]
+        public string? PictureCloseup { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/Pollen/Response/PlantInfo.cs
+++ b/GoogleMapsApi/Entities/Pollen/Response/PlantInfo.cs
@@ -1,0 +1,28 @@
+using System.Text.Json.Serialization;
+
+namespace GoogleMapsApi.Entities.Pollen.Response
+{
+    /// <summary>Pollen information for one specific plant species on a given day.</summary>
+    public sealed class PlantInfo
+    {
+        /// <summary>The plant's code (e.g. <c>"BIRCH"</c>, <c>"OAK"</c>, <c>"RAGWEED"</c>).</summary>
+        [JsonPropertyName("code")]
+        public string? Code { get; set; }
+
+        /// <summary>Human-readable plant name (e.g. <c>"Birch"</c>).</summary>
+        [JsonPropertyName("displayName")]
+        public string? DisplayName { get; set; }
+
+        /// <summary>Whether the plant is in season on this day.</summary>
+        [JsonPropertyName("inSeason")]
+        public bool? InSeason { get; set; }
+
+        /// <summary>The pollen index for this plant. Absent when no data is available.</summary>
+        [JsonPropertyName("indexInfo")]
+        public IndexInfo? IndexInfo { get; set; }
+
+        /// <summary>Descriptive detail about the plant. Absent when <c>PlantsDescription</c> was disabled.</summary>
+        [JsonPropertyName("plantDescription")]
+        public PlantDescription? PlantDescription { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/Pollen/Response/PollenForecastResponse.cs
+++ b/GoogleMapsApi/Entities/Pollen/Response/PollenForecastResponse.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using GoogleMapsApi.Entities.Common;
+using GoogleMapsApi.Entities.Pollen.Request;
+
+namespace GoogleMapsApi.Entities.Pollen.Response
+{
+    /// <summary>Response from the Pollen API <c>forecast:lookup</c> endpoint.</summary>
+    public sealed class PollenForecastResponse : IResponseFor<PollenForecastRequest>
+    {
+        /// <summary>Region code (ISO 3166-1 alpha-2) of the location.</summary>
+        [JsonPropertyName("regionCode")]
+        public string? RegionCode { get; set; }
+
+        /// <summary>The daily forecasts, one entry per requested day.</summary>
+        [JsonPropertyName("dailyInfo")]
+        public List<DayInfo>? DailyInfo { get; set; }
+
+        /// <summary>Token to pass as <c>PageToken</c> on a follow-up request to fetch the next page, if any.</summary>
+        [JsonPropertyName("nextPageToken")]
+        public string? NextPageToken { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/Pollen/Response/PollenHeatmapTileResponse.cs
+++ b/GoogleMapsApi/Entities/Pollen/Response/PollenHeatmapTileResponse.cs
@@ -1,0 +1,19 @@
+using System;
+using GoogleMapsApi.Entities.Common;
+using GoogleMapsApi.Entities.Pollen.Request;
+
+namespace GoogleMapsApi.Entities.Pollen.Response
+{
+    /// <summary>
+    /// Response from the Pollen API heatmap-tile endpoint — the raw PNG bytes of a map tile.
+    /// Being binary, this is populated directly by the engine rather than from JSON.
+    /// </summary>
+    public sealed class PollenHeatmapTileResponse : IResponseFor<PollenHeatmapTileRequest>, IBinaryResponse
+    {
+        /// <summary>The raw PNG bytes of the tile.</summary>
+        public byte[] Content { get; set; } = Array.Empty<byte>();
+
+        /// <summary>The response media type (typically <c>image/png</c>).</summary>
+        public string? ContentType { get; set; }
+    }
+}

--- a/GoogleMapsApi/Entities/Pollen/Response/PollenTypeInfo.cs
+++ b/GoogleMapsApi/Entities/Pollen/Response/PollenTypeInfo.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace GoogleMapsApi.Entities.Pollen.Response
+{
+    /// <summary>Pollen information for one pollen type (grass, tree or weed) on a given day.</summary>
+    public sealed class PollenTypeInfo
+    {
+        /// <summary>The pollen type code (<c>"GRASS"</c>, <c>"TREE"</c> or <c>"WEED"</c>).</summary>
+        [JsonPropertyName("code")]
+        public string? Code { get; set; }
+
+        /// <summary>Human-readable pollen type name (e.g. <c>"Grass"</c>).</summary>
+        [JsonPropertyName("displayName")]
+        public string? DisplayName { get; set; }
+
+        /// <summary>Whether the pollen type is in season on this day.</summary>
+        [JsonPropertyName("inSeason")]
+        public bool? InSeason { get; set; }
+
+        /// <summary>The pollen index for this type. Absent when no data is available.</summary>
+        [JsonPropertyName("indexInfo")]
+        public IndexInfo? IndexInfo { get; set; }
+
+        /// <summary>Health recommendations related to this pollen type.</summary>
+        [JsonPropertyName("healthRecommendations")]
+        public List<string>? HealthRecommendations { get; set; }
+    }
+}

--- a/GoogleMapsApi/GoogleMapsClient.cs
+++ b/GoogleMapsApi/GoogleMapsClient.cs
@@ -19,6 +19,8 @@ using GoogleMapsApi.Entities.Routes.Request;
 using GoogleMapsApi.Entities.Routes.Response;
 using GoogleMapsApi.Entities.PlacesNew.Request;
 using GoogleMapsApi.Entities.PlacesNew.Response;
+using GoogleMapsApi.Entities.Pollen.Request;
+using GoogleMapsApi.Entities.Pollen.Response;
 using GoogleMapsApi.Entities.Solar.Request;
 using GoogleMapsApi.Entities.Solar.Response;
 using GoogleMapsApi.Entities.TimeZone.Request;
@@ -76,6 +78,8 @@ namespace GoogleMapsApi
             AirQualityForecast = new HttpClientEngineFacade<ForecastRequest, ForecastResponse>(httpClient, options);
             AirQualityHistory = new HttpClientEngineFacade<HistoryRequest, HistoryResponse>(httpClient, options);
             AirQualityHeatmapTile = new HttpClientEngineFacade<HeatmapTileRequest, HeatmapTileResponse>(httpClient, options);
+            PollenForecast = new HttpClientEngineFacade<PollenForecastRequest, PollenForecastResponse>(httpClient, options);
+            PollenHeatmapTile = new HttpClientEngineFacade<PollenHeatmapTileRequest, PollenHeatmapTileResponse>(httpClient, options);
             AerialView = new AerialViewApi(httpClient, options);
         }
 
@@ -144,6 +148,12 @@ namespace GoogleMapsApi
 
         /// <inheritdoc/>
         public IEngineFacade<HeatmapTileRequest, HeatmapTileResponse> AirQualityHeatmapTile { get; }
+
+        /// <inheritdoc/>
+        public IEngineFacade<PollenForecastRequest, PollenForecastResponse> PollenForecast { get; }
+
+        /// <inheritdoc/>
+        public IEngineFacade<PollenHeatmapTileRequest, PollenHeatmapTileResponse> PollenHeatmapTile { get; }
 
         /// <inheritdoc/>
         public IAerialViewApi AerialView { get; }

--- a/GoogleMapsApi/IGoogleMapsClient.cs
+++ b/GoogleMapsApi/IGoogleMapsClient.cs
@@ -16,6 +16,8 @@ using GoogleMapsApi.Entities.Routes.Request;
 using GoogleMapsApi.Entities.Routes.Response;
 using GoogleMapsApi.Entities.PlacesNew.Request;
 using GoogleMapsApi.Entities.PlacesNew.Response;
+using GoogleMapsApi.Entities.Pollen.Request;
+using GoogleMapsApi.Entities.Pollen.Response;
 using GoogleMapsApi.Entities.Solar.Request;
 using GoogleMapsApi.Entities.Solar.Response;
 using GoogleMapsApi.Entities.TimeZone.Request;
@@ -101,6 +103,12 @@ namespace GoogleMapsApi
 
         /// <summary>Download an air-quality heatmap map tile as raw PNG bytes via the Air Quality API (billable).</summary>
         IEngineFacade<HeatmapTileRequest, HeatmapTileResponse> AirQualityHeatmapTile { get; }
+
+        /// <summary>Get a multi-day pollen forecast (types and plants) for a coordinate via the Pollen API (billable).</summary>
+        IEngineFacade<PollenForecastRequest, PollenForecastResponse> PollenForecast { get; }
+
+        /// <summary>Download a pollen heatmap map tile as raw PNG bytes via the Pollen API (billable).</summary>
+        IEngineFacade<PollenHeatmapTileRequest, PollenHeatmapTileResponse> PollenHeatmapTile { get; }
 
         /// <summary>Render and look up cinematic flyover videos via the Aerial View API.</summary>
         IAerialViewApi AerialView { get; }

--- a/GoogleMapsApi/PublicAPI.Unshipped.txt
+++ b/GoogleMapsApi/PublicAPI.Unshipped.txt
@@ -680,3 +680,136 @@ override GoogleMapsApi.Entities.AirQuality.Request.CurrentConditionsRequest.GetU
 override GoogleMapsApi.Entities.AirQuality.Request.ForecastRequest.GetUri() -> System.Uri!
 override GoogleMapsApi.Entities.AirQuality.Request.HeatmapTileRequest.GetUri() -> System.Uri!
 override GoogleMapsApi.Entities.AirQuality.Request.HistoryRequest.GetUri() -> System.Uri!
+GoogleMapsApi.Entities.Pollen.Request.PollenForecastRequest
+GoogleMapsApi.Entities.Pollen.Request.PollenForecastRequest.Days.get -> int
+GoogleMapsApi.Entities.Pollen.Request.PollenForecastRequest.Days.set -> void
+GoogleMapsApi.Entities.Pollen.Request.PollenForecastRequest.LanguageCode.get -> string?
+GoogleMapsApi.Entities.Pollen.Request.PollenForecastRequest.LanguageCode.set -> void
+GoogleMapsApi.Entities.Pollen.Request.PollenForecastRequest.Latitude.get -> double
+GoogleMapsApi.Entities.Pollen.Request.PollenForecastRequest.Latitude.set -> void
+GoogleMapsApi.Entities.Pollen.Request.PollenForecastRequest.Longitude.get -> double
+GoogleMapsApi.Entities.Pollen.Request.PollenForecastRequest.Longitude.set -> void
+GoogleMapsApi.Entities.Pollen.Request.PollenForecastRequest.PageSize.get -> int?
+GoogleMapsApi.Entities.Pollen.Request.PollenForecastRequest.PageSize.set -> void
+GoogleMapsApi.Entities.Pollen.Request.PollenForecastRequest.PageToken.get -> string?
+GoogleMapsApi.Entities.Pollen.Request.PollenForecastRequest.PageToken.set -> void
+GoogleMapsApi.Entities.Pollen.Request.PollenForecastRequest.PlantsDescription.get -> bool?
+GoogleMapsApi.Entities.Pollen.Request.PollenForecastRequest.PlantsDescription.set -> void
+GoogleMapsApi.Entities.Pollen.Request.PollenForecastRequest.PollenForecastRequest() -> void
+GoogleMapsApi.Entities.Pollen.Request.PollenHeatmapTileRequest
+GoogleMapsApi.Entities.Pollen.Request.PollenHeatmapTileRequest.MapType.get -> GoogleMapsApi.Entities.Pollen.Request.PollenMapType
+GoogleMapsApi.Entities.Pollen.Request.PollenHeatmapTileRequest.MapType.set -> void
+GoogleMapsApi.Entities.Pollen.Request.PollenHeatmapTileRequest.PollenHeatmapTileRequest() -> void
+GoogleMapsApi.Entities.Pollen.Request.PollenHeatmapTileRequest.X.get -> int
+GoogleMapsApi.Entities.Pollen.Request.PollenHeatmapTileRequest.X.set -> void
+GoogleMapsApi.Entities.Pollen.Request.PollenHeatmapTileRequest.Y.get -> int
+GoogleMapsApi.Entities.Pollen.Request.PollenHeatmapTileRequest.Y.set -> void
+GoogleMapsApi.Entities.Pollen.Request.PollenHeatmapTileRequest.Zoom.get -> int
+GoogleMapsApi.Entities.Pollen.Request.PollenHeatmapTileRequest.Zoom.set -> void
+GoogleMapsApi.Entities.Pollen.Request.PollenMapType
+GoogleMapsApi.Entities.Pollen.Request.PollenMapType.GrassUpi = 2 -> GoogleMapsApi.Entities.Pollen.Request.PollenMapType
+GoogleMapsApi.Entities.Pollen.Request.PollenMapType.TreeUpi = 1 -> GoogleMapsApi.Entities.Pollen.Request.PollenMapType
+GoogleMapsApi.Entities.Pollen.Request.PollenMapType.Unspecified = 0 -> GoogleMapsApi.Entities.Pollen.Request.PollenMapType
+GoogleMapsApi.Entities.Pollen.Request.PollenMapType.WeedUpi = 3 -> GoogleMapsApi.Entities.Pollen.Request.PollenMapType
+GoogleMapsApi.Entities.Pollen.Response.Color
+GoogleMapsApi.Entities.Pollen.Response.Color.Alpha.get -> float?
+GoogleMapsApi.Entities.Pollen.Response.Color.Alpha.set -> void
+GoogleMapsApi.Entities.Pollen.Response.Color.Blue.get -> float?
+GoogleMapsApi.Entities.Pollen.Response.Color.Blue.set -> void
+GoogleMapsApi.Entities.Pollen.Response.Color.Color() -> void
+GoogleMapsApi.Entities.Pollen.Response.Color.Green.get -> float?
+GoogleMapsApi.Entities.Pollen.Response.Color.Green.set -> void
+GoogleMapsApi.Entities.Pollen.Response.Color.Red.get -> float?
+GoogleMapsApi.Entities.Pollen.Response.Color.Red.set -> void
+GoogleMapsApi.Entities.Pollen.Response.Date
+GoogleMapsApi.Entities.Pollen.Response.Date.Date() -> void
+GoogleMapsApi.Entities.Pollen.Response.Date.Day.get -> int
+GoogleMapsApi.Entities.Pollen.Response.Date.Day.set -> void
+GoogleMapsApi.Entities.Pollen.Response.Date.Month.get -> int
+GoogleMapsApi.Entities.Pollen.Response.Date.Month.set -> void
+GoogleMapsApi.Entities.Pollen.Response.Date.Year.get -> int
+GoogleMapsApi.Entities.Pollen.Response.Date.Year.set -> void
+GoogleMapsApi.Entities.Pollen.Response.DayInfo
+GoogleMapsApi.Entities.Pollen.Response.DayInfo.Date.get -> GoogleMapsApi.Entities.Pollen.Response.Date?
+GoogleMapsApi.Entities.Pollen.Response.DayInfo.Date.set -> void
+GoogleMapsApi.Entities.Pollen.Response.DayInfo.DayInfo() -> void
+GoogleMapsApi.Entities.Pollen.Response.DayInfo.PlantInfo.get -> System.Collections.Generic.List<GoogleMapsApi.Entities.Pollen.Response.PlantInfo!>?
+GoogleMapsApi.Entities.Pollen.Response.DayInfo.PlantInfo.set -> void
+GoogleMapsApi.Entities.Pollen.Response.DayInfo.PollenTypeInfo.get -> System.Collections.Generic.List<GoogleMapsApi.Entities.Pollen.Response.PollenTypeInfo!>?
+GoogleMapsApi.Entities.Pollen.Response.DayInfo.PollenTypeInfo.set -> void
+GoogleMapsApi.Entities.Pollen.Response.IndexInfo
+GoogleMapsApi.Entities.Pollen.Response.IndexInfo.Category.get -> string?
+GoogleMapsApi.Entities.Pollen.Response.IndexInfo.Category.set -> void
+GoogleMapsApi.Entities.Pollen.Response.IndexInfo.Code.get -> string?
+GoogleMapsApi.Entities.Pollen.Response.IndexInfo.Code.set -> void
+GoogleMapsApi.Entities.Pollen.Response.IndexInfo.Color.get -> GoogleMapsApi.Entities.Pollen.Response.Color?
+GoogleMapsApi.Entities.Pollen.Response.IndexInfo.Color.set -> void
+GoogleMapsApi.Entities.Pollen.Response.IndexInfo.DisplayName.get -> string?
+GoogleMapsApi.Entities.Pollen.Response.IndexInfo.DisplayName.set -> void
+GoogleMapsApi.Entities.Pollen.Response.IndexInfo.IndexDescription.get -> string?
+GoogleMapsApi.Entities.Pollen.Response.IndexInfo.IndexDescription.set -> void
+GoogleMapsApi.Entities.Pollen.Response.IndexInfo.IndexInfo() -> void
+GoogleMapsApi.Entities.Pollen.Response.IndexInfo.Value.get -> int
+GoogleMapsApi.Entities.Pollen.Response.IndexInfo.Value.set -> void
+GoogleMapsApi.Entities.Pollen.Response.PlantDescription
+GoogleMapsApi.Entities.Pollen.Response.PlantDescription.CrossReaction.get -> string?
+GoogleMapsApi.Entities.Pollen.Response.PlantDescription.CrossReaction.set -> void
+GoogleMapsApi.Entities.Pollen.Response.PlantDescription.Family.get -> string?
+GoogleMapsApi.Entities.Pollen.Response.PlantDescription.Family.set -> void
+GoogleMapsApi.Entities.Pollen.Response.PlantDescription.Picture.get -> string?
+GoogleMapsApi.Entities.Pollen.Response.PlantDescription.Picture.set -> void
+GoogleMapsApi.Entities.Pollen.Response.PlantDescription.PictureCloseup.get -> string?
+GoogleMapsApi.Entities.Pollen.Response.PlantDescription.PictureCloseup.set -> void
+GoogleMapsApi.Entities.Pollen.Response.PlantDescription.PlantDescription() -> void
+GoogleMapsApi.Entities.Pollen.Response.PlantDescription.Season.get -> string?
+GoogleMapsApi.Entities.Pollen.Response.PlantDescription.Season.set -> void
+GoogleMapsApi.Entities.Pollen.Response.PlantDescription.SpecialColors.get -> string?
+GoogleMapsApi.Entities.Pollen.Response.PlantDescription.SpecialColors.set -> void
+GoogleMapsApi.Entities.Pollen.Response.PlantDescription.SpecialShapes.get -> string?
+GoogleMapsApi.Entities.Pollen.Response.PlantDescription.SpecialShapes.set -> void
+GoogleMapsApi.Entities.Pollen.Response.PlantDescription.Type.get -> string?
+GoogleMapsApi.Entities.Pollen.Response.PlantDescription.Type.set -> void
+GoogleMapsApi.Entities.Pollen.Response.PlantInfo
+GoogleMapsApi.Entities.Pollen.Response.PlantInfo.Code.get -> string?
+GoogleMapsApi.Entities.Pollen.Response.PlantInfo.Code.set -> void
+GoogleMapsApi.Entities.Pollen.Response.PlantInfo.DisplayName.get -> string?
+GoogleMapsApi.Entities.Pollen.Response.PlantInfo.DisplayName.set -> void
+GoogleMapsApi.Entities.Pollen.Response.PlantInfo.InSeason.get -> bool?
+GoogleMapsApi.Entities.Pollen.Response.PlantInfo.InSeason.set -> void
+GoogleMapsApi.Entities.Pollen.Response.PlantInfo.IndexInfo.get -> GoogleMapsApi.Entities.Pollen.Response.IndexInfo?
+GoogleMapsApi.Entities.Pollen.Response.PlantInfo.IndexInfo.set -> void
+GoogleMapsApi.Entities.Pollen.Response.PlantInfo.PlantDescription.get -> GoogleMapsApi.Entities.Pollen.Response.PlantDescription?
+GoogleMapsApi.Entities.Pollen.Response.PlantInfo.PlantDescription.set -> void
+GoogleMapsApi.Entities.Pollen.Response.PlantInfo.PlantInfo() -> void
+GoogleMapsApi.Entities.Pollen.Response.PollenForecastResponse
+GoogleMapsApi.Entities.Pollen.Response.PollenForecastResponse.DailyInfo.get -> System.Collections.Generic.List<GoogleMapsApi.Entities.Pollen.Response.DayInfo!>?
+GoogleMapsApi.Entities.Pollen.Response.PollenForecastResponse.DailyInfo.set -> void
+GoogleMapsApi.Entities.Pollen.Response.PollenForecastResponse.NextPageToken.get -> string?
+GoogleMapsApi.Entities.Pollen.Response.PollenForecastResponse.NextPageToken.set -> void
+GoogleMapsApi.Entities.Pollen.Response.PollenForecastResponse.PollenForecastResponse() -> void
+GoogleMapsApi.Entities.Pollen.Response.PollenForecastResponse.RegionCode.get -> string?
+GoogleMapsApi.Entities.Pollen.Response.PollenForecastResponse.RegionCode.set -> void
+GoogleMapsApi.Entities.Pollen.Response.PollenHeatmapTileResponse
+GoogleMapsApi.Entities.Pollen.Response.PollenHeatmapTileResponse.Content.get -> byte[]!
+GoogleMapsApi.Entities.Pollen.Response.PollenHeatmapTileResponse.Content.set -> void
+GoogleMapsApi.Entities.Pollen.Response.PollenHeatmapTileResponse.ContentType.get -> string?
+GoogleMapsApi.Entities.Pollen.Response.PollenHeatmapTileResponse.ContentType.set -> void
+GoogleMapsApi.Entities.Pollen.Response.PollenHeatmapTileResponse.PollenHeatmapTileResponse() -> void
+GoogleMapsApi.Entities.Pollen.Response.PollenTypeInfo
+GoogleMapsApi.Entities.Pollen.Response.PollenTypeInfo.Code.get -> string?
+GoogleMapsApi.Entities.Pollen.Response.PollenTypeInfo.Code.set -> void
+GoogleMapsApi.Entities.Pollen.Response.PollenTypeInfo.DisplayName.get -> string?
+GoogleMapsApi.Entities.Pollen.Response.PollenTypeInfo.DisplayName.set -> void
+GoogleMapsApi.Entities.Pollen.Response.PollenTypeInfo.HealthRecommendations.get -> System.Collections.Generic.List<string!>?
+GoogleMapsApi.Entities.Pollen.Response.PollenTypeInfo.HealthRecommendations.set -> void
+GoogleMapsApi.Entities.Pollen.Response.PollenTypeInfo.InSeason.get -> bool?
+GoogleMapsApi.Entities.Pollen.Response.PollenTypeInfo.InSeason.set -> void
+GoogleMapsApi.Entities.Pollen.Response.PollenTypeInfo.IndexInfo.get -> GoogleMapsApi.Entities.Pollen.Response.IndexInfo?
+GoogleMapsApi.Entities.Pollen.Response.PollenTypeInfo.IndexInfo.set -> void
+GoogleMapsApi.Entities.Pollen.Response.PollenTypeInfo.PollenTypeInfo() -> void
+GoogleMapsApi.GoogleMapsClient.PollenForecast.get -> GoogleMapsApi.IEngineFacade<GoogleMapsApi.Entities.Pollen.Request.PollenForecastRequest!, GoogleMapsApi.Entities.Pollen.Response.PollenForecastResponse!>!
+GoogleMapsApi.GoogleMapsClient.PollenHeatmapTile.get -> GoogleMapsApi.IEngineFacade<GoogleMapsApi.Entities.Pollen.Request.PollenHeatmapTileRequest!, GoogleMapsApi.Entities.Pollen.Response.PollenHeatmapTileResponse!>!
+GoogleMapsApi.IGoogleMapsClient.PollenForecast.get -> GoogleMapsApi.IEngineFacade<GoogleMapsApi.Entities.Pollen.Request.PollenForecastRequest!, GoogleMapsApi.Entities.Pollen.Response.PollenForecastResponse!>!
+GoogleMapsApi.IGoogleMapsClient.PollenHeatmapTile.get -> GoogleMapsApi.IEngineFacade<GoogleMapsApi.Entities.Pollen.Request.PollenHeatmapTileRequest!, GoogleMapsApi.Entities.Pollen.Response.PollenHeatmapTileResponse!>!
+override GoogleMapsApi.Entities.Pollen.Request.PollenForecastRequest.GetUri() -> System.Uri!
+override GoogleMapsApi.Entities.Pollen.Request.PollenHeatmapTileRequest.GetUri() -> System.Uri!

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Release history: see [CHANGELOG.md](CHANGELOG.md).
 
 # GoogleMapsApi
 
-A friendly, strongly-typed .NET wrapper for the Google Maps Web Services APIs — Geocoding, Routes, Directions, Distance Matrix, Elevation, Time Zone, Places, Address Validation, Solar, Aerial View, Air Quality, and Static Maps. Multi-framework (net10.0, net8.0, netstandard2.0 — the latter still covers .NET Framework 4.6.1+), async-first, and battle-tested with **2M+ downloads** on NuGet.
+A friendly, strongly-typed .NET wrapper for the Google Maps Web Services APIs — Geocoding, Routes, Directions, Distance Matrix, Elevation, Time Zone, Places, Address Validation, Solar, Aerial View, Air Quality, Pollen, and Static Maps. Multi-framework (net10.0, net8.0, netstandard2.0 — the latter still covers .NET Framework 4.6.1+), async-first, and battle-tested with **2M+ downloads** on NuGet.
 
 ## Supported APIs
 
@@ -30,6 +30,7 @@ A friendly, strongly-typed .NET wrapper for the Google Maps Web Services APIs �
 | [Solar](https://developers.google.com/maps/documentation/solar) | Building solar potential, roof geometry, panel layouts, financial analyses, and raster data layers (billable) |
 | [Aerial View](https://developers.google.com/maps/documentation/aerial-view) | Render and look up cinematic flyover videos for US addresses |
 | [Air Quality](https://developers.google.com/maps/documentation/air-quality) | Current conditions, hourly forecast and history, plus heatmap tiles, for a coordinate (billable) |
+| [Pollen](https://developers.google.com/maps/documentation/pollen) | Up to 5 days of daily pollen forecast (types and plants) plus heatmap tiles, for a coordinate (billable) |
 | [Static Maps](https://developers.google.com/maps/documentation/maps-static) | Generate URLs for static map images with markers, paths, and styles |
 
 ## Why this vs Google's official packages
@@ -276,6 +277,38 @@ var tile = await maps.AirQualityHeatmapTile.QueryAsync(new HeatmapTileRequest
     Y = 6,
 });
 await File.WriteAllBytesAsync("aqi-tile.png", tile.Content);
+```
+
+### Pollen API (daily forecast + heatmap tiles)
+
+The [Pollen API](https://developers.google.com/maps/documentation/pollen) returns up to five days of daily pollen information — index values, in-season flags and descriptions for pollen types (grass, tree, weed) and individual plants — plus PNG heatmap tiles. It is a **billable** API, so calls beyond the free tier incur charges.
+
+``` C#
+using GoogleMapsApi;
+using GoogleMapsApi.Entities.Pollen.Request;
+
+using var http = new HttpClient();
+var maps = new GoogleMapsClient(http, new GoogleMapsClientOptions { ApiKey = "your-google-maps-api-key" });
+
+// Five-day pollen forecast.
+var forecast = await maps.PollenForecast.QueryAsync(new PollenForecastRequest
+{
+    Latitude = 40.4168,
+    Longitude = -3.7038,
+    Days = 5,
+});
+foreach (var type in forecast.DailyInfo![0].PollenTypeInfo!)
+    Console.WriteLine($"{type.DisplayName}: {type.IndexInfo?.Category}");
+
+// A pollen heatmap tile as raw PNG bytes.
+var tile = await maps.PollenHeatmapTile.QueryAsync(new PollenHeatmapTileRequest
+{
+    MapType = PollenMapType.TreeUpi,
+    Zoom = 4,
+    X = 8,
+    Y = 6,
+});
+await File.WriteAllBytesAsync("pollen-tile.png", tile.Content);
 ```
 
 ### Instance-based client (`IHttpClientFactory`-friendly)


### PR DESCRIPTION
Expose the Google Pollen API on GoogleMapsClient/IGoogleMapsClient:
- PollenForecast      (GET forecast:lookup, up to 5 days, paged)
- PollenHeatmapTile   (GET heatmap PNG map tiles, binary)

Adds request/response entities, hermetic unit tests, and live
[BillableTest] integration tests. Response codes (pollen type, plant,
index) are modelled as strings rather than enums so newly added Google
codes never break forecast deserialization.

<!-- Thanks for contributing! Please fill in the sections below. -->

## Summary

<!-- One or two sentences describing what this PR does and why. -->

## Related issue

<!-- e.g. Fixes #123, Closes #456, or "n/a" if this is a small standalone change. -->

## Changes

<!-- Bullet list of the notable changes in this PR. -->
-
-

## Test plan

<!-- How did you verify this works? Which tests did you add or run? -->
-

## Checklist

- [ ] `dotnet format` has been run.
- [ ] `dotnet test` passes locally (with a valid `GOOGLE_API_KEY` for integration tests).
- [ ] Multi-framework build passes (netstandard2.0, net8.0, net10.0).
- [ ] XML documentation updated if public API surface changed.
