### PR TITLE
[codex] Fix tracing status tag scope

### DIFF
--- a/GoogleMapsApi.Test/DiagnosticsTracingTests.cs
+++ b/GoogleMapsApi.Test/DiagnosticsTracingTests.cs
@@ -106,6 +106,57 @@ namespace GoogleMapsApi.Test
             Assert.That(response, Is.Not.Null);
         }
 
+        [Test]
+        public async Task QueryAsync_WhenGoogleMapsSpanNotRecorded_DoesNotTagAmbientParentSpan()
+        {
+            using var parentSource = new ActivitySource("Test.Parent.Source");
+            using var parentListener = new ActivityListener
+            {
+                ShouldListenTo = s => s.Name == "Test.Parent.Source",
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+            };
+            ActivitySource.AddActivityListener(parentListener);
+
+            // Intentionally NO listener for GoogleMapsActivity.SourceName: the engine's StartActivity
+            // returns null, leaving Activity.Current == the parent span.
+            using var parent = parentSource.StartActivity("user-operation");
+            Assert.That(parent, Is.Not.Null);
+
+            using var handler = new StubHandler(HttpStatusCode.OK, OkGeocodingJson);
+            using var http = new HttpClient(handler);
+            var client = new GoogleMapsClient(http, new GoogleMapsClientOptions { ApiKey = "k" });
+
+            await client.Geocode.QueryAsync(new GeocodingRequest { Address = "a" });
+
+            Assert.That(parent!.GetTagItem("http.response.status_code"), Is.Null);
+        }
+
+        [Test]
+        public async Task QueryAsync_TagsStatusCode_OnStartedSpan_WhenNestedUnderParent()
+        {
+            var captured = new List<Activity>();
+            using var listener = CreateListener(captured);
+
+            using var parentSource = new ActivitySource("Test.Parent.Source");
+            using var parentListener = new ActivityListener
+            {
+                ShouldListenTo = s => s.Name == "Test.Parent.Source",
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+            };
+            ActivitySource.AddActivityListener(parentListener);
+            using var parent = parentSource.StartActivity("user-operation");
+
+            using var handler = new StubHandler(HttpStatusCode.OK, OkGeocodingJson);
+            using var http = new HttpClient(handler);
+            var client = new GoogleMapsClient(http, new GoogleMapsClientOptions { ApiKey = "k" });
+
+            await client.Geocode.QueryAsync(new GeocodingRequest { Address = "a" });
+
+            var span = captured.Single(a => a.OperationName == "GoogleMapsApi Geocoding");
+            Assert.That(span.GetTagItem("http.response.status_code"), Is.EqualTo(200));
+            Assert.That(parent!.GetTagItem("http.response.status_code"), Is.Null);
+        }
+
         private sealed class StubHandler : HttpMessageHandler
         {
             private readonly HttpStatusCode _statusCode;

--- a/GoogleMapsApi/Engine/MapsAPIGenericEngine.cs
+++ b/GoogleMapsApi/Engine/MapsAPIGenericEngine.cs
@@ -63,7 +63,7 @@ namespace GoogleMapsApi.Engine
 				// Binary endpoints (e.g. Solar GeoTIFF) carry raw bytes, not JSON.
 				if (typeof(IBinaryResponse).IsAssignableFrom(typeof(TResponse)))
 				{
-					var (bytes, contentType) = await SendAsync(httpClient, uri, body, timeout, token, async response =>
+					var (bytes, contentType) = await SendAsync(httpClient, uri, body, timeout, token, activity, async response =>
 						(await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false),
 						 response.Content.Headers.ContentType?.MediaType)).ConfigureAwait(false);
 
@@ -76,7 +76,7 @@ namespace GoogleMapsApi.Engine
 					return binaryResult;
 				}
 
-				var responseContent = await SendAsync(httpClient, uri, body, timeout, token,
+				var responseContent = await SendAsync(httpClient, uri, body, timeout, token, activity,
 					response => response.Content.ReadAsStringAsync()).ConfigureAwait(false);
 
 				onRawResponseReceived?.Invoke(Encoding.UTF8.GetBytes(responseContent));
@@ -121,7 +121,7 @@ namespace GoogleMapsApi.Engine
 			return property?.GetValue(response)?.ToString();
 		}
 
-		private static async Task<T> SendAsync<T>(HttpClient httpClient, Uri uri, HttpContent? body, TimeSpan timeout, CancellationToken cancellationToken, Func<HttpResponseMessage, Task<T>> readContent)
+		private static async Task<T> SendAsync<T>(HttpClient httpClient, Uri uri, HttpContent? body, TimeSpan timeout, CancellationToken cancellationToken, Activity? activity, Func<HttpResponseMessage, Task<T>> readContent)
 		{
 			using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 			if (timeout != TimeSpan.FromMilliseconds(-1))
@@ -132,7 +132,7 @@ namespace GoogleMapsApi.Engine
 				using var response = body == null
 					? await httpClient.GetAsync(uri, cts.Token).ConfigureAwait(false)
 					: await httpClient.PostAsync(uri, body, cts.Token).ConfigureAwait(false);
-				Activity.Current?.SetTag("http.response.status_code", (int)response.StatusCode);
+				activity?.SetTag("http.response.status_code", (int)response.StatusCode);
 				await HandleHttpResponse(response, timeout).ConfigureAwait(false);
 				return await readContent(response).ConfigureAwait(false);
 			}


### PR DESCRIPTION
<!-- Thanks for contributing! Please fill in the sections below. -->

## Summary

Fixes tracing so HTTP response status codes are tagged only on the Google Maps client span, not on an ambient parent span when the Google Maps span is not recorded.

## Related issue

n/a

## Changes

- Pass the engine-created activity into HTTP send handling before setting `http.response.status_code`.
- Add regression coverage for unrecorded Google Maps spans and nested parent spans.

## Test plan

- `dotnet test GoogleMapsApi.Test/GoogleMapsApi.Test.csproj --framework net8.0 --filter DiagnosticsTracingTests`
- `dotnet test GoogleMapsApi.Test/GoogleMapsApi.Test.csproj --framework net10.0 --filter DiagnosticsTracingTests`
- `dotnet build GoogleMapsApi/GoogleMapsApi.csproj --framework netstandard2.0 --no-restore`

## Checklist

- [ ] `dotnet format` has been run.
- [ ] `dotnet test` passes locally (with a valid `GOOGLE_API_KEY` for integration tests).
- [x] Multi-framework build passes (netstandard2.0, net8.0, net10.0).
- [x] XML documentation updated if public API surface changed.
