### PR TITLE
docs: reconcile .agents knowledge base with merged VCR harness

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -37,4 +37,7 @@ trusting stale prose.
 - **Target frameworks:** `netstandard2.0; net8.0; net10.0` (the core library). Not 6 frameworks —
   `net6.0`, `net481`, `net462` were dropped in 2.0.
 - **Serialization is `System.Text.Json`**, not Newtonsoft.
-- **Integration tests hit the LIVE Google APIs** (no cassette/VCR) and need a real `GOOGLE_API_KEY`.
+- **Integration tests default to VCR replay.** `VCR_MODE=replay` (the default) serves committed
+  cassettes offline — no `GOOGLE_API_KEY`, no charges. Only the opt-in `record`/`auto`/`live` modes
+  need a real key. (Cassettes aren't seeded yet, so replay is dormant until recorded — see
+  [`testing.md`](testing.md).)

--- a/.agents/known-issues.md
+++ b/.agents/known-issues.md
@@ -19,5 +19,8 @@ When you fix one, remove it from this list (and update the relevant `.agents/*.m
 
 - **B6** — `OnRawResponseReceived` exposes unredacted response bytes (potential PII). Documented as a
   consumer **security note** in [`observability.md`](observability.md).
-- **B9** — integration tests hit live Google APIs with no VCR/cassette (non-hermetic). This is a
-  **deliberate** project decision; documented as a tradeoff in [`testing.md`](testing.md).
+- **B9** — the VCR record/replay harness exists (#306) but **no cassettes are committed yet**, so
+  replay integration coverage is dormant: CI's replay step is cassette-guarded and skips, and a local
+  `replay` run fails on the integration suite until it's seeded. **Fix:** record + commit the dataset
+  (`VCR_MODE=record GOOGLE_API_KEY=<key> RUN_BILLABLE_TESTS=true dotnet test`) — billable; tracked by
+  issue #300. See [`testing.md`](testing.md).


### PR DESCRIPTION
## Summary

Reconciles the `.agents/` agent knowledge base with the VCR record/replay harness that already merged in #306, so the docs stop describing the removed pre-VCR behavior. Docs-only; no code changes.

## Related issue

Refs #300

## Changes

- `.agents/README.md`: the "fast facts" bullet now states integration tests default to **VCR replay** (offline, no `GOOGLE_API_KEY`, no charges); only the opt-in `record`/`auto`/`live` modes need a real key.
- `.agents/known-issues.md`: rewrote **B9** from "no VCR exists (deliberate tradeoff)" to the actual residual — the harness exists but no cassettes are committed yet, so replay is dormant until the dataset is recorded.

## Test plan

- Docs-only change, no code affected. Verified via grep that no stale "live API / no cassette" claims remain in `.agents/` and that the remaining `B9` references (`known-issues.md` + the `testing.md` breadcrumb) are consistent.

## Checklist

- [ ] `dotnet format` has been run. — n/a (docs only)
- [ ] `dotnet test` passes locally (with a valid `GOOGLE_API_KEY` for integration tests). — n/a (docs only)
- [ ] Multi-framework build passes (netstandard2.0, net8.0, net10.0). — n/a (docs only)
- [ ] XML documentation updated if public API surface changed. — n/a (no public API change)
