### PR TITLE
test: harden transit/air-quality integration tests and VCR timestamp normalization

### DIFF
--- a/GoogleMapsApi.Test/AssertInconclusiveTests.cs
+++ b/GoogleMapsApi.Test/AssertInconclusiveTests.cs
@@ -1,0 +1,48 @@
+using GoogleMapsApi.Entities.Directions.Response;
+using GoogleMapsApi.Test.Utils;
+using NUnit.Framework;
+
+namespace GoogleMapsApi.Test
+{
+    [TestFixture]
+    public class AssertInconclusiveTests
+    {
+        [Test]
+        public void HasTransitStep_NonOkDirectionsResponse_Fails()
+        {
+            var response = new DirectionsResponse
+            {
+                Status = DirectionsStatusCodes.REQUEST_DENIED,
+                ErrorMessage = "API key rejected",
+            };
+
+            var ex = Assert.Throws<AssertionException>(() => AssertInconclusive.HasTransitStep(response));
+
+            Assert.That(ex!.Message, Does.Contain("API key rejected"));
+        }
+
+        [Test]
+        public void HasTransitStep_OkResponseWithoutTransitStep_IsInconclusive()
+        {
+            var response = new DirectionsResponse
+            {
+                Status = DirectionsStatusCodes.OK,
+                Routes = new[]
+                {
+                    new Route
+                    {
+                        Legs = new[]
+                        {
+                            new Leg
+                            {
+                                Steps = new[] { new Step() },
+                            },
+                        },
+                    },
+                },
+            };
+
+            Assert.Throws<InconclusiveException>(() => AssertInconclusive.HasTransitStep(response));
+        }
+    }
+}

--- a/GoogleMapsApi.Test/IntegrationTests/AirQualityTests.cs
+++ b/GoogleMapsApi.Test/IntegrationTests/AirQualityTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using GoogleMapsApi.Entities.AirQuality.Request;
 using GoogleMapsApi.Test.Utils;
@@ -37,11 +38,14 @@ namespace GoogleMapsApi.Test.IntegrationTests
         [Test]
         public async Task Forecast_ValidLocation_ReturnsHourlyForecasts()
         {
+            // forecast:lookup requires an explicit future time window; without one the API returns 400.
+            var now = DateTimeOffset.UtcNow;
             var response = await Maps.AirQualityForecast.QueryAsync(new ForecastRequest
             {
                 ApiKey = ApiKey,
                 Latitude = Latitude,
                 Longitude = Longitude,
+                Period = new Interval { StartTime = now, EndTime = now.AddHours(6) },
                 PageSize = 6,
             });
 

--- a/GoogleMapsApi.Test/IntegrationTests/DirectionsTests.cs
+++ b/GoogleMapsApi.Test/IntegrationTests/DirectionsTests.cs
@@ -203,10 +203,12 @@ namespace GoogleMapsApi.Test.IntegrationTests
                             .AddDays(1)
                             .AddHours(13);
             
+            // A longer cross-city route (Stockholm central hub to the airport rail terminus) so Google
+            // reliably returns a transit itinerary with a vehicle icon rather than a walking-only route.
             var request = new DirectionsRequest
             {
                 Origin = "T-centralen, Stockholm, Sverige",
-                Destination = "Kungsträdgården, Stockholm, Sverige",
+                Destination = "Arlanda Central, Sigtuna, Sverige",
                 TravelMode = TravelMode.Transit,
                 DepartureTime = dep_time,
                 Language = "sv",
@@ -217,6 +219,7 @@ namespace GoogleMapsApi.Test.IntegrationTests
             DirectionsResponse result = await Maps.Directions.QueryAsync(request);
 
             AssertInconclusive.NotExceedQuota(result);
+            AssertInconclusive.HasTransitStep(result);
 
             Assert.That(result.Routes, Is.Not.Null.And.Not.Empty, "Routes should not be null or empty");
             Assert.That(result.Routes!.First().Legs, Is.Not.Null.And.Not.Empty, "Legs should not be null or empty");

--- a/GoogleMapsApi.Test/Utils/AssertInconclusive.cs
+++ b/GoogleMapsApi.Test/Utils/AssertInconclusive.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using GoogleMapsApi.Entities.Directions.Response;
 using GoogleMapsApi.Entities.DistanceMatrix.Response;
 using GoogleMapsApi.Entities.Elevation.Response;
@@ -27,6 +28,25 @@ namespace GoogleMapsApi.Test.Utils
         {
             if (response?.Status == DirectionsStatusCodes.OVER_QUERY_LIMIT)
                 throw new InconclusiveException(QuotaExceedMessage);
+        }
+
+        /// <summary>
+        /// If live routing returned no transit step at all (e.g. Google served a walking-only
+        /// itinerary for a short trip), the response carries no vehicle data to assert on - mark the
+        /// test inconclusive rather than failing on volatile live data.
+        /// </summary>
+        public static void HasTransitStep(DirectionsResponse response)
+        {
+            if (response?.Status != DirectionsStatusCodes.OK)
+                Assert.Fail(response?.ErrorMessage ?? $"Directions API returned {response?.Status}.");
+
+            var hasTransit = response?.Routes?
+                .SelectMany(r => r.Legs ?? Enumerable.Empty<Leg>())
+                .SelectMany(l => l.Steps ?? Enumerable.Empty<Step>())
+                .Any(s => s.TransitDetails != null) ?? false;
+
+            if (!hasTransit)
+                throw new InconclusiveException("Google returned no transit step for this route (likely a walking-only itinerary); cannot assert transit vehicle data.");
         }
 
         /// <summary>

--- a/GoogleMapsApi.Test/Vcr/Cassette.cs
+++ b/GoogleMapsApi.Test/Vcr/Cassette.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
 
 namespace GoogleMapsApi.Test.Vcr
@@ -69,12 +70,41 @@ namespace GoogleMapsApi.Test.Vcr
             try
             {
                 using var doc = JsonDocument.Parse(body!);
-                return JsonSerializer.Serialize(doc.RootElement);
+                return JsonSerializer.Serialize(NormalizeJson(doc.RootElement));
             }
             catch (JsonException)
             {
                 return body!.Trim();
             }
+        }
+
+        private static JsonNode? NormalizeJson(JsonElement element, string? parentPropertyName = null)
+        {
+            if (element.ValueKind == JsonValueKind.Object)
+            {
+                var obj = new JsonObject();
+                foreach (var property in element.EnumerateObject())
+                {
+                    obj[property.Name] = parentPropertyName == "period" &&
+                                         property.Value.ValueKind == JsonValueKind.String &&
+                                         (property.Name == "startTime" || property.Name == "endTime")
+                        ? "<timestamp>"
+                        : NormalizeJson(property.Value, property.Name);
+                }
+
+                return obj;
+            }
+
+            if (element.ValueKind == JsonValueKind.Array)
+            {
+                var array = new JsonArray();
+                foreach (var item in element.EnumerateArray())
+                    array.Add(NormalizeJson(item, parentPropertyName));
+
+                return array;
+            }
+
+            return JsonNode.Parse(element.GetRawText());
         }
 
         /// <summary>
@@ -89,7 +119,8 @@ namespace GoogleMapsApi.Test.Vcr
             var occurrence = 0;
             foreach (var interaction in _interactions)
             {
-                if (interaction.MatchKey != key)
+                var interactionKey = $"{interaction.Method} {interaction.Url}\n{NormalizeBody(interaction.RequestBody)}";
+                if (interactionKey != key)
                     continue;
 
                 if (occurrence++ < seen)

--- a/GoogleMapsApi.Test/VcrHarnessTests.cs
+++ b/GoogleMapsApi.Test/VcrHarnessTests.cs
@@ -70,6 +70,22 @@ namespace GoogleMapsApi.Test
         }
 
         [Test]
+        public void NormalizeBody_ReplacesPeriodTimestamps()
+        {
+            const string firstBody = """
+                {"location":{"latitude":37.422,"longitude":-122.0841},"period":{"startTime":"2026-07-15T10:00:00Z","endTime":"2026-07-15T16:00:00Z"},"pageSize":6}
+                """;
+            const string secondBody = """
+                {"location":{"latitude":37.422,"longitude":-122.0841},"period":{"startTime":"2026-07-16T10:00:00Z","endTime":"2026-07-16T16:00:00Z"},"pageSize":6}
+                """;
+
+            var normalized = Cassette.NormalizeBody(firstBody);
+
+            Assert.That(normalized, Is.EqualTo(Cassette.NormalizeBody(secondBody)));
+            Assert.That(normalized, Does.Not.Contain("2026-07-15"));
+        }
+
+        [Test]
         public async Task Record_ReplacesExistingCassette()
         {
             await RecordOnce();


### PR DESCRIPTION
## Summary

Hardens the test suite against volatile live-API data: VCR replay for air-quality forecasts is now deterministic despite a moving time window, and the transit directions test skips gracefully when Google serves a walking-only itinerary.

## Related issue

n/a

## Changes

- Normalize `period.startTime`/`endTime` in VCR request bodies (`Vcr/Cassette.cs`) so forecast replay matching is deterministic across runs, recomputing the interaction match key from the normalized body.
- Send an explicit future `Period` (`Interval`) on the air-quality forecast request, since `forecast:lookup` returns 400 without one.
- Add `AssertInconclusive.HasTransitStep` - fails on a non-OK Directions status and marks the test inconclusive when there is no transit step to assert on.
- Switch the transit directions test to a longer cross-city route (T-centralen to Arlanda Central) so Google reliably returns a transit itinerary, guarded by `HasTransitStep`.
- Add unit tests for `HasTransitStep` (`AssertInconclusiveTests`) and `NormalizeBody` timestamp replacement (`VcrHarnessTests`).

## Test plan

- New unit tests `NormalizeBody_ReplacesPeriodTimestamps` and `HasTransitStep_*` cover the new logic and pass.
- Billable/live integration tests are gated and not run here.

## Checklist

- [x] `dotnet format` has been run (changed files).
- [ ] `dotnet test` passes locally (with a valid `GOOGLE_API_KEY` for integration tests).
- [ ] Multi-framework build passes (netstandard2.0, net8.0, net10.0).
- [x] XML documentation updated if public API surface changed.