### PR TITLE
refactor: unify SSL enforcement and enum handling (fixes #298)

### DIFF
--- a/.agents/adding-a-new-api.md
+++ b/.agents/adding-a-new-api.md
@@ -27,6 +27,8 @@ new surface to the frozen legacy APIs unless Google added a parameter to them.
    - **GET:** override `BaseUrl` to append the path, and `GetQueryStringParameters()` — start from
      `base.GetQueryStringParameters()` (that's what adds the `key`), then `Add(...)` your params.
      Validate required inputs and `throw new ArgumentException(...)` early (see `GeocodingRequest`).
+     Do **not** add an SSL/`IsSSL` check — HTTPS is enforced centrally in `MapsBaseRequest`, and
+     `ConsistencyTests` fails if a request redeclares its own SSL knob.
    - **POST:** override `GetRequestBody()` to return an `HttpContent` (JSON). Use an `internal sealed`
      `Payload` class with `[JsonPropertyName]` attributes for the wire shape. If the endpoint needs a
      field mask (Routes does), expose it as a property with a sensible `Default…` constant

--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -32,14 +32,17 @@ types are `internal`. The only public moving parts you implement against are `IG
 ## The request/response contract
 
 - **Requests** derive from `MapsBaseRequest` (`Entities/Common/MapsBaseRequest.cs`):
-  - `IsSSL` defaults to `true`; `ApiKey` is nullable.
-  - `GetUri()` composes `scheme + BaseUrl + "json?" + query`. Each request overrides `BaseUrl` to add
+  - `ApiKey` is nullable.
+  - `GetUri()` composes `"https://" + BaseUrl + "json?" + query`. Each request overrides `BaseUrl` to add
     its service path (e.g. `GeocodingRequest` adds `geocode/`).
   - `GetQueryStringParameters()` builds the GET query (via `QueryStringParametersList`, which
     URL-escapes and **skips null values**).
   - `GetRequestBody()` returns `null` for GET endpoints, or an `HttpContent` JSON body for POST
     endpoints. **A non-null body is how the engine decides to POST instead of GET.**
-  - Setting an `ApiKey` while `IsSSL == false` throws `ArgumentException` (keys must go over HTTPS).
+  - **HTTPS is enforced centrally** — `GetUri()` always emits `https://`. A new request must **not**
+    add its own SSL check. The legacy `IsSSL` property is `[Obsolete]`, always reads `true`, and
+    throws `NotSupportedException` if assigned `false`; it is removed in 3.0.
+    `ConsistencyTests` locks this invariant by reflection.
 - **Responses** implement the marker interface `IResponseFor<TRequest>` (`Entities/Common/IResponseFor.cs`).
 - The engine is constrained `where TRequest : MapsBaseRequest, new()` and
   `where TResponse : IResponseFor<TRequest>`, so a request can only be paired with its own response —

--- a/.agents/known-issues.md
+++ b/.agents/known-issues.md
@@ -11,7 +11,6 @@ When you fix one, remove it from this list (and update the relevant `.agents/*.m
 | --- | --- | --- | --- | --- |
 | **B3** | medium | `DurationJsonConverter` and `OverviewPolylineJsonConverter` resolve members by name via reflection (`GetProperty`) — rename-fragile, and they silently accept partial objects (a missing token leaves that field unset). | `Engine/JsonConverters/DurationJsonConverter.cs`, `Engine/JsonConverters/OverviewPolylineJsonConverter.cs` | Replace reflection with direct (de)serialization of explicit DTOs. |
 | **B4** | low | HTTP status tag is set on `Activity.Current` instead of the captured `activity`, so it can misattribute under unusual ambient-Activity nesting. | `Engine/MapsAPIGenericEngine.cs:122` | Capture `activity` and tag it directly; pass it down or set the tag inside the parent scope. See [`observability.md`](observability.md). |
-| **B7** | low | Inconsistent SSL enforcement (`TimeZoneRequest` forces HTTPS, others don't) and mixed enum handling (some `[EnumMember]`, some bare names). | `Entities/TimeZone/Request/TimeZoneRequest.cs`; various `Entities/**/Response/Status*.cs` | Decide one SSL policy; standardize on `[EnumMember]` (or document when it's intentionally omitted). |
 
 ## Documented elsewhere (not defects — cross-references)
 

--- a/.agents/serialization.md
+++ b/.agents/serialization.md
@@ -32,9 +32,13 @@ GET query params** (e.g. Directions/Distance Matrix departure time). New POST AP
 
 ## Enum handling rules
 
-- Add `[EnumMember(Value = "wire_value")]` to an enum member when Google's string differs from the C#
-  name (e.g. `street_address`). If the names already match, no attribute is needed — the converter
-  falls back to the member name.
+- Add `[EnumMember(Value = "wire_value")]` to an enum member **only** when Google's string differs
+  from the C# name (e.g. `street_address`, or `DRIVING` on `Driving`). If the wire value is identical
+  to the member name, **omit the attribute** — the converter falls back to the member name, so a
+  valueless `[EnumMember]` or one whose `Value` equals the name is pure noise.
+  `ConsistencyTests.EnumMemberAttributes_AreOnlyPresentWhenTheWireValueDiffers` enforces this by
+  reflection. `Entities/Geocoding/Response/Status.cs` is the reference style for a bare-name enum.
+- `[DataContract]` is **not** used on enums — it is dead metadata under `System.Text.Json`.
 - The factory's `CanConvert` returns true for **every** enum, so any enum on a response is handled
   consistently. Prefer this over per-property `[JsonConverter]` attributes.
 - Be aware: case-insensitive matching means `"OK"` and `"ok"` both parse — it won't catch a typo'd

--- a/GoogleMapsApi.Test/AirQualityUnitTests.cs
+++ b/GoogleMapsApi.Test/AirQualityUnitTests.cs
@@ -75,10 +75,12 @@ namespace GoogleMapsApi.Test
         }
 
         [Test]
-        public void CurrentConditions_GetUri_NonSsl_Throws()
+        public void CurrentConditions_RequestingNonSsl_Throws()
         {
-            Assert.Throws<ArgumentException>(
+#pragma warning disable CS0618 // deliberately exercising the obsolete opt-out
+            Assert.Throws<NotSupportedException>(
                 () => new CurrentConditionsRequest { ApiKey = "k", IsSSL = false, Latitude = Latitude, Longitude = Longitude }.GetUri());
+#pragma warning restore CS0618
         }
 
         [Test]

--- a/GoogleMapsApi.Test/ConsistencyTests.cs
+++ b/GoogleMapsApi.Test/ConsistencyTests.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Serialization;
+using GoogleMapsApi.Entities.Common;
+using GoogleMapsApi.Entities.TimeZone.Request;
+using GoogleMapsApi.StaticMaps;
+using GoogleMapsApi.StaticMaps.Entities;
+using NUnit.Framework;
+
+namespace GoogleMapsApi.Test
+{
+    /// <summary>
+    /// Cross-cutting invariants that keep the request and entity surface uniform (issue #298).
+    /// These are reflection-driven on purpose: a new API that forgets the convention fails here
+    /// rather than quietly re-introducing the inconsistency.
+    /// </summary>
+    [TestFixture]
+    public class ConsistencyTests
+    {
+        private static readonly Assembly LibraryAssembly = typeof(MapsBaseRequest).Assembly;
+
+        private static IEnumerable<Type> ConcreteRequestTypes =>
+            LibraryAssembly.GetTypes()
+                .Where(t => typeof(MapsBaseRequest).IsAssignableFrom(t) && !t.IsAbstract);
+
+        private static IEnumerable<Type> PublicEnums =>
+            LibraryAssembly.GetTypes().Where(t => t.IsEnum && t.IsPublic);
+
+        /// <summary>
+        /// Every request must resolve to HTTPS. Requests with unmet required properties throw while
+        /// building their URI; those are skipped, but the covered count is asserted so this test
+        /// cannot silently decay into checking nothing.
+        /// </summary>
+        [Test]
+        public void AllRequests_ProduceHttpsUris()
+        {
+            var covered = new List<string>();
+            var violations = new List<string>();
+
+            foreach (var type in ConcreteRequestTypes)
+            {
+                if (type.GetConstructor(Type.EmptyTypes) == null)
+                    continue;
+
+                var request = (MapsBaseRequest)Activator.CreateInstance(type)!;
+                request.ApiKey = "test-api-key";
+
+                Uri uri;
+                try
+                {
+                    uri = request.GetUri();
+                }
+                catch (Exception)
+                {
+                    // Required properties not set for this request type - not what we're testing.
+                    continue;
+                }
+
+                covered.Add(type.Name);
+                if (uri.Scheme != Uri.UriSchemeHttps)
+                    violations.Add($"{type.Name} -> {uri.Scheme}");
+            }
+
+            Assert.That(violations, Is.Empty, "Requests must always use HTTPS");
+            Assert.That(covered, Has.Count.GreaterThanOrEqualTo(5),
+                "Too few request types exercised - the reflection filter has decayed");
+        }
+
+        /// <summary>
+        /// No request type may declare its own SSL knob; HTTPS is enforced centrally in
+        /// <see cref="MapsBaseRequest"/>.
+        /// </summary>
+        [Test]
+        public void NoRequestType_DeclaresItsOwnIsSslMember()
+        {
+            var offenders = ConcreteRequestTypes
+                // Compatibility shim for a shipped override; remove with IsSSL in 3.0.
+                .Where(t => t != typeof(TimeZoneRequest))
+                .Where(t => t.GetProperty("IsSSL", BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly) != null)
+                .Select(t => t.Name)
+                .ToList();
+
+            Assert.That(offenders, Is.Empty,
+                "SSL enforcement lives in MapsBaseRequest; request types must not redeclare it");
+        }
+
+        /// <summary>
+        /// Regression for the Static Maps API-key leak: the generated URL embedded the caller's key
+        /// in a plain-HTTP URL because <c>IsSSL</c> defaulted to false.
+        /// </summary>
+        [Test]
+        public void StaticMapUrl_IsHttps_AndNeverLeaksApiKeyOverPlainHttp()
+        {
+            var request = new StaticMapRequest(new Location(40.714728, -73.998672), 12, new ImageSize(400, 400))
+            {
+                ApiKey = "secret-api-key"
+            };
+
+            var url = new StaticMapsEngine().GenerateStaticMapURL(request);
+
+            Assert.That(url, Does.StartWith("https://"));
+            Assert.That(url, Does.Not.StartWith("http://"));
+            Assert.That(url, Does.Contain("secret-api-key"), "sanity: the key is in fact part of the URL");
+        }
+
+        /// <summary>
+        /// Locks the documented enum convention (.agents/serialization.md): carry
+        /// <see cref="EnumMemberAttribute"/> only when Google's wire value actually differs from the
+        /// C# member name. The converter falls back to the member name, so a valueless attribute or
+        /// one whose value equals the name is pure noise.
+        /// </summary>
+        [Test]
+        public void EnumMemberAttributes_AreOnlyPresentWhenTheWireValueDiffers()
+        {
+            var redundant = new List<string>();
+
+            foreach (var enumType in PublicEnums)
+            {
+                foreach (var member in enumType.GetFields(BindingFlags.Public | BindingFlags.Static))
+                {
+                    var attribute = member.GetCustomAttribute<EnumMemberAttribute>();
+                    if (attribute == null)
+                        continue;
+
+                    if (attribute.Value == null)
+                        redundant.Add($"{enumType.FullName}.{member.Name} (no Value)");
+                    else if (string.Equals(attribute.Value, member.Name, StringComparison.Ordinal))
+                        redundant.Add($"{enumType.FullName}.{member.Name} (Value == name)");
+                }
+            }
+
+            Assert.That(redundant, Is.Empty,
+                "Redundant [EnumMember] attributes - the converter already falls back to the member name");
+        }
+    }
+}

--- a/GoogleMapsApi.Test/PollenUnitTests.cs
+++ b/GoogleMapsApi.Test/PollenUnitTests.cs
@@ -101,10 +101,12 @@ namespace GoogleMapsApi.Test
         }
 
         [Test]
-        public void Forecast_GetUri_NonSsl_Throws()
+        public void Forecast_RequestingNonSsl_Throws()
         {
-            Assert.Throws<ArgumentException>(
+#pragma warning disable CS0618 // deliberately exercising the obsolete opt-out
+            Assert.Throws<NotSupportedException>(
                 () => new PollenForecastRequest { ApiKey = "k", IsSSL = false, Latitude = Latitude, Longitude = Longitude, Days = 1 }.GetUri());
+#pragma warning restore CS0618
         }
 
         [Test]

--- a/GoogleMapsApi.Test/RoadsUnitTests.cs
+++ b/GoogleMapsApi.Test/RoadsUnitTests.cs
@@ -80,8 +80,12 @@ namespace GoogleMapsApi.Test
             => Assert.Throws<ArgumentException>(() => new SnapToRoadsRequest { Path = new[] { P1 } }.GetUri());
 
         [Test]
-        public void SnapToRoads_NotSsl_Throws()
-            => Assert.Throws<ArgumentException>(() => new SnapToRoadsRequest { ApiKey = "KEY", IsSSL = false, Path = new[] { P1 } }.GetUri());
+        public void SnapToRoads_RequestingNonSsl_Throws()
+        {
+#pragma warning disable CS0618 // deliberately exercising the obsolete opt-out
+            Assert.Throws<NotSupportedException>(() => new SnapToRoadsRequest { ApiKey = "KEY", IsSSL = false, Path = new[] { P1 } }.GetUri());
+#pragma warning restore CS0618
+        }
 
         [Test]
         public void SnapToRoads_EmptyPath_Throws()

--- a/GoogleMapsApi.Test/SolarUnitTests.cs
+++ b/GoogleMapsApi.Test/SolarUnitTests.cs
@@ -97,10 +97,12 @@ namespace GoogleMapsApi.Test
         }
 
         [Test]
-        public void BuildingInsights_GetUri_NonSsl_Throws()
+        public void BuildingInsights_RequestingNonSsl_Throws()
         {
-            Assert.Throws<ArgumentException>(
+#pragma warning disable CS0618 // deliberately exercising the obsolete opt-out
+            Assert.Throws<NotSupportedException>(
                 () => new BuildingInsightsRequest { ApiKey = "k", IsSSL = false, Latitude = 1, Longitude = 2 }.GetUri());
+#pragma warning restore CS0618
         }
 
         [Test]

--- a/GoogleMapsApi.Test/StaticMaps.cs
+++ b/GoogleMapsApi.Test/StaticMaps.cs
@@ -41,7 +41,7 @@ namespace GoogleMapsApi.Test
 									}
 							}
 				};
-			string expectedResult = "http://maps.google.com/maps/api/staticmap" +
+			string expectedResult = "https://maps.google.com/maps/api/staticmap" +
 									"?center=Brooklyn%20Bridge%2CNew%20York%2CNY&zoom=14&size=512x512&maptype=roadmap" +
 									"&markers=color%3Ablue%7Clabel%3AS%7C40.702147%2C-74.015794&markers=color%3Agreen%7Clabel%3AG%7C40.711614%2C-74.012318" +
 									"&markers=color%3Ared%7Clabel%3AC%7C40.718217%2C-73.998284";
@@ -56,7 +56,7 @@ namespace GoogleMapsApi.Test
 		public void AddressTest()
 		{
 			var request = new StaticMapRequest(new AddressLocation("Berkeley,CA"), 14, new ImageSize(400, 400));
-			string expectedResult = "http://maps.google.com/maps/api/staticmap" +
+			string expectedResult = "https://maps.google.com/maps/api/staticmap" +
 									"?center=Berkeley%2CCA&zoom=14&size=400x400";
 
 			string generateStaticMapURL = new StaticMapsEngine().GenerateStaticMapURL(request);
@@ -69,7 +69,7 @@ namespace GoogleMapsApi.Test
 		public void ZoomLevels()
 		{
 			var request = new StaticMapRequest(new Location(40.714728, -73.998672), 12, new ImageSize(400, 400));
-			string expectedResult = "http://maps.google.com/maps/api/staticmap" +
+			string expectedResult = "https://maps.google.com/maps/api/staticmap" +
 									"?center=40.714728%2C-73.998672&zoom=12&size=400x400";
 
 			string generateStaticMapURL = new StaticMapsEngine().GenerateStaticMapURL(request);
@@ -82,7 +82,7 @@ namespace GoogleMapsApi.Test
 		public void ImageSize()
 		{
 			var request = new StaticMapRequest(new Location(0, 0), 1, new ImageSize(400, 50));
-			string expectedResult = "http://maps.google.com/maps/api/staticmap" +
+			string expectedResult = "https://maps.google.com/maps/api/staticmap" +
 									"?center=0%2C0&zoom=1&size=400x50";
 
 			string generateStaticMapURL = new StaticMapsEngine().GenerateStaticMapURL(request);
@@ -100,7 +100,7 @@ namespace GoogleMapsApi.Test
                 MapType = MapType.Terrain
             };
 
-            string expectedResult = @"http://maps.google.com/maps/api/staticmap" +
+            string expectedResult = @"https://maps.google.com/maps/api/staticmap" +
 									@"?center=40.714728%2C-73.998672&zoom=12&size=400x400&maptype=terrain";
 
 			string actualResult = new StaticMapsEngine().GenerateStaticMapURL(request);

--- a/GoogleMapsApi/Entities/AddressValidation/Request/AddressValidationRequest.cs
+++ b/GoogleMapsApi/Entities/AddressValidation/Request/AddressValidationRequest.cs
@@ -51,8 +51,6 @@ namespace GoogleMapsApi.Entities.AddressValidation.Request
         {
             if (string.IsNullOrWhiteSpace(ApiKey))
                 throw new InvalidOperationException("ApiKey is required for the Address Validation API.");
-            if (!IsSSL)
-                throw new ArgumentException("Address Validation API requires SSL [IsSSL = true].");
 
             return new Uri($"https://addressvalidation.googleapis.com/v1:validateAddress?key={Uri.EscapeDataString(ApiKey!)}");
         }

--- a/GoogleMapsApi/Entities/AerialView/Request/LookupVideoRequest.cs
+++ b/GoogleMapsApi/Entities/AerialView/Request/LookupVideoRequest.cs
@@ -27,8 +27,6 @@ namespace GoogleMapsApi.Entities.AerialView.Request
         {
             if (string.IsNullOrWhiteSpace(ApiKey))
                 throw new InvalidOperationException("ApiKey is required for the Aerial View API.");
-            if (!IsSSL)
-                throw new ArgumentException("Aerial View API requires SSL [IsSSL = true].");
 
             var hasVideoId = !string.IsNullOrWhiteSpace(VideoId);
             var hasAddress = !string.IsNullOrWhiteSpace(Address);

--- a/GoogleMapsApi/Entities/AerialView/Request/RenderVideoRequest.cs
+++ b/GoogleMapsApi/Entities/AerialView/Request/RenderVideoRequest.cs
@@ -30,8 +30,6 @@ namespace GoogleMapsApi.Entities.AerialView.Request
         {
             if (string.IsNullOrWhiteSpace(ApiKey))
                 throw new InvalidOperationException("ApiKey is required for the Aerial View API.");
-            if (!IsSSL)
-                throw new ArgumentException("Aerial View API requires SSL [IsSSL = true].");
 
             return new Uri($"https://aerialview.googleapis.com/v1/videos:renderVideo?key={Uri.EscapeDataString(ApiKey!)}");
         }

--- a/GoogleMapsApi/Entities/AirQuality/Request/CurrentConditionsRequest.cs
+++ b/GoogleMapsApi/Entities/AirQuality/Request/CurrentConditionsRequest.cs
@@ -42,8 +42,6 @@ namespace GoogleMapsApi.Entities.AirQuality.Request
         {
             if (string.IsNullOrWhiteSpace(ApiKey))
                 throw new InvalidOperationException("ApiKey is required for the Air Quality API.");
-            if (!IsSSL)
-                throw new ArgumentException("Air Quality API requires SSL [IsSSL = true].");
 
             return new Uri(
                 "https://airquality.googleapis.com/v1/currentConditions:lookup" +

--- a/GoogleMapsApi/Entities/AirQuality/Request/ForecastRequest.cs
+++ b/GoogleMapsApi/Entities/AirQuality/Request/ForecastRequest.cs
@@ -57,8 +57,6 @@ namespace GoogleMapsApi.Entities.AirQuality.Request
         {
             if (string.IsNullOrWhiteSpace(ApiKey))
                 throw new InvalidOperationException("ApiKey is required for the Air Quality API.");
-            if (!IsSSL)
-                throw new ArgumentException("Air Quality API requires SSL [IsSSL = true].");
 
             return new Uri(
                 "https://airquality.googleapis.com/v1/forecast:lookup" +

--- a/GoogleMapsApi/Entities/AirQuality/Request/HeatmapTileRequest.cs
+++ b/GoogleMapsApi/Entities/AirQuality/Request/HeatmapTileRequest.cs
@@ -33,8 +33,6 @@ namespace GoogleMapsApi.Entities.AirQuality.Request
         {
             if (string.IsNullOrWhiteSpace(ApiKey))
                 throw new InvalidOperationException("ApiKey is required for the Air Quality API.");
-            if (!IsSSL)
-                throw new ArgumentException("Air Quality API requires SSL [IsSSL = true].");
             if (Zoom < 0 || Zoom > 16)
                 throw new ArgumentException("Zoom must be in the range [0, 16].", nameof(Zoom));
             if (X < 0 || Y < 0)

--- a/GoogleMapsApi/Entities/AirQuality/Request/HistoryRequest.cs
+++ b/GoogleMapsApi/Entities/AirQuality/Request/HistoryRequest.cs
@@ -61,8 +61,6 @@ namespace GoogleMapsApi.Entities.AirQuality.Request
         {
             if (string.IsNullOrWhiteSpace(ApiKey))
                 throw new InvalidOperationException("ApiKey is required for the Air Quality API.");
-            if (!IsSSL)
-                throw new ArgumentException("Air Quality API requires SSL [IsSSL = true].");
 
             return new Uri(
                 "https://airquality.googleapis.com/v1/history:lookup" +

--- a/GoogleMapsApi/Entities/Common/MapsBaseRequest.cs
+++ b/GoogleMapsApi/Entities/Common/MapsBaseRequest.cs
@@ -13,24 +13,28 @@ namespace GoogleMapsApi.Entities.Common
     public abstract class MapsBaseRequest
     {
         /// <summary>
-        /// Initializes a new request with SSL enabled and no API key.
+        /// Initializes a new request with no API key.
         /// </summary>
         public MapsBaseRequest()
         {
-            this.isSsl = true;
             ApiKey = null;
         }
 
 
         /// <summary>
-        /// True to use use the https protocol; false to use http. The default is false.
+        /// Always <c>true</c>. The Google Maps Web Services are served over HTTPS only, so this is no
+        /// longer a choice. Assigning <c>false</c> throws rather than silently downgrading the request.
         /// </summary>
+        [Obsolete("All Google Maps Web Services requests use HTTPS. This property is ignored and will be removed in 3.0.")]
         public virtual bool IsSSL
         {
-            get { return isSsl; }
-            set { isSsl = value; }
+            get { return true; }
+            set
+            {
+                if (!value)
+                    throw new NotSupportedException("Plain HTTP is not supported; all requests use HTTPS.");
+            }
         }
-        private bool isSsl;
 
 
         /// <summary>
@@ -62,10 +66,6 @@ namespace GoogleMapsApi.Entities.Common
 
             if (!string.IsNullOrWhiteSpace(ApiKey))
             {
-                if (!this.IsSSL)
-                {
-                    throw new ArgumentException("When using an ApiKey MUST send the request over SSL [IsSSL = true]");
-                }
                 parametersList.Add("key", ApiKey);
             }
 
@@ -78,10 +78,8 @@ namespace GoogleMapsApi.Entities.Common
         /// <returns>The fully composed URI to send to the Google Maps API.</returns>
         public virtual Uri GetUri()
         {
-            string scheme = IsSSL ? "https://" : "http://";
-
             var queryString = GetQueryStringParameters().GetQueryStringPostfix();
-            return new Uri(scheme + BaseUrl + "json?" + queryString);
+            return new Uri("https://" + BaseUrl + "json?" + queryString);
         }
 
         /// <summary>

--- a/GoogleMapsApi/Entities/Common/Type.cs
+++ b/GoogleMapsApi/Entities/Common/Type.cs
@@ -1,8 +1,7 @@
-﻿using System.Runtime.Serialization;
+using System.Runtime.Serialization;
 
 namespace GoogleMapsApi.Entities.Common
 {
-	[DataContract]
 	public enum LocationType
 	{
 		[EnumMember(Value = "street_address")]

--- a/GoogleMapsApi/Entities/DistanceMatrix/Request/Restrictions.cs
+++ b/GoogleMapsApi/Entities/DistanceMatrix/Request/Restrictions.cs
@@ -1,17 +1,11 @@
-﻿namespace GoogleMapsApi.Entities.DistanceMatrix.Request
+namespace GoogleMapsApi.Entities.DistanceMatrix.Request
 {
-    using System.Runtime.Serialization;
 
-    [DataContract]
     public enum DistanceMatrixRestrictions
     {
-        [EnumMember]
         tolls,
-        [EnumMember]
         highways,
-        [EnumMember]
         ferries,
-        [EnumMember]
         indoor,
     }
 }

--- a/GoogleMapsApi/Entities/DistanceMatrix/Request/TrafficModel.cs
+++ b/GoogleMapsApi/Entities/DistanceMatrix/Request/TrafficModel.cs
@@ -1,16 +1,11 @@
-﻿namespace GoogleMapsApi.Entities.DistanceMatrix.Request
+namespace GoogleMapsApi.Entities.DistanceMatrix.Request
 {
-    using System.Runtime.Serialization;
 
-    [DataContract]
     public enum DistanceMatrixTrafficModels
     {
         // To be used for 'driving' travel mode only
-        [EnumMember]
         best_guess, // uses historical trafic conditions. live traffic weighted more significantly for departure times closer to now.
-        [EnumMember]
         pessimistic, // returned duration in traffic should be longer than actual travel on most days.
-        [EnumMember]
         optimistic, // returned duration in traffic should be shorter than actual travel on most days.
     }
 }

--- a/GoogleMapsApi/Entities/DistanceMatrix/Request/TransitMode.cs
+++ b/GoogleMapsApi/Entities/DistanceMatrix/Request/TransitMode.cs
@@ -1,20 +1,13 @@
-﻿namespace GoogleMapsApi.Entities.DistanceMatrix.Request
+namespace GoogleMapsApi.Entities.DistanceMatrix.Request
 {
-    using System.Runtime.Serialization;
 
-    [DataContract]
     public enum DistanceMatrixTransitModes
     {
         // To be used for 'transit' travel mode only
-        [EnumMember]
         bus, // route should prefer travel by bus
-        [EnumMember]
         subway, // route should prefer travel by subway
-        [EnumMember]
         train, // route should prefer travel by train
-        [EnumMember]
         tram, // route should prefer travel by tram or light rail
-        [EnumMember]
         rail, // route should prefer travel by train, tram, light rail and subway
     }
 }

--- a/GoogleMapsApi/Entities/DistanceMatrix/Request/TransitRoutingPreference.cs
+++ b/GoogleMapsApi/Entities/DistanceMatrix/Request/TransitRoutingPreference.cs
@@ -1,14 +1,10 @@
-﻿namespace GoogleMapsApi.Entities.DistanceMatrix.Request
+namespace GoogleMapsApi.Entities.DistanceMatrix.Request
 {
-    using System.Runtime.Serialization;
 
-    [DataContract]
     public enum DistanceMatrixTransitRoutingPreferences
     {
         // To be used for 'transit' travel mode only
-        [EnumMember]
         less_walking, // route should prefer limited amounts of walking
-        [EnumMember]
         fewer_transfers, // route should prefer limited numbers of transfers
     }
 }

--- a/GoogleMapsApi/Entities/DistanceMatrix/Request/TravelMode.cs
+++ b/GoogleMapsApi/Entities/DistanceMatrix/Request/TravelMode.cs
@@ -1,16 +1,10 @@
-﻿namespace GoogleMapsApi.Entities.DistanceMatrix.Request
+namespace GoogleMapsApi.Entities.DistanceMatrix.Request
 {
-    using System.Runtime.Serialization;
 
-    [DataContract]
     public enum DistanceMatrixTravelModes    {
-        [EnumMember]
         driving, // uses road network.
-        [EnumMember]
         walking, // uses pedestrian paths (where available).
-        [EnumMember]
         bicycling, // uses bicycle paths and preferred streets (where available).
-        [EnumMember]
         transit, // uses public transit routes (where available).
     }
 }

--- a/GoogleMapsApi/Entities/DistanceMatrix/Request/UnitSystem.cs
+++ b/GoogleMapsApi/Entities/DistanceMatrix/Request/UnitSystem.cs
@@ -1,13 +1,9 @@
-﻿namespace GoogleMapsApi.Entities.DistanceMatrix.Request
+namespace GoogleMapsApi.Entities.DistanceMatrix.Request
 {
-    using System.Runtime.Serialization;
 
-    [DataContract]
     public enum DistanceMatrixUnitSystems
     {
-        [EnumMember]
         metric, // kilometers an meters.
-        [EnumMember]
         imperial, // miles and feet.
     }
 }

--- a/GoogleMapsApi/Entities/DistanceMatrix/Response/ElementStatusCodes.cs
+++ b/GoogleMapsApi/Entities/DistanceMatrix/Response/ElementStatusCodes.cs
@@ -1,17 +1,11 @@
-﻿namespace GoogleMapsApi.Entities.DistanceMatrix.Response
+namespace GoogleMapsApi.Entities.DistanceMatrix.Response
 {
-	using System.Runtime.Serialization;
 
-	[DataContract]
 	public enum DistanceMatrixElementStatusCodes
 	{
-		[EnumMember]
 		OK,                       // indicates the response contains a valid result.
-		[EnumMember]
 		NOT_FOUND,                // indicates that the origin and/or destination of this pairing could not be geocoded.
-		[EnumMember]
 		ZERO_RESULTS,             // indicates no route could be found between the origin and destination.
-		[EnumMember]
 		MAX_ROUTE_LENGTH_EXCEEDED // indicates the requested route is too long and cannot be processed.
 	}
 }

--- a/GoogleMapsApi/Entities/DistanceMatrix/Response/StatusCodes.cs
+++ b/GoogleMapsApi/Entities/DistanceMatrix/Response/StatusCodes.cs
@@ -1,29 +1,17 @@
-﻿namespace GoogleMapsApi.Entities.DistanceMatrix.Response
+namespace GoogleMapsApi.Entities.DistanceMatrix.Response
 {
-    using System.Runtime.Serialization;
 
-    [DataContract]
 	public enum DistanceMatrixStatusCodes
 	{
-		[EnumMember]
 		OK, // indicates the response contains a valid result.
-		[EnumMember]
 		NOT_FOUND,//indicates at least one of the locations specified in the request's origin, destination, or waypoints could not be geocoded.
-		[EnumMember]
 		ZERO_RESULTS,// indicates no route could be found between the origin and destination.
-		[EnumMember]
 		MAX_WAYPOINTS_EXCEEDED, // 
-		[EnumMember]
 		MAX_ROUTE_LENGTH_EXCEEDED, // indicates the requested route is too long and cannot be processed.
-		[EnumMember]
 		INVALID_REQUEST, // indicates that the provided request was invalid.
-		[EnumMember]
 		MAX_ELEMENTS_EXCEEDED, // indicates that the product of origins and destinations exceeds the per-query limit.
-		[EnumMember]
 		OVER_QUERY_LIMIT, // indicates the service has received too many requests from your application within the allowed time period.
-		[EnumMember]
 		REQUEST_DENIED, // indicates that the service denied use of the directions service by your application.
-		[EnumMember]
 		UNKNOWN_ERROR, // indicates a directions request could not be processed due to a server error. The request may succeed if you try again
 	}
 }

--- a/GoogleMapsApi/Entities/Elevation/Response/Status.cs
+++ b/GoogleMapsApi/Entities/Elevation/Response/Status.cs
@@ -1,19 +1,11 @@
-﻿using System.Runtime.Serialization;
-
 namespace GoogleMapsApi.Entities.Elevation.Response
 {
-	[DataContract]
 	public enum Status
 	{
-		[EnumMember]
 		OK, // indicating the API request was successful
-		[EnumMember]
 		INVALID_REQUEST, // indicating the API request was malformed
-		[EnumMember]
 		OVER_QUERY_LIMIT, // indicating the requestor has exceeded quota
-		[EnumMember]
 		REQUEST_DENIED, // indicating the API did not complete the request
-		[EnumMember]
 		UNKNOWN_ERROR //indicating an unknown error
 	}
 }

--- a/GoogleMapsApi/Entities/Geocoding/Response/LocationType.cs
+++ b/GoogleMapsApi/Entities/Geocoding/Response/LocationType.cs
@@ -1,32 +1,25 @@
-﻿using System.Runtime.Serialization;
-
 namespace GoogleMapsApi.Entities.Geocoding.Response
 {
-	[DataContract]
 	public enum GeocodeLocationType
 	{
         /// <summary>
         /// Indicates that the returned result is a precise geocode for which we have location information accurate down to street address precision.
         /// </summary>
-        [EnumMember]
         ROOFTOP,
 
         /// <summary>
         /// Indicates that the returned result reflects an approximation (usually on a road) interpolated between two precise points (such as intersections). Interpolated results are generally returned when rooftop geocodes are unavailable for a street address.
         /// </summary>
-        [EnumMember]
         RANGE_INTERPOLATED,
 
         /// <summary>
         /// Indicates that the returned result is the geometric center of a result such as a polyline (for example, a street) or polygon (region).
         /// </summary>
-        [EnumMember]
         GEOMETRIC_CENTER,
 
         /// <summary>
         /// Indicates that the returned result is approximate.
         /// </summary>
-        [EnumMember]
         APPROXIMATE
 	}
 }

--- a/GoogleMapsApi/Entities/PlacesNew/Request/AutocompleteRequest.cs
+++ b/GoogleMapsApi/Entities/PlacesNew/Request/AutocompleteRequest.cs
@@ -52,8 +52,6 @@ namespace GoogleMapsApi.Entities.PlacesNew.Request
                 throw new ArgumentException("Input is required for Autocomplete.", nameof(Input));
             if (string.IsNullOrWhiteSpace(ApiKey))
                 throw new ArgumentException("ApiKey is required for the Places API (New).", nameof(ApiKey));
-            if (!IsSSL)
-                throw new ArgumentException("Places API (New) requires SSL [IsSSL = true].");
 
             return new Uri(
                 "https://places.googleapis.com/v1/places:autocomplete" +

--- a/GoogleMapsApi/Entities/PlacesNew/Request/PlaceDetailsRequest.cs
+++ b/GoogleMapsApi/Entities/PlacesNew/Request/PlaceDetailsRequest.cs
@@ -44,8 +44,6 @@ namespace GoogleMapsApi.Entities.PlacesNew.Request
                 throw new ArgumentException("PlaceId is required for Place Details.", nameof(PlaceId));
             if (string.IsNullOrWhiteSpace(ApiKey))
                 throw new ArgumentException("ApiKey is required for the Places API (New).", nameof(ApiKey));
-            if (!IsSSL)
-                throw new ArgumentException("Places API (New) requires SSL [IsSSL = true].");
             if (string.IsNullOrWhiteSpace(FieldMask))
                 throw new ArgumentException("FieldMask is required for the Places API (New). See PlaceDetailsRequest.DefaultFieldMask for a starting point.", nameof(FieldMask));
 

--- a/GoogleMapsApi/Entities/PlacesNew/Request/PlacePhotoRequest.cs
+++ b/GoogleMapsApi/Entities/PlacesNew/Request/PlacePhotoRequest.cs
@@ -34,8 +34,6 @@ namespace GoogleMapsApi.Entities.PlacesNew.Request
                 throw new ArgumentException("PhotoName is required for Place Photo.", nameof(PhotoName));
             if (string.IsNullOrWhiteSpace(ApiKey))
                 throw new ArgumentException("ApiKey is required for the Places API (New).", nameof(ApiKey));
-            if (!IsSSL)
-                throw new ArgumentException("Places API (New) requires SSL [IsSSL = true].");
             if (!MaxHeightPx.HasValue && !MaxWidthPx.HasValue)
                 throw new ArgumentException("At least one of MaxHeightPx or MaxWidthPx is required for Place Photo.");
 

--- a/GoogleMapsApi/Entities/PlacesNew/Request/SearchNearbyRequest.cs
+++ b/GoogleMapsApi/Entities/PlacesNew/Request/SearchNearbyRequest.cs
@@ -57,8 +57,6 @@ namespace GoogleMapsApi.Entities.PlacesNew.Request
             ValidateLocationRestriction();
             if (string.IsNullOrWhiteSpace(ApiKey))
                 throw new ArgumentException("ApiKey is required for the Places API (New).", nameof(ApiKey));
-            if (!IsSSL)
-                throw new ArgumentException("Places API (New) requires SSL [IsSSL = true].");
             if (string.IsNullOrWhiteSpace(FieldMask))
                 throw new ArgumentException("FieldMask is required for the Places API (New). See SearchNearbyRequest.DefaultFieldMask for a starting point.", nameof(FieldMask));
 

--- a/GoogleMapsApi/Entities/PlacesNew/Request/SearchTextRequest.cs
+++ b/GoogleMapsApi/Entities/PlacesNew/Request/SearchTextRequest.cs
@@ -77,8 +77,6 @@ namespace GoogleMapsApi.Entities.PlacesNew.Request
                 throw new ArgumentException("TextQuery is required for Text Search.", nameof(TextQuery));
             if (string.IsNullOrWhiteSpace(ApiKey))
                 throw new ArgumentException("ApiKey is required for the Places API (New).", nameof(ApiKey));
-            if (!IsSSL)
-                throw new ArgumentException("Places API (New) requires SSL [IsSSL = true].");
             if (string.IsNullOrWhiteSpace(FieldMask))
                 throw new ArgumentException("FieldMask is required for the Places API (New). See SearchTextRequest.DefaultFieldMask for a starting point.", nameof(FieldMask));
 

--- a/GoogleMapsApi/Entities/Pollen/Request/PollenForecastRequest.cs
+++ b/GoogleMapsApi/Entities/Pollen/Request/PollenForecastRequest.cs
@@ -42,8 +42,6 @@ namespace GoogleMapsApi.Entities.Pollen.Request
         {
             if (string.IsNullOrWhiteSpace(ApiKey))
                 throw new InvalidOperationException("ApiKey is required for the Pollen API.");
-            if (!IsSSL)
-                throw new ArgumentException("Pollen API requires SSL [IsSSL = true].");
             if (Days < 1 || Days > 5)
                 throw new ArgumentException("Days must be in the range [1, 5].", nameof(Days));
 

--- a/GoogleMapsApi/Entities/Pollen/Request/PollenHeatmapTileRequest.cs
+++ b/GoogleMapsApi/Entities/Pollen/Request/PollenHeatmapTileRequest.cs
@@ -32,8 +32,6 @@ namespace GoogleMapsApi.Entities.Pollen.Request
         {
             if (string.IsNullOrWhiteSpace(ApiKey))
                 throw new InvalidOperationException("ApiKey is required for the Pollen API.");
-            if (!IsSSL)
-                throw new ArgumentException("Pollen API requires SSL [IsSSL = true].");
             if (Zoom < 0 || Zoom > 16)
                 throw new ArgumentException("Zoom must be in the range [0, 16].", nameof(Zoom));
             if (X < 0 || Y < 0)

--- a/GoogleMapsApi/Entities/Roads/Request/NearestRoadsRequest.cs
+++ b/GoogleMapsApi/Entities/Roads/Request/NearestRoadsRequest.cs
@@ -27,7 +27,7 @@ namespace GoogleMapsApi.Entities.Roads.Request
         public override Uri GetUri()
         {
             var points = RoadsRequestHelper.BuildPointsParameter(Points, MaxPoints, nameof(Points));
-            RoadsRequestHelper.ValidateApiKeyAndSsl(ApiKey, IsSSL);
+            RoadsRequestHelper.ValidateApiKey(ApiKey);
 
             var url =
                 "https://roads.googleapis.com/v1/nearestRoads" +

--- a/GoogleMapsApi/Entities/Roads/Request/RoadsRequestHelper.cs
+++ b/GoogleMapsApi/Entities/Roads/Request/RoadsRequestHelper.cs
@@ -13,14 +13,12 @@ namespace GoogleMapsApi.Entities.Roads.Request
     internal static class RoadsRequestHelper
     {
         /// <summary>
-        /// Validates that an API key is present and SSL is enabled (required for every Roads endpoint).
+        /// Validates that an API key is present (required for every Roads endpoint).
         /// </summary>
-        public static void ValidateApiKeyAndSsl(string? apiKey, bool isSsl)
+        public static void ValidateApiKey(string? apiKey)
         {
             if (string.IsNullOrWhiteSpace(apiKey))
                 throw new ArgumentException("ApiKey is required for the Roads API.", nameof(apiKey));
-            if (!isSsl)
-                throw new ArgumentException("Roads API requires SSL [IsSSL = true].");
         }
 
         /// <summary>

--- a/GoogleMapsApi/Entities/Roads/Request/SnapToRoadsRequest.cs
+++ b/GoogleMapsApi/Entities/Roads/Request/SnapToRoadsRequest.cs
@@ -36,7 +36,7 @@ namespace GoogleMapsApi.Entities.Roads.Request
         public override Uri GetUri()
         {
             var path = RoadsRequestHelper.BuildPointsParameter(Path, MaxPathPoints, nameof(Path));
-            RoadsRequestHelper.ValidateApiKeyAndSsl(ApiKey, IsSSL);
+            RoadsRequestHelper.ValidateApiKey(ApiKey);
 
             var url =
                 "https://roads.googleapis.com/v1/snapToRoads" +

--- a/GoogleMapsApi/Entities/Roads/Request/SpeedLimitsRequest.cs
+++ b/GoogleMapsApi/Entities/Roads/Request/SpeedLimitsRequest.cs
@@ -45,7 +45,7 @@ namespace GoogleMapsApi.Entities.Roads.Request
             if (hasPath == hasPlaceIds)
                 throw new ArgumentException("Exactly one of Path or PlaceIds must be specified for Speed Limits, and both cannot be specified.");
 
-            RoadsRequestHelper.ValidateApiKeyAndSsl(ApiKey, IsSSL);
+            RoadsRequestHelper.ValidateApiKey(ApiKey);
 
             var url = new StringBuilder("https://roads.googleapis.com/v1/speedLimits?");
 

--- a/GoogleMapsApi/Entities/Routes/Request/RoutesRequest.cs
+++ b/GoogleMapsApi/Entities/Routes/Request/RoutesRequest.cs
@@ -104,8 +104,6 @@ namespace GoogleMapsApi.Entities.Routes.Request
         {
             if (string.IsNullOrWhiteSpace(ApiKey))
                 throw new InvalidOperationException("ApiKey is required for the Routes API.");
-            if (!IsSSL)
-                throw new ArgumentException("Routes API requires SSL [IsSSL = true].");
             if (string.IsNullOrWhiteSpace(FieldMask))
                 throw new InvalidOperationException("FieldMask is required for the Routes API. See RoutesRequest.DefaultFieldMask for a starting point.");
 

--- a/GoogleMapsApi/Entities/Solar/Request/BuildingInsightsRequest.cs
+++ b/GoogleMapsApi/Entities/Solar/Request/BuildingInsightsRequest.cs
@@ -30,8 +30,6 @@ namespace GoogleMapsApi.Entities.Solar.Request
         {
             if (string.IsNullOrWhiteSpace(ApiKey))
                 throw new InvalidOperationException("ApiKey is required for the Solar API.");
-            if (!IsSSL)
-                throw new ArgumentException("Solar API requires SSL [IsSSL = true].");
 
             var url =
                 "https://solar.googleapis.com/v1/buildingInsights:findClosest" +

--- a/GoogleMapsApi/Entities/Solar/Request/DataLayersRequest.cs
+++ b/GoogleMapsApi/Entities/Solar/Request/DataLayersRequest.cs
@@ -48,8 +48,6 @@ namespace GoogleMapsApi.Entities.Solar.Request
         {
             if (string.IsNullOrWhiteSpace(ApiKey))
                 throw new InvalidOperationException("ApiKey is required for the Solar API.");
-            if (!IsSSL)
-                throw new ArgumentException("Solar API requires SSL [IsSSL = true].");
             if (RadiusMeters <= 0)
                 throw new ArgumentException("RadiusMeters must be greater than zero.");
 

--- a/GoogleMapsApi/Entities/Solar/Request/GeoTiffRequest.cs
+++ b/GoogleMapsApi/Entities/Solar/Request/GeoTiffRequest.cs
@@ -25,8 +25,6 @@ namespace GoogleMapsApi.Entities.Solar.Request
         {
             if (string.IsNullOrWhiteSpace(ApiKey))
                 throw new InvalidOperationException("ApiKey is required for the Solar API.");
-            if (!IsSSL)
-                throw new ArgumentException("Solar API requires SSL [IsSSL = true].");
             if (string.IsNullOrWhiteSpace(Url))
                 throw new ArgumentException("Url is required; supply a data-layer URL from a DataLayersResponse.", nameof(Url));
             if (!Uri.TryCreate(Url, UriKind.Absolute, out var layerUri) ||

--- a/GoogleMapsApi/Entities/TimeZone/Request/TimeZoneRequest.cs
+++ b/GoogleMapsApi/Entities/TimeZone/Request/TimeZoneRequest.cs
@@ -31,12 +31,13 @@ namespace GoogleMapsApi.Entities.TimeZone.Request
         public string? Language { get; set; } // optional
 
         /// <summary>
-        /// The language in which to return results. See the list of supported domain languages. Note that we often update supported languages so this list may not be exhaustive. Defaults to en.
+        /// Always <c>true</c>. Kept on this request for binary compatibility until 3.0.
         /// </summary>
+        [Obsolete("All Google Maps Web Services requests use HTTPS. This property is ignored and will be removed in 3.0.")]
         public override bool IsSSL
         {
-            get { return true; }
-            set { throw new NotSupportedException("This operation is not supported, TimeZoneRequest must use SSL"); }
+            get { return base.IsSSL; }
+            set { base.IsSSL = value; }
         }
 
         protected override QueryStringParametersList GetQueryStringParameters()

--- a/GoogleMapsApi/Entities/TimeZone/Response/Status.cs
+++ b/GoogleMapsApi/Entities/TimeZone/Response/Status.cs
@@ -1,21 +1,12 @@
-﻿using System.Runtime.Serialization;
-
 namespace GoogleMapsApi.Entities.TimeZone.Response
 {
-    [DataContract]
     public enum Status
     {
-        [EnumMember(Value = "OK")]
         OK, // indicates that no errors occurred; the place was successfully detected and at least one result was returned.
-        [EnumMember(Value = "ZERO_RESULTS")]
         ZERO_RESULTS, // indicates that the search was successful but returned no results. This may occur if the search was passed a latlng in a remote location.
-        [EnumMember(Value = "OVER_QUERY_LIMIT")]
         OVER_QUERY_LIMIT, // indicates that you are over your quota.
-        [EnumMember(Value = "REQUEST_DENIED")]
         REQUEST_DENIED, // indicates that your request was denied.
-        [EnumMember(Value = "INVALID_REQUEST")]
         INVALID_REQUEST, // generally indicates that the query parameter (location or radius) is missing.
-        [EnumMember(Value = "UNKNOWN_ERROR")]
         UNKNOWN_ERROR // indicates an unknown error
     }
 }

--- a/GoogleMapsApi/StaticMaps/Entities/StaticMapRequest.cs
+++ b/GoogleMapsApi/StaticMaps/Entities/StaticMapRequest.cs
@@ -104,7 +104,20 @@ namespace GoogleMapsApi.StaticMaps.Entities
 		/// </summary>
 		public IList<MapStyleRule>? Styles { get; set; }
 
-		public bool IsSSL { get; set; }
+		/// <summary>
+		/// Always <c>true</c>. The Static Maps API is served over HTTPS only, so this is no longer a
+		/// choice. Assigning <c>false</c> throws rather than silently sending the API key in cleartext.
+		/// </summary>
+		[Obsolete("The Static Maps API is served over HTTPS. This property is ignored and will be removed in 3.0.")]
+		public bool IsSSL
+		{
+			get { return true; }
+			set
+			{
+				if (!value)
+					throw new NotSupportedException("Plain HTTP is not supported; all requests use HTTPS.");
+			}
+		}
 
         /// <summary>
         /// Add API key support for the static map. This parameter is required for all static map requests.

--- a/GoogleMapsApi/StaticMaps/StaticMapsEngine.cs
+++ b/GoogleMapsApi/StaticMaps/StaticMapsEngine.cs
@@ -29,8 +29,6 @@ namespace GoogleMapsApi.StaticMaps
 		/// <returns>The fully composed Static Maps URL.</returns>
 		public string GenerateStaticMapURL(StaticMapRequest request)
 		{
-			string scheme = request.IsSSL ? "https://" : "http://";
-
 			var parametersList = new QueryStringParametersList();
 
             if (!string.IsNullOrEmpty(request.ApiKey))
@@ -385,7 +383,7 @@ namespace GoogleMapsApi.StaticMaps
 				}
 			}
 
-			return scheme + BaseUrl + "?" + parametersList.GetQueryStringPostfix();
+			return "https://" + BaseUrl + "?" + parametersList.GetQueryStringPostfix();
 		}
 	}
 }

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -185,6 +185,27 @@ These were renamed to fix casing (`...OffSet` → `...Offset`). The JSON wire ma
 
 ---
 
+## 5. `IsSSL` deprecated (2.x), removed in 3.0
+
+The Google Maps Web Services are served over HTTPS only, so `IsSSL` no longer models a real choice.
+It is now `[Obsolete]` on both `MapsBaseRequest` and `StaticMapRequest`:
+
+- Every request URL is built with `https://`, unconditionally.
+- The getter always returns `true`.
+- Assigning `false` throws `NotSupportedException` instead of silently downgrading the request.
+
+```diff
+- var req = new GeocodingRequest { ApiKey = "...", IsSSL = true };
++ var req = new GeocodingRequest { ApiKey = "..." };
+```
+
+**Static Maps behavior change:** `StaticMapRequest.IsSSL` previously defaulted to `false`, so
+`StaticMapsEngine.GenerateStaticMapURL` returned an `http://` URL with your API key in the query
+string — sending the key in cleartext. It now always returns `https://`. If you depended on the
+`http://` prefix (for example in a cached or hard-coded expected URL), update it.
+
+---
+
 ## Quick reference
 
 ```diff

--- a/benchmarks/GoogleMapsApi.Benchmarks/UrlGenerationBenchmarks.cs
+++ b/benchmarks/GoogleMapsApi.Benchmarks/UrlGenerationBenchmarks.cs
@@ -89,7 +89,6 @@ public class UrlGenerationBenchmarks
             imageSize: new ImageSize(500, 400))
         {
             ApiKey = ApiKey,
-            IsSSL = true,
         };
     }
 


### PR DESCRIPTION
## Summary

Unifies SSL enforcement and enum handling, which had drifted into five competing SSL patterns and an
unwritten enum rule. While surveying, this turned up a real defect: `StaticMapRequest.IsSSL` had no
initializer so it defaulted to `false`, and `StaticMapsEngine` emitted
`http://maps.google.com/...?key=<API_KEY>` with no guard at all - putting the caller's API key on the
wire in cleartext by default.

## Related issue

Fixes #298 (tech-debt item **B7**).

## Changes

- **`fix`** - Static Maps now always emits `https://`; the API key is no longer sent in cleartext.
- **`refactor!`** - HTTPS is enforced centrally in `MapsBaseRequest.GetUri()`. Removed 18 copy-pasted
  `if (!IsSSL) throw` blocks and the Roads helper's SSL half (all already dead code - those requests
  hardcode `https://` in their own URL builders). `ValidateApiKeyAndSsl` → `ValidateApiKey`.
- **`refactor!`** - `IsSSL` is `[Obsolete]` on `MapsBaseRequest` and `StaticMapRequest`: reads `true`,
  throws `NotSupportedException` if assigned `false` rather than silently downgrading. Removed in 3.0.
  The `TimeZoneRequest` override is kept as a binary-compatibility shim.
- **`refactor`** - Removed 49 redundant `[EnumMember]` attributes (valueless, or `Value` equal to the
  member name) and 12 `[DataContract]`s that are dead metadata under `System.Text.Json`. Attributes
  whose value genuinely differs - including case-only ones like `DRIVING` on `Driving` - are
  untouched, so **every wire value is unchanged**.
- **`test`/`docs`** - New reflection-driven `ConsistencyTests` locking both invariants; `.agents/`
  docs updated and the B7 row dropped; `MIGRATION.md` documents the deprecation and the Static Maps
  behaviour change.

## Test plan

- Added `GoogleMapsApi.Test/ConsistencyTests.cs` with four invariants: every request resolves to
  HTTPS, no request redeclares its own SSL knob, the Static Maps key-leak stays fixed, and no
  redundant `[EnumMember]` survives. All four were written first and confirmed **failing** against
  the old code (the leak reproduced as
  `http://maps.google.com/maps/api/staticmap?key=secret-api-key&...`).
- `dotnet test` - **544 passed, 0 failed** (263 unit + 9 DI, across net8.0 and net10.0).
- `dotnet build` - **0 errors, 0 warnings** across netstandard2.0, net8.0, net10.0.
- Updated the 4 tests that set `IsSSL = false` and the 5 Static Maps URL assertions.

## Checklist

- [x] `dotnet format` has been run (verified on changed files; the repo has ~80 pre-existing
      violations elsewhere, so a blanket run was avoided).
- [x] `dotnet test` passes locally. Integration tests were **not** run - no `GOOGLE_API_KEY` /
      network in this environment; they were filtered out.
- [x] Multi-framework build passes (netstandard2.0, net8.0, net10.0).
- [x] XML documentation updated if public API surface changed.

### Follow-ups not in scope

`StaticMapsEngine` still targets the legacy `maps.google.com` host rather than
`maps.googleapis.com`, and `[DataContract]` remains on ~8 DTO classes where it is equally dead.
