### PR TITLE
fix: surface Google's error response body on failed HTTP requests

### DIFF
--- a/GoogleMapsApi.Test/HttpErrorResponseTests.cs
+++ b/GoogleMapsApi.Test/HttpErrorResponseTests.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Security.Authentication;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using GoogleMapsApi.Entities.AirQuality.Request;
+using NUnit.Framework;
+
+namespace GoogleMapsApi.Test
+{
+    /// <summary>
+    /// Hermetic tests for how the engine reports HTTP failures. Google returns a descriptive JSON error
+    /// body on 4xx; it has to reach the caller, redacted and bounded.
+    /// </summary>
+    [TestFixture]
+    public class HttpErrorResponseTests
+    {
+        private const double Latitude = 37.4;
+        private const double Longitude = -122.1;
+
+        [Test]
+        public void BadRequest_IncludesGoogleErrorBodyInMessage()
+        {
+            const string body = """
+            {"error":{"code":400,"message":"The start time must be in the future.","status":"INVALID_ARGUMENT"}}
+            """;
+            var ex = Assert.ThrowsAsync<HttpRequestException>(() => QueryAsync(HttpStatusCode.BadRequest, body));
+
+            Assert.That(ex!.Message, Does.Contain("BadRequest"));
+            Assert.That(ex.Message, Does.Contain("INVALID_ARGUMENT"));
+            Assert.That(ex.Message, Does.Contain("The start time must be in the future."));
+        }
+
+        [Test]
+        public void ErrorBody_RedactsApiKeyAndSignature()
+        {
+            const string body = """
+            {"error":{"message":"Invalid request: https://airquality.googleapis.com/v1/forecast:lookup?key=SUPER_SECRET&signature=SIG"}}
+            """;
+            var ex = Assert.ThrowsAsync<HttpRequestException>(() => QueryAsync(HttpStatusCode.BadRequest, body));
+
+            Assert.That(ex!.Message, Does.Not.Contain("SUPER_SECRET"));
+            Assert.That(ex.Message, Does.Not.Contain("SIG"));
+            Assert.That(ex.Message, Does.Contain("key=REDACTED"));
+            Assert.That(ex.Message, Does.Contain("signature=REDACTED"));
+        }
+
+        [Test]
+        public void ErrorBody_IsTruncatedWhenOversized()
+        {
+            var body = new string('x', 10_000);
+            var ex = Assert.ThrowsAsync<HttpRequestException>(() => QueryAsync(HttpStatusCode.BadRequest, body));
+
+            Assert.That(ex!.Message.Count(c => c == 'x'), Is.EqualTo(2000));
+            Assert.That(ex.Message, Does.EndWith("..."));
+        }
+
+        [Test]
+        public void EmptyErrorBody_KeepsTheStatusOnlyMessage()
+        {
+            var ex = Assert.ThrowsAsync<HttpRequestException>(() => QueryAsync(HttpStatusCode.BadRequest, ""));
+
+            Assert.That(ex!.Message, Is.EqualTo("Failed with HttpResponse: BadRequest and message: Bad Request"));
+        }
+
+        [Test]
+        public void Forbidden_StillThrowsAuthenticationExceptionWithRedactedBody()
+        {
+            const string body = """
+            {"error":{"status":"PERMISSION_DENIED","message":"https://airquality.googleapis.com/v1/currentConditions:lookup?key=SUPER_SECRET is not authorized."}}
+            """;
+            var ex = Assert.ThrowsAsync<AuthenticationException>(() => QueryAsync(HttpStatusCode.Forbidden, body));
+
+            Assert.That(ex!.Message, Does.Contain("PERMISSION_DENIED"));
+            Assert.That(ex.Message, Does.Not.Contain("SUPER_SECRET"));
+        }
+
+        [Test]
+        public void RequestTimeout_StillThrowsTimeoutException()
+        {
+            Assert.ThrowsAsync<TimeoutException>(() => QueryAsync(HttpStatusCode.RequestTimeout, "irrelevant"));
+        }
+
+        private static async Task QueryAsync(HttpStatusCode status, string body)
+        {
+            using var handler = new FailingHandler(status, body);
+            using var http = new HttpClient(handler);
+            var client = new GoogleMapsClient(http, new GoogleMapsClientOptions { ApiKey = "k" });
+
+            await client.AirQualityCurrentConditions.QueryAsync(
+                new CurrentConditionsRequest { Latitude = Latitude, Longitude = Longitude });
+        }
+
+        private sealed class FailingHandler : HttpMessageHandler
+        {
+            private readonly HttpStatusCode _status;
+            private readonly string _body;
+
+            public FailingHandler(HttpStatusCode status, string body)
+            {
+                _status = status;
+                _body = body;
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                return Task.FromResult(new HttpResponseMessage(_status)
+                {
+                    Content = new StringContent(_body, Encoding.UTF8, "application/json"),
+                });
+            }
+        }
+    }
+}

--- a/GoogleMapsApi.Test/IntegrationTests/AirQualityTests.cs
+++ b/GoogleMapsApi.Test/IntegrationTests/AirQualityTests.cs
@@ -38,14 +38,16 @@ namespace GoogleMapsApi.Test.IntegrationTests
         [Test]
         public async Task Forecast_ValidLocation_ReturnsHourlyForecasts()
         {
-            // forecast:lookup requires an explicit future time window; without one the API returns 400.
+            // forecast:lookup rejects a window that isn't strictly in the future, so start at the next
+            // whole hour rather than at "now" — which is already in the past by the time Google sees it.
             var now = DateTimeOffset.UtcNow;
+            var start = new DateTimeOffset(now.Year, now.Month, now.Day, now.Hour, 0, 0, TimeSpan.Zero).AddHours(1);
             var response = await Maps.AirQualityForecast.QueryAsync(new ForecastRequest
             {
                 ApiKey = ApiKey,
                 Latitude = Latitude,
                 Longitude = Longitude,
-                Period = new Interval { StartTime = now, EndTime = now.AddHours(6) },
+                Period = new Interval { StartTime = start, EndTime = start.AddHours(6) },
                 PageSize = 6,
             });
 

--- a/GoogleMapsApi/Engine/MapsAPIGenericEngine.cs
+++ b/GoogleMapsApi/Engine/MapsAPIGenericEngine.cs
@@ -128,6 +128,20 @@ namespace GoogleMapsApi.Engine
 		private static string RedactUrl(Uri uri)
 			=> secretQueryParameter.Replace(uri.AbsoluteUri, "$1REDACTED");
 
+		private const int MaxErrorBodyLength = 2000;
+
+		/// <summary>
+		/// Prepares an error response body for inclusion in an exception message: secrets are redacted in
+		/// case the service echoed the request URL back, and oversized bodies (HTML error pages) are cut off.
+		/// </summary>
+		private static string SanitizeErrorBody(string body)
+		{
+			var redacted = secretQueryParameter.Replace(body, "$1REDACTED");
+			return redacted.Length > MaxErrorBodyLength
+				? redacted.Substring(0, MaxErrorBodyLength) + "..."
+				: redacted;
+		}
+
 		private static string? GetResponseStatus(TResponse response)
 		{
 			var property = statusProperties.GetOrAdd(typeof(TResponse), static t => t.GetProperty("Status"));
@@ -175,17 +189,19 @@ namespace GoogleMapsApi.Engine
 			if (!response.IsSuccessStatusCode)
 			{
 				var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+				var errorBody = string.IsNullOrWhiteSpace(responseContent) ? null : SanitizeErrorBody(responseContent);
 
 				if (response.StatusCode == HttpStatusCode.Forbidden ||
 					response.StatusCode == HttpStatusCode.ProxyAuthenticationRequired ||
 					response.StatusCode == HttpStatusCode.Unauthorized)
-					throw new System.Security.Authentication.AuthenticationException(responseContent);
+					throw new System.Security.Authentication.AuthenticationException(errorBody ?? response.StatusCode.ToString());
 
 				if (response.StatusCode == HttpStatusCode.GatewayTimeout ||
 					response.StatusCode == HttpStatusCode.RequestTimeout)
 					throw new TimeoutException($"The request has exceeded the timeout limit of {timeout} and has been aborted.");
 
-				throw new HttpRequestException($"Failed with HttpResponse: {response.StatusCode} and message: {response.ReasonPhrase}");
+				var message = $"Failed with HttpResponse: {response.StatusCode} and message: {response.ReasonPhrase}";
+				throw new HttpRequestException(errorBody == null ? message : $"{message}. Response: {errorBody}");
 			}
 		}
 


### PR DESCRIPTION
## Why

The weekly scheduled live job has failed on every run since 2026-06-22. [Run 29731242464](https://github.com/maximn/google-maps/actions/runs/29731242464) failed with:

```
System.Net.Http.HttpRequestException : Failed with HttpResponse: BadRequest and message: Bad Request
```

That message is all the log had - which surfaced two separate problems.

## 1. The library discards Google's error body

`MapsAPIGenericEngine.HandleHttpResponse` read `responseContent`, used it for the 401/403/407 branch, then threw it away for every other status and reported only `response.ReasonPhrase`. Google returns a descriptive body (`{"error":{"code":400,"status":"INVALID_ARGUMENT","message":"..."}}`) that consumers never saw.

The body is now appended to the `HttpRequestException` message:

- redacted with the existing `secretQueryParameter` regex, in case the service echoes the request URL back with `key=`/`signature=`
- truncated at 2000 chars so an HTML error page can't blow up the message
- the same redaction now applies to the `AuthenticationException` message, which previously passed the raw body through

Exception types and the existing message prefix are unchanged; no public API surface change.

## 2. The forecast test sends a start time that is already in the past

`AirQualityTests.Forecast_ValidLocation_ReturnsHourlyForecasts` set `Period.StartTime = DateTimeOffset.UtcNow`. `forecast:lookup` requires a future time ("To get air quality forecasts, set the `dateTime` parameter to a future date and time"), and `AirQualityJson.Rfc3339` truncates to whole seconds - so by the time the request reaches Google the start is unambiguously in the past. #355 added the `Period` to fix an earlier 400 but picked exactly the boundary value. It now starts at the next whole hour.

Replay is unaffected: `Cassette.NormalizeJson` already rewrites `period.startTime`/`endTime` to `<timestamp>` before matching.

## Tests

New `GoogleMapsApi.Test/HttpErrorResponseTests.cs` covers the error body reaching the caller, key/signature redaction, truncation, the empty-body case, and that 403 -> `AuthenticationException` / 408 -> `TimeoutException` still hold. Full offline suite passes (269 tests).

The forecast fix itself needs a live call to confirm - apply `run-billable-tests` to this PR to run the live job.

## Not addressed

`Directions_WithIcons` failed on the 2026-07-13 and 2026-06-22 scheduled runs and passed on 2026-07-20 - independently flaky.