### PR TITLE
test: stop the live route-length test failing on Google's shifted threshold

### DIFF
--- a/GoogleMapsApi.Test/AssertInconclusiveTests.cs
+++ b/GoogleMapsApi.Test/AssertInconclusiveTests.cs
@@ -44,5 +44,35 @@ namespace GoogleMapsApi.Test
 
             Assert.Throws<InconclusiveException>(() => AssertInconclusive.HasTransitStep(response));
         }
+
+        [Test]
+        public void EnforcedRouteLengthLimit_RouteRejected_Passes()
+        {
+            var response = new DirectionsResponse { Status = DirectionsStatusCodes.MAX_ROUTE_LENGTH_EXCEEDED };
+
+            Assert.DoesNotThrow(() => AssertInconclusive.EnforcedRouteLengthLimit(response));
+        }
+
+        [Test]
+        public void EnforcedRouteLengthLimit_GoogleAcceptedTheRoute_IsInconclusive()
+        {
+            var response = new DirectionsResponse { Status = DirectionsStatusCodes.OK };
+
+            Assert.Throws<InconclusiveException>(() => AssertInconclusive.EnforcedRouteLengthLimit(response));
+        }
+
+        [Test]
+        public void EnforcedRouteLengthLimit_UnrelatedFailure_Fails()
+        {
+            var response = new DirectionsResponse
+            {
+                Status = DirectionsStatusCodes.REQUEST_DENIED,
+                ErrorMessage = "API key rejected",
+            };
+
+            var ex = Assert.Throws<AssertionException>(() => AssertInconclusive.EnforcedRouteLengthLimit(response));
+
+            Assert.That(ex!.Message, Does.Contain("API key rejected"));
+        }
     }
 }

--- a/GoogleMapsApi.Test/DirectionsUnitTests.cs
+++ b/GoogleMapsApi.Test/DirectionsUnitTests.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using GoogleMapsApi.Engine;
+using GoogleMapsApi.Entities.Directions.Request;
+using GoogleMapsApi.Entities.Directions.Response;
+using NUnit.Framework;
+
+namespace GoogleMapsApi.Test
+{
+    /// <summary>
+    /// Offline coverage for the Directions status codes. The live
+    /// <c>DirectionsTests.Directions_ExceedingRouteLength</c> can only observe whatever Google's
+    /// current server-side route-length threshold happens to be, so the contract we actually own -
+    /// mapping the wire status onto <see cref="DirectionsStatusCodes"/> - is pinned here instead.
+    /// </summary>
+    [TestFixture]
+    public class DirectionsUnitTests
+    {
+        [Test]
+        public async Task MaxRouteLengthExceeded_IsDeserialized()
+        {
+            const string json = """
+                {
+                   "geocoded_waypoints" : [],
+                   "routes" : [],
+                   "status" : "MAX_ROUTE_LENGTH_EXCEEDED"
+                }
+                """;
+
+            var response = await QueryAsync(json);
+
+            Assert.That(response.Status, Is.EqualTo(DirectionsStatusCodes.MAX_ROUTE_LENGTH_EXCEEDED));
+            Assert.That(response.Routes, Is.Empty);
+        }
+
+        [Test]
+        public async Task ErrorStatus_CarriesErrorMessage()
+        {
+            const string json = """
+                {
+                   "error_message" : "The provided API key is invalid.",
+                   "routes" : [],
+                   "status" : "REQUEST_DENIED"
+                }
+                """;
+
+            var response = await QueryAsync(json);
+
+            Assert.That(response.Status, Is.EqualTo(DirectionsStatusCodes.REQUEST_DENIED));
+            Assert.That(response.ErrorMessage, Is.EqualTo("The provided API key is invalid."));
+        }
+
+        [TestCase("OK", DirectionsStatusCodes.OK)]
+        [TestCase("NOT_FOUND", DirectionsStatusCodes.NOT_FOUND)]
+        [TestCase("ZERO_RESULTS", DirectionsStatusCodes.ZERO_RESULTS)]
+        [TestCase("MAX_WAYPOINTS_EXCEEDED", DirectionsStatusCodes.MAX_WAYPOINTS_EXCEEDED)]
+        [TestCase("MAX_ROUTE_LENGTH_EXCEEDED", DirectionsStatusCodes.MAX_ROUTE_LENGTH_EXCEEDED)]
+        [TestCase("INVALID_REQUEST", DirectionsStatusCodes.INVALID_REQUEST)]
+        [TestCase("OVER_QUERY_LIMIT", DirectionsStatusCodes.OVER_QUERY_LIMIT)]
+        [TestCase("REQUEST_DENIED", DirectionsStatusCodes.REQUEST_DENIED)]
+        [TestCase("UNKNOWN_ERROR", DirectionsStatusCodes.UNKNOWN_ERROR)]
+        public async Task EveryDocumentedStatus_RoundTripsFromTheWire(string wireValue, DirectionsStatusCodes expected)
+        {
+            var response = await QueryAsync($$"""{ "routes" : [], "status" : "{{wireValue}}" }""");
+
+            Assert.That(response.Status, Is.EqualTo(expected));
+        }
+
+        private static Task<DirectionsResponse> QueryAsync(string responseJson)
+        {
+            var request = new DirectionsRequest { Origin = "NYC, USA", Destination = "Miami, USA", ApiKey = "KEY" };
+            var handler = new StubHandler(responseJson);
+            using var http = new HttpClient(handler);
+            return MapsAPIGenericEngine<DirectionsRequest, DirectionsResponse>.QueryGoogleAPIAsync(
+                http, request, TimeSpan.FromMilliseconds(-1), CancellationToken.None, null, null);
+        }
+
+        private sealed class StubHandler : HttpMessageHandler
+        {
+            private readonly string _responseJson;
+            public StubHandler(string responseJson) { _responseJson = responseJson; }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+                => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(_responseJson, Encoding.UTF8, "application/json")
+                });
+        }
+    }
+}

--- a/GoogleMapsApi.Test/IntegrationTests/DirectionsTests.cs
+++ b/GoogleMapsApi.Test/IntegrationTests/DirectionsTests.cs
@@ -88,7 +88,7 @@ namespace GoogleMapsApi.Test.IntegrationTests
             var result = await Maps.Directions.QueryAsync(request);
 
             AssertInconclusive.NotExceedQuota(result);
-            Assert.That(result.Status, Is.EqualTo(DirectionsStatusCodes.MAX_ROUTE_LENGTH_EXCEEDED), result.ErrorMessage);
+            AssertInconclusive.EnforcedRouteLengthLimit(result);
         }
 
         [Test]

--- a/GoogleMapsApi.Test/Utils/AssertInconclusive.cs
+++ b/GoogleMapsApi.Test/Utils/AssertInconclusive.cs
@@ -50,6 +50,22 @@ namespace GoogleMapsApi.Test.Utils
         }
 
         /// <summary>
+        /// Google's route-length ceiling is an undocumented server-side threshold that has moved
+        /// before: a route it once rejected with MAX_ROUTE_LENGTH_EXCEEDED now routes fine. Treat OK
+        /// as inconclusive so a shifted threshold surfaces as live drift instead of a red build; any
+        /// other status still fails. Deterministic coverage of the status itself lives in
+        /// DirectionsUnitTests.
+        /// </summary>
+        public static void EnforcedRouteLengthLimit(DirectionsResponse response)
+        {
+            if (response?.Status == DirectionsStatusCodes.OK)
+                throw new InconclusiveException("Google accepted a route that previously exceeded its length limit; the server-side threshold has moved.");
+
+            if (response?.Status != DirectionsStatusCodes.MAX_ROUTE_LENGTH_EXCEEDED)
+                Assert.Fail($"Directions API returned {response?.Status}. {response?.ErrorMessage}");
+        }
+
+        /// <summary>
         /// If the response status indicates fail because of quota exceeded - mark test as inconclusive.
         /// </summary>
         public static void NotExceedQuota(ElevationResponse response)


### PR DESCRIPTION
## Why

The weekly scheduled live drift-check [failed](https://github.com/maximn/google-maps/actions/runs/32700014616/job/97349474484):

```
Failed Directions_ExceedingRouteLength
  Expected: MAX_ROUTE_LENGTH_EXCEEDED
  But was:  OK
```

Not a regression - Google-side drift, which is exactly what that scheduled job exists to catch. The test builds a deliberately absurd route (NYC → Miami via Seattle/Dallas/Naginey/Edmonton ×3) and asserts the real Directions API rejects it. Google now computes that route happily.

Evidence it isn't us: the last commit touching the test is #355, long before; the previous scheduled live run passed on effectively the same tree; and it isn't quota masking (`NotExceedQuota` passed, status was `OK`, not `OVER_QUERY_LIMIT`).

The route-length ceiling is an **undocumented server-side threshold**. Chasing it with more waypoints would just move the flake, so the assertion is split by who owns it.

## What

**Live test - degrade to inconclusive.** New `AssertInconclusive.EnforcedRouteLengthLimit`, alongside the existing `NotExceedQuota` / `HasTransitStep`:

| status | result |
| --- | --- |
| `MAX_ROUTE_LENGTH_EXCEEDED` | passes |
| `OK` | **inconclusive**, message names the cause |
| anything else | fails, with status + error message |

`DirectionsTests.cs` is a one-line swap to call it. The scheduled run reports drift instead of going red, and still fails loudly on a genuine regression.

**Offline - pin what we actually own.** New `DirectionsUnitTests` covers the wire-status → `DirectionsStatusCodes` mapping deterministically, via the `StubHandler` + `MapsAPIGenericEngine` pattern already used by `RoadsUnitTests` / `PollenUnitTests` / `SolarUnitTests`:

- `MaxRouteLengthExceeded_IsDeserialized` - the assertion the live test used to carry
- `ErrorStatus_CarriesErrorMessage` - `error_message` binding
- `EveryDocumentedStatus_RoundTripsFromTheWire` - all 9 enum members, so a future rename or `EnumMember` slip breaks offline

Plus three tests for the new helper in `AssertInconclusiveTests`.

### Why not a VCR cassette

Cassettes are *recordings*. Google no longer emits `MAX_ROUTE_LENGTH_EXCEEDED` for this route, so `VCR_MODE=record` cannot produce one - the file would have to be hand-forged, contradicting `Cassettes/README.md`. `StubHandler` needs no fixture and tests the same contract.

## Verification

- `net10.0` and `net8.0`: **283 passed, 0 failed** (offline filter, `VCR_MODE=replay`)
- `dotnet format --verify-no-changes` clean on all files authored here. `DirectionsTests.cs` reports violations, but all are pre-existing lines (40-47, 57, 61, 71, 111+), none at the changed line 91 - the known repo-wide format debt.

## Follow-up (not in this PR)

If the next run or two confirms Google has permanently dropped the limit, the honest end state is deleting the live test and keeping only the offline coverage. Left in place for now so a re-tightened threshold is still observed.